### PR TITLE
Update template for `repositories.yml` and change Arclight::Repository

### DIFF
--- a/lib/arclight/repository.rb
+++ b/lib/arclight/repository.rb
@@ -58,7 +58,7 @@ module Arclight
     # @return [Hash<Slug,Repository>]
     def self.from_yaml(file)
       repos = {}
-      data = YAML.safe_load(File.read(file))
+      data  = YAML.safe_load(File.read(file))
       data.keys.each do |slug|
         repos[slug] = new(slug, data[slug])
       end
@@ -69,7 +69,7 @@ module Arclight
     #
     # @return [Array<Repository>]
     def self.all(yaml_file = nil)
-      yaml_file = ENV['REPOSITORY_FILE'] || 'config/repositories.yml' if yaml_file.nil?
+      yaml_file ||= (ENV['REPOSITORY_FILE'] || 'config/repositories.yml')
       from_yaml(yaml_file).values
     end
 

--- a/spec/controllers/arclight/repositories_controller_spec.rb
+++ b/spec/controllers/arclight/repositories_controller_spec.rb
@@ -31,8 +31,9 @@ RSpec.describe Arclight::RepositoriesController, type: :controller do
       expect(repo.slug).to eq 'nlm'
       collections = controller.instance_variable_get(:@collections)
       expect(collections.first).to be_an(SolrDocument)
-      expect(collections.first.unitid).to eq 'MS C 271'
+      expect(collections.find { |c| c.id == 'aoa271' }.unitid).to eq 'MS C 271'
     end
+
     it 'raises RecordNotFound if non-registered slug' do
       expect { get :show, params: { id: 'not-registered' } }.to raise_error(
         ActiveRecord::RecordNotFound


### PR DESCRIPTION
Works along with #674 (changes to repositories.yml file to use
new `request_type` section.

  * Makes template for `repositories.yml` reflect format changes
  for request_types as implemented in #674
  * Allows passing the name of a yaml file to Repository `#all` and
    `#find_by`
  * Adds spec to pull in `repositories.yml` template and do basic
    sanity checks.698_update_generator_template_for_new_request_type_format
  * Change `repositories_controll_spect#looks up the repository detail
    page` to grab an explicit collection instead of using `#first`