### PR TITLE
Open repository configuration to add'l request types

### DIFF
--- a/app/controllers/concerns/arclight/field_config_helpers.rb
+++ b/app/controllers/concerns/arclight/field_config_helpers.rb
@@ -33,8 +33,7 @@ module Arclight
 
     def request_config_present(var, document)
       repository_config_present(var, document) &&
-        document.repository_config.google_request_url.present? &&
-        document.repository_config.google_request_mappings.present?
+        document.repository_config.request_config_present?
     end
 
     def context_sidebar_repository(args)

--- a/app/models/arclight/requests/google_form.rb
+++ b/app/models/arclight/requests/google_form.rb
@@ -22,7 +22,7 @@ module Arclight
       ##
       # Url of form to fill
       def url
-        document.repository_config.google_request_url
+        document.repository_config.request_url_for_type('google_form')
       end
 
       ##
@@ -32,7 +32,7 @@ module Arclight
       # @return [Hash]
       def form_mapping
         Rack::Utils.parse_nested_query(
-          document.repository_config.google_request_mappings
+          document.repository_config.request_mappings_for_type('google_form')
         )
       end
 

--- a/lib/arclight/repository.rb
+++ b/lib/arclight/repository.rb
@@ -35,8 +35,9 @@ module Arclight
 
     def request_config_present_for_type?(type)
       return false unless type && request_config_present?
-      config = request_types.fetch(type)
-      config&.fetch('request_url') && config&.fetch('request_mappings')
+      config = request_types[type]
+      config&.fetch('request_url').present? &&
+        config&.fetch('request_mappings').present?
     end
 
     def request_url_for_type(type)

--- a/lib/arclight/repository.rb
+++ b/lib/arclight/repository.rb
@@ -29,8 +29,8 @@ module Arclight
     def request_config_present?
       return false unless request_types
       request_configs = request_types.map { |_k, v| v }
-      request_configs[0]&.fetch('request_url') &&
-        request_configs[0]&.fetch('request_mappings')
+      request_configs[0]&.fetch('request_url').present? &&
+        request_configs[0]&.fetch('request_mappings').present?
     end
 
     def request_config_present_for_type?(type)

--- a/lib/arclight/repository.rb
+++ b/lib/arclight/repository.rb
@@ -26,6 +26,31 @@ module Arclight
       [city, state_zip, country].compact.join(', ')
     end
 
+    def request_config_present?
+      return false unless request_types
+      request_configs = request_types.map { |_k, v| v }
+      request_configs[0]&.fetch('request_url') &&
+        request_configs[0]&.fetch('request_mappings')
+    end
+
+    def request_config_present_for_type?(type)
+      return false unless type && request_config_present?
+      config = request_types.fetch(type)
+      config&.fetch('request_url') && config&.fetch('request_mappings')
+    end
+
+    def request_url_for_type(type)
+      return nil unless type && request_config_present_for_type?(type)
+      config = request_types.fetch(type)
+      config.fetch('request_url')
+    end
+
+    def request_mappings_for_type(type)
+      return nil unless type && request_config_present_for_type?(type)
+      config = request_types.fetch(type)
+      config.fetch('request_mappings')
+    end
+
     # Load repository information from a YAML file
     #
     # @param [String] `filename`

--- a/spec/fixtures/config/repositories.yml
+++ b/spec/fixtures/config/repositories.yml
@@ -42,8 +42,10 @@ nlm:
   phone: ''
   contact_info: 'hmdref@nlm.nih.gov'
   thumbnail_url: "https://collections.nlm.nih.gov/pageturnerserver/ajaxp?theurl=http://localhost:8080/fedora/get/nlm:nlmuid-101421040-img/THUMB"
-  google_request_url: 'https://docs.google.com/a/stanford.edu/forms/d/e/1FAIpQLSeOamhY_IcFw4sPnz0ddwWWkrPaHbM5wp7JVbOLOL_mIusEyw/viewform'
-  google_request_mappings: "document_url=entry.1980510262&collection_name=entry.619150170&collection_creator=entry.14428541&eadid=entry.996397105&containers=entry.1125277048&title=entry.862815208"
+  request_types:
+    google_form:
+      request_url: 'https://docs.google.com/a/stanford.edu/forms/d/e/1FAIpQLSeOamhY_IcFw4sPnz0ddwWWkrPaHbM5wp7JVbOLOL_mIusEyw/viewform'
+      request_mappings: "document_url=entry.1980510262&collection_name=entry.619150170&collection_creator=entry.14428541&eadid=entry.996397105&containers=entry.1125277048&title=entry.862815208"
 
 umich-bhl:
   name: 'University of Michigan. Bentley Historical Library'

--- a/spec/fixtures/config/repositories.yml
+++ b/spec/fixtures/config/repositories.yml
@@ -12,8 +12,10 @@ sample:
   phone: '123-456-7890'
   contact_info: 'My Contact Info'
   thumbnail_url: 'http://example.com/thumbnail_ABC.jpg'
-  google_request_url: 'https://docs.google.com/abc123'
-  google_request_mappings: 'collection_name=abc&eadid=123'
+  request_types:
+      google_form:
+          request_url: 'https://docs.google.com/abc123'
+          request_mappings: 'collection_name=abc&eadid=123'
   downstream_defined_field: 'Custom Data From Consumer'
 sul-spec:
   name: 'Stanford University Libraries. Special Collections and University Archives'

--- a/spec/lib/arclight/repository_spec.rb
+++ b/spec/lib/arclight/repository_spec.rb
@@ -77,11 +77,22 @@ RSpec.describe Arclight::Repository do
       it '#thumbnail_url' do
         expect(repo.thumbnail_url).to eq 'http://example.com/thumbnail_ABC.jpg'
       end
-      it '#google_request_url' do
-        expect(repo.google_request_url).to eq 'https://docs.google.com/abc123'
+    end
+    context 'methods' do
+      it '#request_config_present?' do
+        expect(repo.request_config_present?).to be true
       end
-      it '#google_request_mappings' do
-        expect(repo.google_request_mappings).to eq 'collection_name=abc&eadid=123'
+      it '#request_config_present_for_type? is present' do
+        expect(repo.request_config_present_for_type?('google_form')).to be true
+      end
+      it '#request_config_present_for_type? is not present' do
+        expect(repo.request_config_present_for_type?('fake_type')).to be false
+      end
+      it '#request_url_for_type' do
+        expect(repo.request_url_for_type('google_form')).to eq 'https://docs.google.com/abc123'
+      end
+      it '#request_mappings_for_type' do
+        expect(repo.request_mappings_for_type('google_form')).to eq 'collection_name=abc&eadid=123'
       end
     end
   end

--- a/spec/models/arclight/requests/google_form_spec.rb
+++ b/spec/models/arclight/requests/google_form_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Arclight::Requests::GoogleForm do
 
   let(:config) do
     instance_double 'Arclight::Repository',
-                    google_request_url: 'https://docs.google.com/abc123',
-                    google_request_mappings: 'collection_name=abc&eadid=123'
+                    request_url_for_type: 'https://docs.google.com/abc123',
+                    request_mappings_for_type: 'collection_name=abc&eadid=123'
   end
   let(:document) { instance_double 'Blacklight::SolrDocument', repository_config: config }
   let(:presenter) { instance_double 'Arclight::ShowPresenter', heading: 'Indiana Jones and the Last Crusade' }


### PR DESCRIPTION
Moving beyond the world in which we only use google forms for request integration. Closes #641.

This PR moves the repository yml config away from
```
google_request_url: blah
google_request_mappings: yadda=yadda
```
to
```
request_types:
    google_form:
        request_url: blah
        request_mappings: yadda=yadda
```

Do we want to allow people to continue using the old style of configuration? If so, what's the best way to go about that given the implementation here?