### PR TITLE
add flex-wrap to pagination

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -77,3 +77,7 @@
     }
   }
 }
+
+.pagination {
+  flex-wrap: wrap;
+}


### PR DESCRIPTION
closes #687 
### Issue
Pagination does not wrap on mobile

### Resolution
Add flex-wrap: wrap to .pagination

### Demo
Before:
<a href="https://cl.ly/e57a95909107" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/2M411H1T222i0o0r0j0z/Screen%20Shot%202019-09-03%20at%2012.11.22%20PM.png" style="display: block;height: auto;width: 100%;"/></a>

After:
<a href="https://cl.ly/6709d3dafbf8" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/3f0L1r2j0Z1q3h1K261O/Screen%20Shot%202019-09-03%20at%2012.04.10%20PM.png" style="display: block;height: auto;width: 100%;"/></a>