### PR TITLE
Use select and map to always expect an array

### DIFF
--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -296,7 +296,7 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
     context.output_hash['parent_ssm']&.drop(1)&.each do |id|
       accumulator.concat Array
         .wrap(context.clipboard[:parent].output_hash['components'])
-        .find { |c| c['ref_ssi'] == [id] }&.[]('normalized_title_ssm')
+        .select { |c| c['ref_ssi'] == [id] }.map { |c| c['normalized_title_ssm'] }.flatten
     end
   end
   to_field 'parent_unittitles_teim' do |_record, accumulator, context|


### PR DESCRIPTION
Previously causing an error:

```
    Exception: TypeError: no implicit conversion of nil into Array
    /Users/pjreed/dev/arclight/lib/arclight/traject/ead2_config.rb:297:in `concat'
```

Fixes #747 