### PR TITLE
Create a more resilient repository lookup

### DIFF
--- a/app/views/catalog/_group.html.erb
+++ b/app/views/catalog/_group.html.erb
@@ -5,10 +5,12 @@
     <div class='al-grouped-title-bar'>
       <div class='row'>
         <div class='col-md-12'>
-          <% repository = Arclight::Repository.find_by(name: parent_document.repository) %>
-          <div class='al-grouped-repository'>
-            <%= link_to_if(repository.present?, repository.name, arclight_engine.repository_path(repository.slug)) %>
-          </div>
+          <% repository = Arclight::Repository.find_by(name: parent_document.repository || g.docs.first.repository) %>
+          <% if repository.present? %>
+            <div class='al-grouped-repository'>
+              <%= link_to(repository.name, arclight_engine.repository_path(repository.slug)) %>
+            </div>
+          <% end %>
           <h3>
             <%= show_presenter(parent_document).heading %>
           </h3>


### PR DESCRIPTION
This partially resolves an issue with the arclight-demo site. It seems that some documents are not indexing correctly (#747 ) and this is causing errors in the UI.