### PR TITLE
Remove the document title from the breadcrumb …

### DIFF
--- a/app/views/catalog/_show_breadcrumbs_default.html.erb
+++ b/app/views/catalog/_show_breadcrumbs_default.html.erb
@@ -12,9 +12,6 @@
           <%= link_to parent.label, solr_document_path(parent.global_id) %>
         <% end %>
       <% end %>
-      <li class="breadcrumb-item al-bc-item active" aria-current="page">
-        <%= document.normalized_title %>
-      </li>
     </ol>
   </nav>
 </div>

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -311,11 +311,10 @@ RSpec.describe 'Collection Page', type: :feature do
     end
   end
   describe 'breadcrumb' do
-    it 'links home, collection, displays title' do
+    it 'links home and to the collection' do
       within '.al-show-breadcrumb' do
         expect(page).to have_css 'a', text: 'Home'
         expect(page).to have_css 'a', text: 'Collections'
-        expect(page).to have_content 'Alpha Omega Alpha Archives, 1894-1992'
       end
     end
   end

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -240,12 +240,11 @@ RSpec.describe 'Component Page', type: :feature do
     end
   end
   describe 'breadcrumb' do
-    it 'links home, collection, parents and displays title' do
+    it 'links home, collection, and parents' do
       within '.al-show-breadcrumb' do
         expect(page).to have_css 'a', text: 'Home'
         expect(page).to have_css 'a', text: 'Collections'
         expect(page).to have_css 'a', count: 4
-        expect(page).to have_content(/"A brief account of the origin of the /)
       end
     end
   end

--- a/spec/features/item_breadcrumbs_spec.rb
+++ b/spec/features/item_breadcrumbs_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe 'Item breadcrumb', type: :feature do
   end
   it 'show page breadcrumbs' do
     visit solr_document_path id: 'aoa271aspace_e8755922a9336970292ca817983e7139'
-    expect(page).to have_css 'li.breadcrumb-item.al-bc-item', count: 7
     expect(page).to have_css 'li.breadcrumb-item.al-bc-item a', count: 6
   end
 end


### PR DESCRIPTION
…(as it will duplicate the document heading).

Closes #629 

## Before
<img width="931" alt="before" src="https://user-images.githubusercontent.com/96776/63724587-f6f62500-c80c-11e9-9d40-3e84967fa971.png">

## After
<img width="988" alt="after" src="https://user-images.githubusercontent.com/96776/63724588-f6f62500-c80c-11e9-8eb4-2939a59f5899.png">
