### PR TITLE
Use #respond_to? to see if a request_types key is configured.

### DIFF
--- a/lib/arclight/repository.rb
+++ b/lib/arclight/repository.rb
@@ -26,8 +26,17 @@ module Arclight
       [city, state_zip, country].compact.join(', ')
     end
 
+    # Why are we using self#respond_to? below?
+    #
+    # All the keys in the config hash from `repositories.yml` are
+    # on-the-fly added as attr_accessors up in #initialize. If the
+    # request_types key isn't present, the method won't be created.
+    #
+    # Since the original data is thrown away, this is the best way
+    # to see if that key was present.
     def request_config_present?
-      return false unless request_types
+      return false unless respond_to? :request_types
+      return false if request_types.nil? || request_types.empty?
       request_configs = request_types.map { |_k, v| v }
       request_configs[0]&.fetch('request_url').present? &&
         request_configs[0]&.fetch('request_mappings').present?

--- a/spec/controllers/arclight/repositories_controller_spec.rb
+++ b/spec/controllers/arclight/repositories_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Arclight::RepositoriesController, type: :controller do
       expect(repo.slug).to eq 'nlm'
       collections = controller.instance_variable_get(:@collections)
       expect(collections.first).to be_an(SolrDocument)
-      expect(collections.first.unitid).to eq 'MS C 271'
+      expect(collections.find { |c| c.id == 'aoa271' }.unitid).to eq 'MS C 271'
     end
     it 'raises RecordNotFound if non-registered slug' do
       expect { get :show, params: { id: 'not-registered' } }.to raise_error(


### PR DESCRIPTION
Use #respond_to? to see if a request_types key is configured.

Closes #692

Also changes repositories_control_spec to not assume order of documents
(via use of #first), instead using `collections.find { |c| c.id == 'aoa271' }` to get the specific one
being tested.