### PR TITLE
Support unitdates in series

### DIFF
--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -39,7 +39,7 @@ module ArclightHelper
   end
 
   def collection_count
-    facets_from_request.find { |f| f.name == 'collection_sim' }.try(:items).try(:count)
+    @response.response['numFound']
   end
 
   ##

--- a/lib/arclight/normalized_date.rb
+++ b/lib/arclight/normalized_date.rb
@@ -9,14 +9,26 @@ module Arclight
     # @param [String | Array<String>] `inclusive` from the `unitdate`
     # @param [String] `bulk` from the `unitdate`
     # @param [String] `other` from the `unitdate` when type is not specified
-    def initialize(inclusive, bulk = nil, other = nil)
-      if inclusive.is_a? Array # of YYYY-YYYY for ranges
-        @inclusive = YearRange.new(inclusive.include?('/') ? inclusive : inclusive.map { |v| v.tr('-', '/') }).to_s
-      elsif inclusive.present?
-        @inclusive = inclusive.strip
+    def initialize(inclusiveHash, bulkHash = nil, otherHash = nil)
+      @inclusive = []
+      @bulk = []
+      @other = []
+      inclusiveHash.each do |inclusive|
+        if inclusive.is_a? Array # of YYYY-YYYY for ranges
+          @inclusive << YearRange.new(inclusive.include?('/') ? inclusive : inclusive.map { |v| v.tr('-', '/') }).to_s
+        elsif inclusive.present?
+          @inclusive << inclusive.strip
+        end
       end
-      @bulk = bulk.strip if bulk.present?
-      @other = other.strip if other.present?
+      bulkHash.each do |bulk|
+        @bulk << bulk.strip if bulk.present?
+      end
+      otherHash.each do |other|
+        @other << other.strip if other.present?
+      end
+      @inclusive = @inclusive.join(", ")
+      @bulk = @bulk.join(", ")
+      @other = @other.join(", ")
     end
 
     # @return [String] the normalized title/date

--- a/lib/arclight/shared_indexing_behavior.rb
+++ b/lib/arclight/shared_indexing_behavior.rb
@@ -83,7 +83,7 @@ module Arclight
     end
 
     def add_normalized_title(solr_doc)
-      dates = Arclight::NormalizedDate.new(unitdate_inclusive.first, unitdate_bulk.first, unitdate_other.first).to_s
+      dates = Arclight::NormalizedDate.new(unitdate_inclusive, unitdate_bulk, unitdate_other).to_s
       title = Arclight::NormalizedTitle.new(solr_doc['title_ssm'].try(:first), dates).to_s
       solr_doc['normalized_title_ssm'] = [title]
       solr_doc['normalized_date_ssm'] = [dates]

--- a/lib/arclight/solr_ead_indexer_ext.rb
+++ b/lib/arclight/solr_ead_indexer_ext.rb
@@ -103,13 +103,19 @@ module Arclight
     # TODO: these xpaths should be DRY'd up -- they're in both terminologies
     def extract_title_and_dates(node, prefix = nil)
       data = {
-        title:              node.at_xpath("#{prefix}did/unittitle"),
-        unitdate_inclusive: node.at_xpath("#{prefix}did/unitdate[@type=\"inclusive\"]"),
-        unitdate_bulk:      node.at_xpath("#{prefix}did/unitdate[@type=\"bulk\"]"),
-        unitdate_other:     node.at_xpath("#{prefix}did/unitdate[not(@type)]")
+        unitdate_inclusive: [],
+        unitdate_bulk: [],
+        unitdate_other: []
       }
-      data.each do |k, v|
-        data[k] = v.text if v
+      data[:title] = node.xpath("#{prefix}did/unittitle").text if node.xpath("#{prefix}did/unittitle")
+      node.xpath("#{prefix}did/unitdate[@type=\"inclusive\"]").each do |unitdate|
+        if unitdate.attr("type").downcase  == "inclusive"
+          data[:unitdate_inclusive] << unitdate.text if unitdate
+        elsif unitdate.attr("type").downcase  == "bulk"
+          data[:unitdate_bulk] << unitdate.text if unitdate
+        else
+          data[:unitdate_other] << unitdate.text if unitdate
+        end
       end
       data
     end


### PR DESCRIPTION
Previously, the indexer ignores multiple dates in series when creating `normalized_date` even though this is supported in DACS (https://github.com/saa-ts-dacs/dacs/blob/master/part_I/chapter_2/4_date.md#L42-43). Thus, only the first date in a series would be displayed to users, likely omitting useful description. 

I dunno how to write the tests for the change, so this is likely to fail.