### PR TITLE
Convert geogname_sim and geogname_ssm indexing to traject

### DIFF
--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -76,6 +76,10 @@ to_field 'repository_sim' do |_record, accumulator, context|
   accumulator << context.clipboard[:repository]
 end
 
+to_field 'geogname_ssm', extract_xpath('//xmlns:archdesc/xmlns:controlaccess/xmlns:geogname')
+
+to_field 'geogname_sim', extract_xpath('//xmlns:archdesc/xmlns:controlaccess/xmlns:geogname')
+
 # Each component child document
 # <c> <c01> <c12>
 # rubocop:disable Metrics/BlockLength
@@ -179,8 +183,8 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
   end
 
   # to_field 'names_ssim'
-  # to_field 'geogname_sim'
-  # to_field 'geogname_ssm'
+  to_field 'geogname_sim', extract_xpath('./xmlns:controlaccess/xmlns:geogname')
+  to_field 'geogname_ssm', extract_xpath('./xmlns:controlaccess/xmlns:geogname')
   # to_field 'places_ssim'
 
   # Indexes the controlled terms for archival description into the access_subject field

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -66,6 +66,12 @@ describe 'EAD 2 traject indexing', type: :feature do
         expect(result[field]).to include 'Stanford University Libraries. Special Collections and University Archives'
       end
     end
+    it 'geogname' do
+      %w[geogname_sim geogname_ssm].each do |field|
+        expect(result[field]).to include 'Yosemite National Park (Calif.)'
+      end
+    end
+
     describe 'components' do
       it 'id' do
         expect(result['components'].first).to include 'id' => ['a0011-xmlaspace_ref6_lx4']
@@ -73,6 +79,11 @@ describe 'EAD 2 traject indexing', type: :feature do
       it 'repository' do
         %w[repository_sim repository_ssm].each do |field|
           expect(result['components'].first[field]).to include 'Stanford University Libraries. Special Collections and University Archives'
+        end
+      end
+      it 'geogname' do
+        %w[geogname_sim geogname_ssm].each do |field|
+          expect(result['components'].first[field]).to be_nil
         end
       end
     end
@@ -133,6 +144,15 @@ describe 'EAD 2 traject indexing', type: :feature do
         'Societies',
         'Speeches'
       )
+    end
+
+    it 'indexes geognames' do
+      component = result['components'].find { |d| d['id'] == ['aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'] }
+      expect(component).to include 'geogname_sim'
+      expect(component['geogname_sim']).to include('Popes Creek (Md.)')
+
+      expect(component).to include 'geogname_ssm'
+      expect(component['geogname_ssm']).to include('Popes Creek (Md.)')
     end
 
     context 'with nested controlaccess elements' do


### PR DESCRIPTION
Fixes #588
(Part of #567)

Uses slightly modified xpath, follow-on fix for PR #585 incoming in a separate PR