### PR TITLE
Allow for handling of components w/o IDs using a configurable strategy

### DIFF
--- a/lib/arclight/hash_absolute_xpath.rb
+++ b/lib/arclight/hash_absolute_xpath.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'digest'
+
+module Arclight
+  ##
+  # Take a Nokogiri node and get its absolute path (inserting our own indexes for component levels)
+  # and hash that outout. This is intended as a potential strategy for handling missing IDs in EADs.
+  class HashAbsoluteXpath
+    class << self
+      attr_writer :hash_algorithm
+
+      def hash_algorithm
+        return Digest::SHA1 unless defined? @hash_algorithm
+
+        @hash_algorithm
+      end
+    end
+
+    COMPONENT_NODE_NAME_REGEX = /^c\d{,2}$/.freeze
+    attr_reader :node
+    def initialize(node)
+      @node = node
+    end
+
+    def to_hexdigest
+      self.class.hash_algorithm.hexdigest(absolute_xpath)
+    end
+
+    def absolute_xpath
+      ancestor_tree = node.ancestors.map do |ancestor|
+        if ancestor.name =~ COMPONENT_NODE_NAME_REGEX
+          index = component_siblings_for_node(ancestor).index(ancestor)
+          "#{ancestor.name}#{index}"
+        else
+          ancestor.name
+        end
+      end
+
+      "#{[ancestor_tree.reverse, node.name].flatten.join('/')}#{current_index}"
+    end
+
+    private
+
+    def current_index
+      siblings.index(node)
+    end
+
+    def component_siblings_for_node(xml_node)
+      xml_node.parent.children.select { |n| n.name =~ COMPONENT_NODE_NAME_REGEX }
+    end
+
+    def siblings
+      @siblings ||= component_siblings_for_node(node)
+    end
+  end
+end

--- a/lib/arclight/missing_id_strategy.rb
+++ b/lib/arclight/missing_id_strategy.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'arclight/hash_absolute_xpath'
+
+module Arclight
+  ##
+  # A class to configure a selected MissingIdStrategy.
+  # Defaults to Arclight::HashAbsoluteXpath
+  # This can be updated in an initializer to be any other class
+  class MissingIdStrategy
+    class << self
+      attr_writer :selected
+
+      def selected
+        return Arclight::HashAbsoluteXpath unless defined? @selected
+
+        @selected
+      end
+    end
+  end
+end

--- a/spec/lib/arclight/hash_absolute_xpath_spec.rb
+++ b/spec/lib/arclight/hash_absolute_xpath_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'arclight/hash_absolute_xpath'
+
+RSpec.describe Arclight::HashAbsoluteXpath do
+  let(:components) { xml.xpath('//xmlns:c') }
+
+  let(:xml) { Nokogiri::XML.parse(raw_xml) }
+
+  let(:raw_xml) do
+    <<-XML
+      <ead
+        xmlns="urn:isbn:1-931666-22-9"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd"
+      >
+        <archdesc>
+          <c>
+            <did><unittitle>C0</unittitle></did>
+            <c>
+              <did><unittitle>C0.0</unittitle></did>
+            </c>
+          </c>
+          <c>
+            <did><unittitle>C1</unittitle></did>
+            <c>
+              <did><unittitle>C1.0</unittitle></did>
+            </c>
+            <c>
+              <did><unittitle>C1.1</unittitle></did>
+            </c>
+          </c>
+        </archdesc>
+      </ead>
+    XML
+  end
+
+  it 'returns the absolute xpath of node passed in (adding indexes to all the c nodes)' do
+    expect(described_class.new(components[0]).absolute_xpath).to eq 'document/ead/archdesc/c0'
+    expect(described_class.new(components[1]).absolute_xpath).to eq 'document/ead/archdesc/c0/c0'
+    expect(described_class.new(components[2]).absolute_xpath).to eq 'document/ead/archdesc/c1'
+    expect(described_class.new(components[3]).absolute_xpath).to eq 'document/ead/archdesc/c1/c0'
+    expect(described_class.new(components[4]).absolute_xpath).to eq 'document/ead/archdesc/c1/c1'
+  end
+
+  it 'hashes the absolute_xpath' do
+    expect(described_class.new(components[0]).to_hexdigest).to eq 'c015cba710557ac75e1c9b4da33e37fbdee41e82'
+    expect(described_class.new(components[1]).to_hexdigest).to eq '0e6141f0e5d704f223e254e26a62c954643f5553'
+    expect(described_class.new(components[2]).to_hexdigest).to eq '24494999c8c5a300dabdcd74f0885f1f380a71f3'
+    expect(described_class.new(components[3]).to_hexdigest).to eq '76229094a02f4644b05317e51ecaa5dfc950d811'
+    expect(described_class.new(components[4]).to_hexdigest).to eq '20fb448f390a0e3a5da9f2506c782a62e6264fc9'
+  end
+
+  it 'allows the hashing algorithm to be configured' do
+    hash_algorithm = described_class.hash_algorithm
+    described_class.hash_algorithm = Digest::SHA256
+    expect(described_class.new(components[0]).to_hexdigest).to eq '0b77f8ad4db958f29236f78bd367f466c82b45800ffae72a1cec91742fa37a59'
+    described_class.hash_algorithm = hash_algorithm
+  end
+end

--- a/spec/lib/arclight/missing_id_strategy_spec.rb
+++ b/spec/lib/arclight/missing_id_strategy_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'arclight/missing_id_strategy'
+
+RSpec.describe Arclight::MissingIdStrategy do
+  subject(:strategy) { described_class.selected }
+
+  it 'defaults to Arclight::HashAbsoluteXpath' do
+    expect(strategy).to eq Arclight::HashAbsoluteXpath
+  end
+end


### PR DESCRIPTION
Closes #446 

This adds an initial strategy that attempts to return an absolute path to the component that takes component sibling hierarchy into account.  I couldn't fine a native way to do this in nokogiri, so if anybody (@billdueber maybe knows something handy?)

Updated https://github.com/projectblacklight/arclight/wiki/Indexing-EAD-in-ArcLight w/ details about why you should have IDs and how to configure the behavior of what happens when a component does not have an idea.

## TODO
- [x] Add warnings
- [x] Document _why_ components should have IDs