### PR TITLE
Update display of grouped collection fixes #702

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -43,6 +43,7 @@
     padding: $result-item-body-padding;
 
     h3 {
+      display: inline;
       font-size: $h4-font-size;
     }
   }

--- a/app/views/catalog/_group.html.erb
+++ b/app/views/catalog/_group.html.erb
@@ -6,8 +6,11 @@
       <div class='row'>
         <div class='col-md-12'>
           <h3>
-            <%= link_to_document parent_document, document_show_link_field(parent_document) %>
+            <%= show_presenter(parent_document).heading %>
           </h3>
+          <%= content_tag('span', class: 'badge badge-light') do %>
+            <%= parent_document.extent %>
+          <% end if parent_document.extent %>
           <%= content_tag('div', class: 'al-document-abstract-or-scope') do %>
             <%= content_tag('div', 'data-arclight-truncate' => true) do %>
               <%= parent_document.abstract_or_scope %>

--- a/spec/features/grouped_results_spec.rb
+++ b/spec/features/grouped_results_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe 'Grouped search results', type: :feature do
   it 'displays collection group information' do
     visit search_catalog_path q: 'alpha', group: 'true'
     within '.al-grouped-title-bar' do
-      expect(page).to have_css 'h3 a', text: /Alpha/
+      expect(page).to have_css 'h3', text: /Alpha/
       expect(page).to have_css '.al-document-abstract-or-scope', text: /founded in 1902/
+      expect(page).to have_css '.badge', text: '15.0 linear feet (36 boxes + oversize folder)'
     end
     within '.grouped-documents' do
       expect(page).to have_css 'article', count: 3


### PR DESCRIPTION
Based off of Gary's comment, waiting to style the badge more until we have more context/understanding

<img width="886" alt="Screen Shot 2019-09-05 at 4 10 36 PM" src="https://user-images.githubusercontent.com/1656824/64386953-cc1f8400-cff7-11e9-9b08-db8827442d23.png">
