### PR TITLE
Index access_subjects at their individual levels (document, component)

### DIFF
--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -104,6 +104,21 @@ end
 
 to_field 'places_ssim', extract_xpath('//xmlns:archdesc/xmlns:controlaccess/xmlns:geogname')
 
+
+# Indexes the controlled terms for archival description into the access_subject field
+# Please see https://www.loc.gov/ead/tglib/elements/controlaccess.html
+to_field 'access_subjects_ssim', extract_xpath('//xmlns:archdesc/xmlns:controlaccess', to_text: false) do |_record, accumulator|
+  accumulator.map! do |element|
+    %w[corpname famname function genreform geogname name note occupation persname subject title].map do |selector|
+      element.xpath(".//xmlns:#{selector}").map(&:text)
+    end
+  end.flatten!
+end
+
+to_field 'access_subjects_ssm' do |_record, accumulator, context|
+  accumulator.concat Array.wrap(context.output_hash['access_subjects_ssim'])
+end
+
 # Each component child document
 # <c> <c01> <c12>
 # rubocop:disable Metrics/BlockLength
@@ -246,29 +261,17 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
 
   # Indexes the controlled terms for archival description into the access_subject field
   # Please see https://www.loc.gov/ead/tglib/elements/controlaccess.html
-  to_field 'access_subjects_ssim', extract_xpath('//xmlns:controlaccess/xmlns:corpname')
-  to_field 'access_subjects_ssim', extract_xpath('//xmlns:controlaccess/xmlns:famname')
-  to_field 'access_subjects_ssim', extract_xpath('//xmlns:controlaccess/xmlns:function')
-  to_field 'access_subjects_ssim', extract_xpath('//xmlns:controlaccess/xmlns:genreform')
-  to_field 'access_subjects_ssim', extract_xpath('//xmlns:controlaccess/xmlns:geogname')
-  to_field 'access_subjects_ssim', extract_xpath('//xmlns:controlaccess/xmlns:name')
-  to_field 'access_subjects_ssim', extract_xpath('//xmlns:controlaccess/xmlns:note')
-  to_field 'access_subjects_ssim', extract_xpath('//xmlns:controlaccess/xmlns:occupation')
-  to_field 'access_subjects_ssim', extract_xpath('//xmlns:controlaccess/xmlns:persname')
-  to_field 'access_subjects_ssim', extract_xpath('//xmlns:controlaccess/xmlns:subject')
-  to_field 'access_subjects_ssim', extract_xpath('//xmlns:controlaccess/xmlns:title')
+  to_field 'access_subjects_ssim', extract_xpath('./xmlns:controlaccess', to_text: false) do |_record, accumulator|
+    accumulator.map! do |element|
+      %w[corpname famname function genreform geogname name note occupation persname subject title].map do |selector|
+        element.xpath(".//xmlns:#{selector}").map(&:text)
+      end
+    end.flatten!
+  end
 
-  to_field 'access_subjects_ssm', extract_xpath('//xmlns:controlaccess/xmlns:corpname')
-  to_field 'access_subjects_ssm', extract_xpath('//xmlns:controlaccess/xmlns:famname')
-  to_field 'access_subjects_ssm', extract_xpath('//xmlns:controlaccess/xmlns:function')
-  to_field 'access_subjects_ssm', extract_xpath('//xmlns:controlaccess/xmlns:genreform')
-  to_field 'access_subjects_ssm', extract_xpath('//xmlns:controlaccess/xmlns:geogname')
-  to_field 'access_subjects_ssm', extract_xpath('//xmlns:controlaccess/xmlns:name')
-  to_field 'access_subjects_ssm', extract_xpath('//xmlns:controlaccess/xmlns:note')
-  to_field 'access_subjects_ssm', extract_xpath('//xmlns:controlaccess/xmlns:occupation')
-  to_field 'access_subjects_ssm', extract_xpath('//xmlns:controlaccess/xmlns:persname')
-  to_field 'access_subjects_ssm', extract_xpath('//xmlns:controlaccess/xmlns:subject')
-  to_field 'access_subjects_ssm', extract_xpath('//xmlns:controlaccess/xmlns:title')
+  to_field 'access_subjects_ssm' do |_record, accumulator, context|
+    accumulator.concat Array.wrap(context.output_hash['access_subjects_ssim'])
+  end
 
   to_field 'language_ssm', extract_xpath('xmlns:did/xmlns:langmaterial')
   to_field 'accessrestrict_ssm', extract_xpath('xmlns:accessrestrict/*[local-name()!="head"]')

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -83,6 +83,7 @@ to_field 'geogname_ssm', extract_xpath('//xmlns:archdesc/xmlns:controlaccess/xml
 
 to_field 'geogname_sim', extract_xpath('//xmlns:archdesc/xmlns:controlaccess/xmlns:geogname')
 
+
 to_field 'creator_ssm', extract_xpath("//xmlns:archdesc/xmlns:did/xmlns:origination[@label='creator']")
 to_field 'creator_ssim', extract_xpath("//xmlns:archdesc/xmlns:did/xmlns:origination[@label='creator']")
 to_field 'creator_sort' do |record, accumulator|
@@ -104,12 +105,10 @@ end
 
 to_field 'places_ssim', extract_xpath('//xmlns:archdesc/xmlns:controlaccess/xmlns:geogname')
 
-
-# Indexes the controlled terms for archival description into the access_subject field
-# Please see https://www.loc.gov/ead/tglib/elements/controlaccess.html
+# Indexes only specified controlled terms for archival description into the access_subject field
 to_field 'access_subjects_ssim', extract_xpath('//xmlns:archdesc/xmlns:controlaccess', to_text: false) do |_record, accumulator|
   accumulator.map! do |element|
-    %w[corpname famname function genreform geogname name note occupation persname subject title].map do |selector|
+    %w[subject function occupation genreform].map do |selector|
       element.xpath(".//xmlns:#{selector}").map(&:text)
     end
   end.flatten!
@@ -259,11 +258,10 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
   to_field 'geogname_ssm', extract_xpath('./xmlns:controlaccess/xmlns:geogname')
   to_field 'places_ssim', extract_xpath('xmlns:controlaccess/xmlns:geogname')
 
-  # Indexes the controlled terms for archival description into the access_subject field
-  # Please see https://www.loc.gov/ead/tglib/elements/controlaccess.html
+  # Indexes only specified controlled terms for archival description into the access_subject field
   to_field 'access_subjects_ssim', extract_xpath('./xmlns:controlaccess', to_text: false) do |_record, accumulator|
     accumulator.map! do |element|
-      %w[corpname famname function genreform geogname name note occupation persname subject title].map do |selector|
+      %w[subject function occupation genreform].map do |selector|
         element.xpath(".//xmlns:#{selector}").map(&:text)
       end
     end.flatten!

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -83,7 +83,6 @@ to_field 'geogname_ssm', extract_xpath('//xmlns:archdesc/xmlns:controlaccess/xml
 
 to_field 'geogname_sim', extract_xpath('//xmlns:archdesc/xmlns:controlaccess/xmlns:geogname')
 
-
 to_field 'creator_ssm', extract_xpath("//xmlns:archdesc/xmlns:did/xmlns:origination[@label='creator']")
 to_field 'creator_ssim', extract_xpath("//xmlns:archdesc/xmlns:did/xmlns:origination[@label='creator']")
 to_field 'creator_sort' do |record, accumulator|
@@ -293,7 +292,7 @@ end
 ##
 # Used for evaluating xpath components to find
 class NokogiriXpathExtensions
-  # rubocop:disable Naming/PredicateName, Style/FormatString
+  # rubocop:disable Style/PredicateName, Style/FormatString
   def is_component(node_set)
     node_set.find_all do |node|
       component_elements = (1..12).map { |i| "c#{'%02d' % i}" }
@@ -301,5 +300,5 @@ class NokogiriXpathExtensions
       component_elements.include? node.name
     end
   end
-  # rubocop:enable Naming/PredicateName, Style/FormatString
+  # rubocop:enable Style/PredicateName, Style/FormatString
 end

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -159,13 +159,9 @@ describe 'EAD 2 traject indexing', type: :feature do
       %w[access_subjects_ssm access_subjects_ssim].each do |field|
         expect(result).to include field
         expect(result[field]).to contain_exactly(
-          'Alpha Omega Alpha',
-          'Bierring, Walter L. (Walter Lawrence), 1868-1961',
           'Fraternizing',
           'Medicine',
-          'Mindanao Island (Philippines)',
           'Photographs',
-          'Root, William Webster, 1867-1932',
           'Societies'
         )
       end
@@ -194,25 +190,16 @@ describe 'EAD 2 traject indexing', type: :feature do
       end
 
       it 'indexes the values as controlled vocabulary terms' do
-        expect(result).to include 'access_subjects_ssim'
-        expect(result['access_subjects_ssim']).to contain_exactly(
-          'Acquired Immunodeficiency Syndrome',
-          'African Americans',
-          'Homosexuality',
-          'Human Immunodeficiency Virus',
-          'Public Health',
-          'United States. Presidential Commission on the Human Immunodeficiency Virus  Epidemic'
-        )
-
-        expect(result).to include 'access_subjects_ssm'
-        expect(result['access_subjects_ssm']).to contain_exactly(
-          'Acquired Immunodeficiency Syndrome',
-          'African Americans',
-          'Homosexuality',
-          'Human Immunodeficiency Virus',
-          'Public Health',
-          'United States. Presidential Commission on the Human Immunodeficiency Virus  Epidemic'
-        )
+        %w[access_subjects_ssm access_subjects_ssim].each do |field|
+          expect(result).to include field
+          expect(result[field]).to contain_exactly(
+            'Acquired Immunodeficiency Syndrome',
+            'African Americans',
+            'Homosexuality',
+            'Human Immunodeficiency Virus',
+            'Public Health'
+          )
+        end
       end
     end
   end

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -156,45 +156,27 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'indexes the values as controlled vocabulary terms' do
-      expect(result).to include 'components'
-      expect(result['components']).not_to be_empty
-      first_component = result['components'].first
+      %w[access_subjects_ssm access_subjects_ssim].each do |field|
+        expect(result).to include field
+        expect(result[field]).to contain_exactly(
+          'Alpha Omega Alpha',
+          'Bierring, Walter L. (Walter Lawrence), 1868-1961',
+          'Fraternizing',
+          'Medicine',
+          'Mindanao Island (Philippines)',
+          'Photographs',
+          'Root, William Webster, 1867-1932',
+          'Societies'
+        )
+      end
+    end
 
-      expect(first_component).to include 'access_subjects_ssim'
-      expect(first_component['access_subjects_ssim']).to contain_exactly(
-        'Alpha Omega Alpha',
-        'Bierring, Walter L. (Walter Lawrence), 1868-1961',
-        'Fraternizing',
-        'Medicine',
-        'Minutes',
-        'Mindanao Island (Philippines)',
-        'Owner of the reel of yellow nylon rope',
-        'Photographs',
-        'Popes Creek (Md.)',
-        'Records',
-        'Robertson\'s Crab House',
-        'Root, William Webster, 1867-1932',
-        'Societies',
-        'Speeches'
-      )
-
-      expect(first_component).to include 'access_subjects_ssm'
-      expect(first_component['access_subjects_ssm']).to contain_exactly(
-        'Alpha Omega Alpha',
-        'Bierring, Walter L. (Walter Lawrence), 1868-1961',
-        'Fraternizing',
-        'Medicine',
-        'Minutes',
-        'Mindanao Island (Philippines)',
-        'Owner of the reel of yellow nylon rope',
-        'Photographs',
-        'Popes Creek (Md.)',
-        'Records',
-        'Robertson\'s Crab House',
-        'Root, William Webster, 1867-1932',
-        'Societies',
-        'Speeches'
-      )
+    it 'control access within a component' do
+      component = result['components'].find { |c| c['id'] == ['aoa271aspace_81c806b82a14c3c79d395bbd383b886f'] }
+      %w[access_subjects_ssm access_subjects_ssim].each do |field|
+        expect(component).to include field
+        expect(component[field]).to contain_exactly 'Minutes'
+      end
     end
 
     it 'indexes geognames' do
@@ -212,12 +194,8 @@ describe 'EAD 2 traject indexing', type: :feature do
       end
 
       it 'indexes the values as controlled vocabulary terms' do
-        expect(result).to include 'components'
-        expect(result['components']).not_to be_empty
-        first_component = result['components'].first
-
-        expect(first_component).to include 'access_subjects_ssim'
-        expect(first_component['access_subjects_ssim']).to contain_exactly(
+        expect(result).to include 'access_subjects_ssim'
+        expect(result['access_subjects_ssim']).to contain_exactly(
           'Acquired Immunodeficiency Syndrome',
           'African Americans',
           'Homosexuality',
@@ -226,8 +204,8 @@ describe 'EAD 2 traject indexing', type: :feature do
           'United States. Presidential Commission on the Human Immunodeficiency Virus  Epidemic'
         )
 
-        expect(first_component).to include 'access_subjects_ssm'
-        expect(first_component['access_subjects_ssm']).to contain_exactly(
+        expect(result).to include 'access_subjects_ssm'
+        expect(result['access_subjects_ssm']).to contain_exactly(
           'Acquired Immunodeficiency Syndrome',
           'African Americans',
           'Homosexuality',


### PR DESCRIPTION
A follow on to #585. I noticed that for each component document, it had all of the other `access_subjects` as part of it.  This still maintains the nesting requested in #469.

However, I realize we are indexing all of the controlaccess fields now. Previously we had specified to constrain this, thus the follow on commit to do such. https://github.com/projectblacklight/arclight/commit/0dd37fd9e6569649fc2ae70b922eb95f5eddfc53

