### PR TITLE
Update repositories.yml template; change Arclight::Repository for flexibility

### DIFF
--- a/lib/arclight/repository.rb
+++ b/lib/arclight/repository.rb
@@ -68,19 +68,22 @@ module Arclight
     # Mimics ActiveRecord's `all` behavior
     #
     # @return [Array<Repository>]
-    def self.all
-      from_yaml(ENV['REPOSITORY_FILE'] || 'config/repositories.yml').values
+    def self.all(yaml_file = nil)
+      if yaml_file.nil?
+        yaml_file = ENV['REPOSITORY_FILE'] || 'config/repositories.yml'
+      end
+      from_yaml(yaml_file).values
     end
 
     # Mimics ActiveRecord dynamic `find_by` behavior for the slug or name
     #
     # @param [String] `slug` or `name`
     # @return [Repository]
-    def self.find_by(slug: nil, name: nil)
+    def self.find_by(slug: nil, name: nil, yaml_file: nil)
       if slug
-        all.find { |repo| repo.slug == slug }
+        all(yaml_file).find { |repo| repo.slug == slug }
       elsif name
-        all.find { |repo| repo.name == name }
+        all(yaml_file).find { |repo| repo.name == name }
       else
         raise ArgumentError, 'Requires either slug or name parameters to find_by'
       end

--- a/lib/arclight/repository.rb
+++ b/lib/arclight/repository.rb
@@ -69,9 +69,7 @@ module Arclight
     #
     # @return [Array<Repository>]
     def self.all(yaml_file = nil)
-      if yaml_file.nil?
-        yaml_file = ENV['REPOSITORY_FILE'] || 'config/repositories.yml'
-      end
+      yaml_file = ENV['REPOSITORY_FILE'] || 'config/repositories.yml' if yaml_file.nil?
       from_yaml(yaml_file).values
     end
 

--- a/lib/generators/arclight/templates/config/repositories.yml
+++ b/lib/generators/arclight/templates/config/repositories.yml
@@ -11,8 +11,10 @@ nlm:
   phone: ''
   contact_info: 'hmdref@nlm.nih.gov'
   thumbnail_url: "https://collections.nlm.nih.gov/pageturnerserver/ajaxp?theurl=http://localhost:8080/fedora/get/nlm:nlmuid-101421040-img/THUMB"
-  google_request_url: 'https://docs.google.com/a/stanford.edu/forms/d/e/1FAIpQLSeOamhY_IcFw4sPnz0ddwWWkrPaHbM5wp7JVbOLOL_mIusEyw/viewform'
-  google_request_mappings: "document_url=entry.1980510262&collection_name=entry.619150170&collection_creator=entry.14428541&eadid=entry.996397105&containers=entry.1125277048&title=entry.862815208"
+  request_types:
+    google_form:
+      request_url: 'https://docs.google.com/a/stanford.edu/forms/d/e/1FAIpQLSeOamhY_IcFw4sPnz0ddwWWkrPaHbM5wp7JVbOLOL_mIusEyw/viewform'
+      request_mappings: "document_url=entry.1980510262&collection_name=entry.619150170&collection_creator=entry.14428541&eadid=entry.996397105&containers=entry.1125277048&title=entry.862815208"
 sul-spec:
   name: 'Stanford University Libraries. Special Collections and University Archives'
   visit_note: 'Special Collections and University Archives materials are stored offsite and must be paged 36 hours in advance.'

--- a/spec/lib/arclight/repository_spec.rb
+++ b/spec/lib/arclight/repository_spec.rb
@@ -113,16 +113,16 @@ RSpec.describe Arclight::Repository do
   end
 
   context 'the repositories.yml template for the generator is valid' do
-    let(:repositories_yml_template_file) {
-      SPEC_ROOT.parent + "lib/generators/arclight/templates/config/repositories.yml"
-    }
+    let(:repositories_yml_template_file) do
+      SPEC_ROOT.parent + 'lib/generators/arclight/templates/config/repositories.yml'
+    end
 
-    it "successfully loads the template repositories file" do
+    it 'successfully loads the template repositories file' do
       nlm = described_class.find_by(slug: 'nlm', yaml_file: repositories_yml_template_file)
       expect(nlm.city).to eq 'Bethesda'
     end
 
-    it "has new-style request_type" do
+    it 'has new-style request_type' do
       raw_yaml_hash = YAML.safe_load(File.read(repositories_yml_template_file))
       nlm = described_class.find_by(slug: 'nlm', yaml_file: repositories_yml_template_file)
       google_form_url = nlm.request_url_for_type('google_form')

--- a/spec/lib/arclight/repository_spec.rb
+++ b/spec/lib/arclight/repository_spec.rb
@@ -112,6 +112,24 @@ RSpec.describe Arclight::Repository do
     end
   end
 
+  context 'the repositories.yml template for the generator is valid' do
+    let(:repositories_yml_template_file) {
+      SPEC_ROOT.parent + "lib/generators/arclight/templates/config/repositories.yml"
+    }
+
+    it "successfully loads the template repositories file" do
+      nlm = described_class.find_by(slug: 'nlm', yaml_file: repositories_yml_template_file)
+      expect(nlm.city).to eq 'Bethesda'
+    end
+
+    it "has new-style request_type" do
+      raw_yaml_hash = YAML.safe_load(File.read(repositories_yml_template_file))
+      nlm = described_class.find_by(slug: 'nlm', yaml_file: repositories_yml_template_file)
+      google_form_url = nlm.request_url_for_type('google_form')
+      expect(google_form_url).to eq raw_yaml_hash['nlm']['request_types']['google_form']['request_url']
+    end
+  end
+
   describe 'extension' do
     let(:repo) { described_class.find_by(slug: 'sample') }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 ENV['RAILS_ENV'] ||= 'test'
 ENV['REPOSITORY_FILE'] ||= 'spec/fixtures/config/repositories.yml'
+SPEC_ROOT = Pathname.new(__dir__)
 
 require 'simplecov'
 SimpleCov.start do


### PR DESCRIPTION
Modifies `repositories.yml template` to reflect changes from #674 (changes to repositories.yml file to use new `request_type` section).

This just deals with the template file.  fix to make the *code* use this new format is coming in #692 

  * Makes template for `repositories.yml` reflect format changes for
request_types as implemented in #674
  * Allows passing the name of a yaml file to Repository `#all` and
    `#find_by`
  * Adds spec to pull in `repositories.yml` template and do basic
    sanity checks.