### PR TITLE
allow text to wrap inside dd

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -75,3 +75,9 @@
     content: "\0229F";
   }
 }
+
+
+dl dd {
+  overflow-wrap: break-word;
+}
+


### PR DESCRIPTION
closes #694 

### Issue
items with long urls are flowing outside of their container on mobile

### Solution
add css overflow-wrap: break-word to all of the dd elements

### Demo
before:
<a href="https://cl.ly/5f162fa7f801" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/2s260H1v1U363y1f0v3b/Screen%20Shot%202019-09-03%20at%203.06.55%20PM.png" style="display: block;height: auto;width: 100%;"/></a>

after:
<a href="https://cl.ly/2c6cb97f4d0d" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/3k1K1c2v0m0N1R351B3Z/Screen%20Shot%202019-09-03%20at%203.07.33%20PM.png" style="display: block;height: auto;width: 100%;"/></a>