### PR TITLE
Implements a NokogiriNamespacelessReader class in order to handle processing EAD Documents without namespaces

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -89,6 +89,8 @@ Metrics/AbcSize:
 # ExcludedMethods: refine
 Metrics/BlockLength:
   Max: 278
+  Exclude:
+    - 'spec/features/traject/ead2_indexing_spec.rb'
 
 # Offense count: 1
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/lib/arclight/traject/nokogiri_namespaceless_reader.rb
+++ b/lib/arclight/traject/nokogiri_namespaceless_reader.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Arclight
+  module Traject
+    # Provides a Traject Reader for XML Documents which removes the namespaces
+    class NokogiriNamespacelessReader < ::Traject::NokogiriReader
+      # Overrides the #each method (which is used for iterating through each Document)
+      # @param args
+      # @see ::Traject::NokogiriReader#each
+      # @see Enumerable#each
+      def each(*args)
+        return to_enum(:each, *args) unless block_given?
+
+        super do |doc|
+          new_doc = doc.dup
+          new_doc.remove_namespaces!
+          yield new_doc
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #575 using an approach suggested by @cbeer 