### PR TITLE
Traject: index ancestor accessrestrict & userestrict using xpath axes…

### DIFF
--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -299,6 +299,7 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
         .select { |c| c['ref_ssi'] == [id] }.map { |c| c['normalized_title_ssm'] }.flatten
     end
   end
+
   to_field 'parent_unittitles_teim' do |_record, accumulator, context|
     accumulator.concat context.output_hash['parent_unittitles_ssm']
   end
@@ -360,40 +361,18 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
     accumulator.concat context.output_hash['level_ssm']&.map(&:capitalize)
   end
 
-  to_field 'parent_access_restrict_ssm', extract_xpath('./accessrestrict/p')
-
-  to_field 'parent_access_restrict_ssm' do |_record, accumulator, context|
-    next unless context.output_hash['accessrestrict_ssm'].nil?
-
-    context.output_hash['parent_ssm']&.each do |id|
-      accumulator.concat Array
-        .wrap(context.clipboard[:parent]&.output_hash&.[]('components'))
-        .select { |c| c['ref_ssi'] == [id] }.map { |c| c['accessrestrict_ssm'] }
-    end
+  # Get the <accessrestrict> from the closest ancestor that has one (includes top-level)
+  to_field 'parent_access_restrict_ssm' do |record, accumulator|
+    accumulator.concat Array
+      .wrap(record.xpath('(./ancestor::*/accessrestrict)[last()]/*[local-name()!="head"]')
+      .map(&:text))
   end
 
-  to_field 'parent_access_restrict_ssm' do |_record, accumulator, context|
-    next unless context.output_hash['parent_access_restrict_ssm'].nil?
-
-    accumulator.concat Array.wrap(context.clipboard[:parent]&.output_hash&.[]('accessrestrict_ssm'))
-  end
-
-  to_field 'parent_access_terms_ssm', extract_xpath('userestrict/p')
-
-  to_field 'parent_access_terms_ssm' do |_record, accumulator, context|
-    next unless context.output_hash['userestrict_ssm'].nil?
-
-    context.output_hash['parent_ssm']&.each do |id|
-      accumulator.concat Array
-        .wrap(context.clipboard[:parent]&.output_hash&.[]('components'))
-        .select { |c| c['ref_ssi'] == [id] }.map { |c| c['userestrict_ssm'] }
-    end
-  end
-
-  to_field 'parent_access_terms_ssm' do |_record, accumulator, context|
-    next unless context.output_hash['parent_access_terms_ssm'].nil?
-
-    accumulator << context.clipboard[:parent]&.output_hash&.[]('access_terms_ssm')&.first
+  # Get the <userestrict> from self OR the closest ancestor that has one (includes top-level)
+  to_field 'parent_access_terms_ssm' do |record, accumulator|
+    accumulator.concat Array
+      .wrap(record.xpath('(./ancestor-or-self::*/userestrict)[last()]/*[local-name()!="head"]')
+      .map(&:text))
   end
 
   to_field 'digital_objects_ssm', extract_xpath('./dao') do |record, accumulator|

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe 'Component Page', type: :feature do
     it 'has a restrictions and access' do
       click_link 'Access'
       expect(page).to have_css 'dt', text: 'PARENT RESTRICTIONS:'
-      expect(page).to have_css 'dd', text: 'No restrictions on access.'
+      expect(page).to have_css 'dd', text: /^RESTRICTED: Access to these folders requires prior written approval./
       expect(page).to have_css 'dt', text: 'TERMS OF ACCESS:'
       expect(page).to have_css 'dd', text: /^Copyright was transferred to the public domain./
     end

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -303,50 +303,92 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'selects the components' do
-      expect(result['components'].length).to eq 37
+      expect(result['components'].length).to eq 38
     end
 
-    context 'when nested component' do
-      let(:component_with_access_restrict) { result['components'].find { |c| c['ref_ssi'] == ['aspace_dba76dab6f750f31aa5fc73e5402e71d'] } }
-      let(:component_where_parent_has_access_restrict) { result['components'].find { |c| c['ref_ssi'] == ['aspace_72f14d6c32e142baa3eeafdb6e4d69be'] } }
-      let(:component_with_access_terms) { result['components'].find { |c| c['ref_ssi'] == ['aspace_72f14d6c32e142baa3eeafdb6e4d69be'] } }
-      let(:component_where_parent_has_access_terms) { result['components'].find { |c| c['ref_ssi'] == ['aspace_dba76dab6f750f31aa5fc73e5402e71d'] } }
-      let(:component_with_many_parents) { result['components'].find { |c| c['ref_ssi'] == ['aspace_f934f1add34289f28bd0feb478e68275'] } }
+    context 'nested component' do
+      describe 'accessrestrict' do
+        let(:component_with_own_accessrestrict) do
+          result['components'].find { |c| c['ref_ssi'] == ['aspace_dba76dab6f750f31aa5fc73e5402e71d'] }
+        end
+        let(:component_inheriting_accessrestrict_from_parent) do
+          result['components'].find { |c| c['ref_ssi'] == ['aspace_843e8f9f22bac69872d0802d6fffbb04'] }
+        end
+        let(:component_inheriting_accessrestrict_from_grandparent) do
+          result['components'].find { |c| c['ref_ssi'] == ['aspace_4b4fa033c630a45d41fcd608cf0d184d'] }
+        end
+        let(:component_inheriting_accessrestrict_from_collection) do
+          result['components'].find { |c| c['ref_ssi'] == ['aspace_72f14d6c32e142baa3eeafdb6e4d69be'] }
+        end
 
-      it 'has access restrict' do
-        expect(component_with_access_restrict['parent_access_restrict_ssm']).to eq ['Restricted until 2018.']
+        it 'has own accessrestrict' do
+          expect(component_with_own_accessrestrict['accessrestrict_ssm'])
+            .to eq ['Restricted until 2018.']
+          expect(component_with_own_accessrestrict['parent_access_restrict_ssm'])
+            .to eq ['No restrictions on access.']
+        end
+
+        it 'gets accessrestrict from parent component' do
+          expect(component_inheriting_accessrestrict_from_parent['accessrestrict_ssm'])
+            .to be_nil
+          expect(component_inheriting_accessrestrict_from_parent['parent_access_restrict_ssm'])
+            .to include(a_string_matching(/RESTRICTED: Access to these folders requires prior written approval./))
+        end
+
+        it 'gets accessrestrict from grandparent component' do
+          expect(component_inheriting_accessrestrict_from_grandparent['accessrestrict_ssm']).to be_nil
+          expect(component_inheriting_accessrestrict_from_grandparent['parent_access_restrict_ssm'])
+            .to include(a_string_matching(/RESTRICTED: Access to these folders requires prior written approval./))
+        end
+        it 'gets accessrestrict from collection' do
+          expect(component_inheriting_accessrestrict_from_collection['accessrestrict_ssm']).to be_nil
+          expect(component_inheriting_accessrestrict_from_collection['parent_access_restrict_ssm'])
+            .to eq ['No restrictions on access.']
+        end
       end
+      describe 'userestrict' do
+        let(:component_with_own_userestrict) do
+          result['components'].find { |c| c['ref_ssi'] == ['aspace_72f14d6c32e142baa3eeafdb6e4d69be'] }
+        end
 
-      it 'gets access restrict from parent if component does not have terms' do
-        expect(component_where_parent_has_access_restrict['parent_ssm']).to eq %w[aoa271]
-        expect(component_where_parent_has_access_restrict['parent_access_restrict_ssm']).to eq ['No restrictions on access.']
-      end
+        let(:component_inheriting_userestrict_from_collection) do
+          result['components'].find { |c| c['ref_ssi'] == ['aspace_dba76dab6f750f31aa5fc73e5402e71d'] }
+        end
 
-      it 'has access terms' do
-        expect(component_with_access_terms['parent_access_terms_ssm']).to eq ['Original photographs must be handled using gloves.']
-      end
+        it 'has own userestrict' do
+          expect(component_with_own_userestrict['userestrict_ssm'])
+            .to eq ['Original photographs must be handled using gloves.']
+          expect(component_with_own_userestrict['parent_access_terms_ssm'])
+            .to eq ['Original photographs must be handled using gloves.']
+        end
 
-      it 'gets access terms from parent if component does not have terms' do
-        expect(component_where_parent_has_access_terms['parent_ssm']).to eq %w[aoa271]
-        expect(component_where_parent_has_access_terms['parent_access_terms_ssm'])
-          .to eq ["Copyright was transferred to the public domain. Contact the Reference Staff for details\n        regarding rights."]
-      end
-
-      it 'parent_unittitles should be displayable and searchable' do
-        component = result['components'].find { |c| c['id'] == ['aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671'] }
-        %w[parent_unittitles_ssm parent_unittitles_teim].each do |field|
-          expect(component[field]).to contain_exactly(
-            'Alpha Omega Alpha Archives, 1894-1992'
-          )
+        it 'gets userestrict from collection' do
+          expect(component_inheriting_userestrict_from_collection['access_terms_ssm'])
+            .to be_nil
+          expect(component_inheriting_userestrict_from_collection['parent_access_terms_ssm'])
+            .to include(a_string_matching(/Copyright was transferred to the public domain./))
         end
       end
 
-      it 'parents are correctly ordered' do
-        expect(component_with_many_parents['parent_ssm']).to eq %w[
-          aoa271
-          aspace_563a320bb37d24a9e1e6f7bf95b52671
-          aspace_238a0567431f36f49acea49ef576d408
-        ]
+      describe 'parents & titles' do
+        let(:component_with_many_parents) { result['components'].find { |c| c['ref_ssi'] == ['aspace_f934f1add34289f28bd0feb478e68275'] } }
+
+        it 'parent_unittitles should be displayable and searchable' do
+          component = result['components'].find { |c| c['id'] == ['aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671'] }
+          %w[parent_unittitles_ssm parent_unittitles_teim].each do |field|
+            expect(component[field]).to contain_exactly(
+              'Alpha Omega Alpha Archives, 1894-1992'
+            )
+          end
+        end
+
+        it 'parents are correctly ordered' do
+          expect(component_with_many_parents['parent_ssm']).to eq %w[
+            aoa271
+            aspace_563a320bb37d24a9e1e6f7bf95b52671
+            aspace_238a0567431f36f49acea49ef576d408
+          ]
+        end
       end
     end
   end

--- a/spec/fixtures/ead/nlm/alphaomegaalpha.xml
+++ b/spec/fixtures/ead/nlm/alphaomegaalpha.xml
@@ -253,6 +253,12 @@
             operation of Alpha Omega Alpha. Not all records are necessarily official documents
             but provide important background context.</p>
         </scopecontent>
+        <accessrestrict id="aspace_7bbec2cdc1e6e0cb7b2ff1acb7c9e364">
+          <head>Conditions Governing Access</head>
+          <p>RESTRICTED: Access to these folders requires prior written approval. To request access,
+            please contact Research Services prior to your visit.</p>
+          <p>All or portions of this collection may be housed off-site. The library may require up to 48-hours to retrieve these materials for research use.</p>
+        </accessrestrict>
         <c id="aspace_843e8f9f22bac69872d0802d6fffbb04" level="file">
           <did>
             <origination>
@@ -539,6 +545,14 @@
           <controlaccess>
             <genreform source="aat">Records</genreform>
           </controlaccess>
+          <c id="aspace_4b4fa033c630a45d41fcd608cf0d184d" level="file">
+            <did>
+              <unittitle>Miscellaneous 1999</unittitle>
+              <container id="aspace_d55e41948bba30fc2b5a74ddda810294"
+                         label="Mixed Materials"
+                         type="box">1</container>
+            </did>
+          </c>
         </c>
         <c id="aspace_4365cd1ed8bd8fee1bac6077a4d81359" level="otherlevel">
           <did>


### PR DESCRIPTION
…. Bugfix for duplicated parent access restrictions on component show page. Closes #653 & fixes #752