### PR TITLE
Fixes all the remaining feature specs using traject indexing.

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -54,7 +54,8 @@
   // Series level
   .blacklight-series .document-title-heading,
   .blacklight-file .document-title-heading,
-  .blacklight-otherlevel .document-title-heading {
+  .blacklight-binder .document-title-heading,
+  .blacklight-other .document-title-heading {
     font-size: $h5-font-size;
     font-weight: 400;
     margin-bottom: ($spacer / 2);
@@ -69,7 +70,8 @@
     // Additional for levels below series
     .blacklight-subseries .document-title-heading,
     .blacklight-file .document-title-heading,
-    .blacklight-otherlevel .document-title-heading {
+    .blacklight-binder .document-title-heading,
+    .blacklight-other .document-title-heading {
       font-size: $h6-font-size;
 
       .documentHeader {
@@ -80,7 +82,8 @@
     // Icongraphy for each level
     .blacklight-subseries .document-title-heading,
     .al-hierarchy-level-1 .blacklight-file .document-title-heading,
-    .al-hierarchy-level-1 .blacklight-otherlevel .document-title-heading {
+    .al-hierarchy-level-1 .blacklight-binder .document-title-heading,
+    .al-hierarchy-level-1 .blacklight-other .document-title-heading {
       padding-left: 10px;
 
       &:before {

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -41,14 +41,6 @@ SEARCHABLE_NOTES_FIELDS = %w[
   userestrict
 ].freeze
 
-SEARCHABLE_NOTES_TEIM_FIELDS = %w[
-  accessrestrict
-  altformavail
-  prefercite
-  scopecontent
-  userestrict
-].freeze
-
 DID_SEARCHABLE_NOTES_FIELDS = %w[
   abstract
   materialspec
@@ -203,10 +195,9 @@ end
 SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_ssm", extract_xpath("//xmlns:archdesc/xmlns:#{selector}/*[local-name()!='head']")
   to_field "#{selector}_heading_ssm", extract_xpath("//xmlns:archdesc/xmlns:#{selector}/xmlns:head") unless selector == 'prefercite'
-end
-SEARCHABLE_NOTES_TEIM_FIELDS.map do |selector|
   to_field "#{selector}_teim", extract_xpath("//xmlns:archdesc/xmlns:#{selector}/*[local-name()!='head']")
 end
+
 DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_ssm", extract_xpath("//xmlns:did/xmlns:#{selector}")
 end

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -281,6 +281,9 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
         .find { |c| c['ref_ssi'] == [id] }&.[]('normalized_title_ssm')
     end
   end
+  to_field 'parent_unittitles_teim' do |_record, accumulator, context|
+    accumulator.concat context.output_hash['parent_unittitles_ssm']
+  end
 
   to_field 'unitid_ssm', extract_xpath('./xmlns:did/xmlns:unitid')
   to_field 'repository_ssm' do |_record, accumulator, context|

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -246,7 +246,7 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
       context.output_hash['unitdate_bulk_ssim'],
       context.output_hash['unitdate_other_ssim']
     ).to_s
-    title = context.output_hash['title_ssm'].first
+    title = context.output_hash['title_ssm']&.first
     accumulator << Arclight::NormalizedTitle.new(title, dates).to_s
   end
 

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -264,7 +264,7 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
 
   to_field 'parent_ssm' do |record, accumulator, context|
     accumulator << context.clipboard[:parent].output_hash['id'].first
-    accumulator.concat NokogiriXpathExtensions.new.is_component(record.ancestors).map { |n| n.attribute('id').value }
+    accumulator.concat NokogiriXpathExtensions.new.is_component(record.ancestors).reverse.map { |n| n.attribute('id').value }
   end
 
   to_field 'parent_ssi' do |_record, accumulator, context|

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -433,6 +433,7 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
   SEARCHABLE_NOTES_FIELDS.map do |selector|
     to_field "#{selector}_ssm", extract_xpath(".//xmlns:#{selector}/*[local-name()!='head']")
     to_field "#{selector}_heading_ssm", extract_xpath(".//xmlns:archdesc/xmlns:#{selector}/xmlns:head")
+    to_field "#{selector}_teim", extract_xpath(".//xmlns:#{selector}/*[local-name()!='head']")
   end
   DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
     to_field "#{selector}_ssm", extract_xpath(".//xmlns:did/xmlns:#{selector}")

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -22,7 +22,7 @@ namespace :arclight do
     print "Loading #{ENV['FILE']} into index...\n"
     load_indexer # a leftover construct from solr_ead. Likely will need to be removed/modified when we remove that
     elapsed_time = Benchmark.realtime { 
-      `bundle exec traject -u #{ENV['SOLR_URL']} -i xml -c lib/arclight/traject/ead2_config.rb #{ENV['FILE']}`
+      `bundle exec traject -u #{ENV['SOLR_URL']} -i xml -c #{Arclight::Engine.root}/lib/arclight/traject/ead2_config.rb #{ENV['FILE']}`
     }
     print "Indexed #{ENV['FILE']} (in #{elapsed_time.round(3)} secs).\n"
   end

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -19,15 +19,11 @@ namespace :arclight do
   desc 'Index an EAD document, use FILE=<path/to/ead.xml> and REPOSITORY_ID=<myid>'
   task :index do
     raise 'Please specify your EAD document, ex. FILE=<path/to/ead.xml>' unless ENV['FILE']
-    indexer = load_indexer
     print "Loading #{ENV['FILE']} into index...\n"
-    elapsed_time = if ENV['TRAJECT']
-                     Benchmark.realtime { 
-                       `bundle exec traject -u #{ENV['SOLR_URL']} -i xml -c lib/arclight/traject/ead2_config.rb #{ENV['FILE']}`
-                     }
-                   else
-                     Benchmark.realtime { indexer.update(ENV['FILE']) }
-                   end
+    load_indexer # a leftover construct from solr_ead. Likely will need to be removed/modified when we remove that
+    elapsed_time = Benchmark.realtime { 
+      `bundle exec traject -u #{ENV['SOLR_URL']} -i xml -c lib/arclight/traject/ead2_config.rb #{ENV['FILE']}`
+    }
     print "Indexed #{ENV['FILE']} (in #{elapsed_time.round(3)} secs).\n"
   end
 

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe 'Collection Page', type: :feature do
         within '#contents' do
           within '.document-position-0' do
             click_link 'View'
-            within '.blacklight-otherlevel.document-position-3' do
+            within '.blacklight-other.document-position-3' do
               expect(page).to have_css '.document-title-containers', text: /Box 1, Folder 4\-5/
             end
             expect(page).to have_css 'a', text: 'Reports'

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -105,8 +105,8 @@ RSpec.describe 'Search results', type: :feature do
 
         within('.blacklight-names_ssim') do
           expect(page).to have_css('h3 a', text: 'Names')
-          expect(page).to have_css('li .facet-label', text: 'Root, William Webster, 1867-1932', visible: false)
-          expect(page).to have_css('li .facet-label', text: 'Stanford University', visible: false)
+          expect(page).to have_css('li .facet-label', text: 'Department of Special Collections and University Archives', visible: false)
+          expect(page).to have_css('li .facet-label', text: '1118 Badger Vine Special Collections', visible: false)
         end
 
         within('.blacklight-repository_sim') do
@@ -122,11 +122,9 @@ RSpec.describe 'Search results', type: :feature do
 
         within('.blacklight-access_subjects_ssim') do
           expect(page).to have_css('h3 a', text: 'Subject')
-          expect(page).to have_css('li .facet-label', text: 'Societies', visible: false)
           expect(page).to have_css('li .facet-label', text: 'Fraternizing', visible: false)
           expect(page).to have_css('li .facet-label', text: 'Photographs', visible: false)
           expect(page).to have_css('li .facet-label', text: 'Medicine', visible: false)
-          expect(page).to have_css('li .facet-label', text: 'Records', visible: false)
         end
 
         within('.blacklight-has_online_content_ssim') do

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -299,6 +299,15 @@ describe 'EAD 2 traject indexing', type: :feature do
         expect(component_where_parent_has_access_terms['parent_access_terms_ssm'])
           .to eq ["Copyright was transferred to the public domain. Contact the Reference Staff for details\n        regarding rights."]
       end
+
+      it 'parent_unittitles should be displayable and searchable' do
+        component = result['components'].find { |c| c['id'] == ['aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671'] }
+        %w[parent_unittitles_ssm parent_unittitles_teim].each do |field|
+          expect(component[field]).to contain_exactly(
+            'Alpha Omega Alpha Archives, 1894-1992'
+          )
+        end
+      end
     end
   end
 

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -212,6 +212,7 @@ describe 'EAD 2 traject indexing', type: :feature do
 
     it '#bioghist' do
       expect(result['bioghist_ssm'].first).to match(/^Alpha Omega Alpha Honor Medical Society was founded/)
+      expect(result['bioghist_teim'].second).to match(/Hippocratic oath/)
       expect(result['bioghist_heading_ssm'].first).to match(/^Historical Note/)
     end
 

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -280,6 +280,7 @@ describe 'EAD 2 traject indexing', type: :feature do
       let(:component_where_parent_has_access_restrict) { result['components'].find { |c| c['ref_ssi'] == ['aspace_72f14d6c32e142baa3eeafdb6e4d69be'] } }
       let(:component_with_access_terms) { result['components'].find { |c| c['ref_ssi'] == ['aspace_72f14d6c32e142baa3eeafdb6e4d69be'] } }
       let(:component_where_parent_has_access_terms) { result['components'].find { |c| c['ref_ssi'] == ['aspace_dba76dab6f750f31aa5fc73e5402e71d'] } }
+      let(:component_with_many_parents) { result['components'].find { |c| c['ref_ssi'] == ['aspace_f934f1add34289f28bd0feb478e68275'] } }
 
       it 'has access restrict' do
         expect(component_with_access_restrict['parent_access_restrict_ssm']).to eq ['Restricted until 2018.']
@@ -307,6 +308,14 @@ describe 'EAD 2 traject indexing', type: :feature do
             'Alpha Omega Alpha Archives, 1894-1992'
           )
         end
+      end
+
+      it 'parents are correctly ordered' do
+        expect(component_with_many_parents['parent_ssm']).to eq %w[
+          aoa271
+          aspace_563a320bb37d24a9e1e6f7bf95b52671
+          aspace_238a0567431f36f49acea49ef576d408
+        ]
       end
     end
   end


### PR DESCRIPTION
This resolves ~5~ **all** failing feature specs when using traject indexing.

Based off of what solr_ead is doing:

https://github.com/awead/solr_ead/blob/54a5f5217152882946be6d4ee6deda0e1c80263c/lib/solr_ead/document.rb#L34-L67

and what legacy indexing is doing:

https://github.com/projectblacklight/arclight/blob/a1ec06251b5a937e785d32ef74f2adb817df5ae6/lib/arclight/shared_terminology_behavior.rb#L27-L51

It is indexing content as `displayable` and `searchable`.

[`ssm`](https://github.com/samvera-deprecated/solrizer/blob/f39e48a321429b9e0a155a635fbaf6a929782284/lib/solrizer/default_descriptors.rb#L56) and [`teim` ](https://github.com/samvera-deprecated/solrizer/blob/f39e48a321429b9e0a155a635fbaf6a929782284/lib/solrizer/default_descriptors.rb#L13)

Additionally, some minor changes were made to accommodate intention in the previous code that seemed to actually be a bug.