### PR TITLE
Fix incorrect component ead_ssi, to reflect parent ead id and un slugified

### DIFF
--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -35,9 +35,7 @@ end
 to_field 'id', extract_xpath('//xmlns:eadid'), strip, gsub('.', '-')
 to_field 'title_ssm', extract_xpath('//xmlns:archdesc/xmlns:did/xmlns:unittitle')
 to_field 'title_teim', extract_xpath('//xmlns:archdesc/xmlns:did/xmlns:unittitle')
-to_field 'ead_ssi' do |_record, accumulator, context|
-  accumulator << context.output_hash['id'].first
-end
+to_field 'ead_ssi', extract_xpath('//xmlns:eadid')
 
 to_field 'level_ssm' do |record, accumulator|
   accumulator << record.at_xpath('//xmlns:archdesc').attribute('level').value
@@ -140,7 +138,7 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
   end
 
   to_field 'ead_ssi' do |_record, accumulator, context|
-    accumulator << context.output_hash['id'].first
+    accumulator << context.clipboard[:parent].output_hash['ead_ssi'].first
   end
 
   to_field 'title_ssm', extract_xpath('./xmlns:did/xmlns:unittitle')

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -43,7 +43,7 @@ describe 'EAD 2 traject indexing', type: :feature do
 
     it 'id' do
       expect(result['id'].first).to eq 'a0011-xml'
-      expect(result['ead_ssi'].first).to eq 'a0011-xml'
+      expect(result['ead_ssi'].first).to eq 'a0011.xml'
     end
     it 'title' do
       %w[title_ssm title_teim].each do |field|
@@ -102,6 +102,9 @@ describe 'EAD 2 traject indexing', type: :feature do
       end
       it 'id' do
         expect(first_component).to include 'id' => ['a0011-xmlaspace_ref6_lx4']
+      end
+      it 'ead_ssi should be parents' do
+        expect(first_component['ead_ssi']).to eq result['ead_ssi']
       end
       it 'repository' do
         %w[repository_sim repository_ssm].each do |field|


### PR DESCRIPTION
This fixes an issue I ran across while validating some of this work and looking for gaps in our ticketing. I went back and verified that the `ead_ssi` should be the unsluggified id of the top level document.