### PR TITLE
Add repository link to collection grouping fixes #701

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -38,6 +38,9 @@
 }
 
 .al-grouped-results {
+  .al-grouped-repository {
+    font-size: $font-size-sm;
+  }
   .al-grouped-title-bar {
     background-color: $gray-200;
     padding: $result-item-body-padding;

--- a/app/views/catalog/_group.html.erb
+++ b/app/views/catalog/_group.html.erb
@@ -5,6 +5,10 @@
     <div class='al-grouped-title-bar'>
       <div class='row'>
         <div class='col-md-12'>
+          <% repository = Arclight::Repository.find_by(name: parent_document.repository) %>
+          <div class='al-grouped-repository'>
+            <%= link_to_if(repository.present?, repository.name, arclight_engine.repository_path(repository.slug)) %>
+          </div>
           <h3>
             <%= link_to_document parent_document, document_show_link_field(parent_document) %>
           </h3>

--- a/spec/features/grouped_results_spec.rb
+++ b/spec/features/grouped_results_spec.rb
@@ -26,4 +26,8 @@ RSpec.describe 'Grouped search results', type: :feature do
       expect(page).to have_css '.blacklight-icons', count: 3
     end
   end
+  it 'has link to repository' do
+    visit search_catalog_path q: 'alpha', group: 'true'
+    expect(page).to have_css '.al-grouped-repository a', text: /National Library of Medicine/
+  end
 end


### PR DESCRIPTION
Fixes #701
We don't yet have breadcrumb icons, so that will have to wait.
![Screen Shot 2019-09-05 at 5 11 53 PM](https://user-images.githubusercontent.com/1656824/64389537-59ff6d00-d000-11e9-9279-b0c4e86bd77e.png)
