### PR TITLE
Update level indexing in traject to reflect otherlevel logic.

### DIFF
--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -234,12 +234,21 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
   end
 
   to_field 'level_ssm' do |record, accumulator|
-    accumulator << record.attribute('level')
+    level = record.attribute('level')&.value
+    other_level = record.attribute('otherlevel')&.value
+
+    accumulator << if level == 'otherlevel'
+                     alternative_level = other_level if other_level
+                     alternative_level.present? ? alternative_level : 'Other'
+                   elsif level.present?
+                     level&.capitalize
+                   end
   end
 
-  to_field 'level_sim' do |record, accumulator|
-    accumulator << record.attribute('level')
+  to_field 'level_sim' do |_record, accumulator, context|
+    accumulator << context.output_hash['level_ssm']&.map(&:capitalize)
   end
+
   to_field 'userestrict_ssm', extract_xpath('xmlns:userestrict/xmlns:p')
   # to_field 'parent_access_restrict_ssm'
   # to_field 'parent_access_terms_ssm'

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -148,6 +148,22 @@ describe 'EAD 2 traject indexing', type: :feature do
         component = result['components'].find { |c| c['ref_ssi'] == ['aspace_ref6_lx4'] }
         expect(component['containers_ssim']).to eq ['box 1']
       end
+
+      describe 'levels' do
+        let(:fixture_path) do
+          Arclight::Engine.root.join('spec', 'fixtures', 'ead', 'nlm', 'alphaomegaalpha.xml')
+        end
+        let(:level_component) { result['components'].find { |c| c['ref_ssi'] == ['aspace_a951375d104030369a993ff943f61a77'] } }
+        let(:other_level_component) { result['components'].find { |c| c['ref_ssi'] == ['aspace_e6db65d47e891d61d69c2798c68a8f02'] } }
+
+        it 'is the level Capitalized' do
+          expect(level_component['level_ssm']).to eq(['Series'])
+        end
+
+        it 'is the otherlevel attribute when the level attribute is "otherlevel"' do
+          expect(other_level_component['level_ssm']).to eq(['Binder'])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Closes #599 

I believe we missed porting this logic: https://github.com/projectblacklight/arclight/blob/a770246bb72d86c8625227b97e732c64d782cdbd/lib/arclight/custom_component.rb#L70-L82