### PR TITLE
Adds foundational group by collection

### DIFF
--- a/app/models/concerns/arclight/search_behavior.rb
+++ b/app/models/concerns/arclight/search_behavior.rb
@@ -11,6 +11,7 @@ module Arclight
         add_hierarchy_max_rows
         add_hierarchy_sort
         add_highlighting
+        add_grouping
       ]
     end
 
@@ -39,6 +40,18 @@ module Arclight
         solr_params['hl'] = true
         solr_params['hl.fl'] = 'text'
         solr_params['hl.snippets'] = 3
+      end
+      solr_params
+    end
+
+    ##
+    # Adds grouping parameters for Solr if enabled
+    def add_grouping(solr_params)
+      if blacklight_params[:group] == 'true'
+        solr_params[:group] = true
+        solr_params['group.field'] = 'collection_ssi'
+        solr_params['group.ngroups'] = true
+        solr_params['group.limit'] = 3
       end
       solr_params
     end

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -112,6 +112,9 @@ end
 to_field 'collection_sim' do |_record, accumulator, context|
   accumulator.concat context.output_hash.fetch('normalized_title_ssm', [])
 end
+to_field 'collection_ssi' do |_record, accumulator, context|
+  accumulator.concat context.output_hash.fetch('normalized_title_ssm', [])
+end
 
 to_field 'repository_ssm' do |_record, accumulator, context|
   accumulator << context.clipboard[:repository]
@@ -311,6 +314,9 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
     accumulator.concat context.clipboard[:parent].output_hash['normalized_title_ssm']
   end
   to_field 'collection_sim' do |_record, accumulator, context|
+    accumulator.concat context.clipboard[:parent].output_hash['normalized_title_ssm']
+  end
+  to_field 'collection_ssi' do |_record, accumulator, context|
     accumulator.concat context.clipboard[:parent].output_hash['normalized_title_ssm']
   end
 

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -101,7 +101,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'collection has normalized_title' do
-      %w[collection_ssm collection_sim].each do |field|
+      %w[collection_ssm collection_sim collection_ssi].each do |field|
         expect(result[field]).to include 'Stanford University student life photograph album, circa 1900-1906'
       end
     end
@@ -143,7 +143,7 @@ describe 'EAD 2 traject indexing', type: :feature do
       end
 
       it 'collection has normalized title' do
-        %w[collection_sim collection_ssm].each do |field|
+        %w[collection_sim collection_ssm collection_ssi].each do |field|
           expect(first_component[field]).to include 'Stanford University student life photograph album, circa 1900-1906'
         end
       end

--- a/spec/models/concerns/arclight/search_behavior_spec.rb
+++ b/spec/models/concerns/arclight/search_behavior_spec.rb
@@ -65,4 +65,25 @@ describe Arclight::SearchBehavior do
       end
     end
   end
+  describe '#add_grouping' do
+    context 'when group is selected' do
+      let(:user_params) { { group: 'true' } }
+
+      it 'adds grouping params' do
+        expect(search_builder_instance.add_grouping(solr_params)).to include(
+          group: true,
+          'group.field' => 'collection_ssi',
+          'group.ngroups' => true,
+          'group.limit' => 3
+        )
+      end
+    end
+    context 'when group is not selected' do
+      it 'enables highlighting' do
+        expect(search_builder_instance.add_grouping(solr_params)).not_to include(
+          group: true
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds some foundational aspects of #681 by enabling grouping when param `group=true` is passed in a search. #681 is large and the idea here is that after enabling this, we can split it out into new tickets.

Examples:
`http://127.0.0.1:3000/?utf8=%E2%9C%93&group=true&search_field=all_fields&q=alpha`

![Screen Shot 2019-09-04 at 7 22 16 AM](https://user-images.githubusercontent.com/1656824/64258601-c4bb8600-cee4-11e9-9be9-610b3db2429b.png)

`http://127.0.0.1:3000/?utf8=%E2%9C%93&group=true&search_field=all_fields&q=national`
![Screen Shot 2019-09-04 at 7 22 47 AM](https://user-images.githubusercontent.com/1656824/64258634-d3a23880-cee4-11e9-95d7-9278bdea3570.png)
