### PR TITLE
712 extent label style

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -18,6 +18,14 @@
 
     .document-title-heading {
       font-size: $h5-font-size;
+      .al-document-extent {
+        background-color: $gray-200;
+        border: $result-item-border-styling;
+        font-size: $font-size-sm;
+        margin-bottom: 0.25rem;
+        padding: 2px $result-item-body-padding;
+        border-radius: 10px;
+      }
     }
 
     .breadcrumb-links,

--- a/app/views/catalog/_arclight_index_default.html.erb
+++ b/app/views/catalog/_arclight_index_default.html.erb
@@ -25,12 +25,6 @@
     </div>
 
     <div class="row">
-      <%= content_tag('div', class: 'al-document-extent col') do %>
-        <%= document.extent %>
-      <% end if document.extent %>
-    </div>
-
-    <div class="row">
       <%= content_tag('div', class: 'al-document-abstract-or-scope col') do %>
         <%= content_tag('div', 'data-arclight-truncate' => true) do %>
           <%= document.abstract_or_scope %>

--- a/app/views/catalog/_arclight_search_index_header.html.erb
+++ b/app/views/catalog/_arclight_search_index_header.html.erb
@@ -2,5 +2,8 @@
 <div class="documentHeader col" data-document-id="<%= document.id %>">
   <h3 class="index_title document-title-heading">
     <%= link_to_document document, document_show_link_field(document), counter: counter %>
+    <%= content_tag('span', class: 'al-document-extent badge badge-light') do %>
+        <%= document.extent %>
+      <% end if document.extent %>
   </h3>
 </div>

--- a/app/views/catalog/_arclight_search_index_header.html.erb
+++ b/app/views/catalog/_arclight_search_index_header.html.erb
@@ -3,7 +3,7 @@
   <h3 class="index_title document-title-heading">
     <%= link_to_document document, document_show_link_field(document), counter: counter %>
     <%= content_tag('span', class: 'al-document-extent badge badge-light') do %>
-        <%= document.extent %>
-      <% end if document.extent %>
+      <%= document.extent %>
+    <% end if document.extent %>
   </h3>
 </div>

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Search results', type: :feature do
         expect(page).to have_css('h3 a', text: 'Alpha Omega Alpha Archives, 1894-1992')
         expect(page).to have_css('.blacklight-icons svg')
         expect(page).to have_css('.al-document-creator', text: 'Alpha Omega Alpha')
-        expect(page).to have_css('.al-document-extent', text: /^15\.0 linear feet/)
+        expect(page).to have_css('.documentHeader .al-document-extent', text: /^15\.0 linear feet/)
         expect(page).to have_css(
           '.al-document-abstract-or-scope',
           text: /^Alpha Omega Alpha Honor Medical Society was founded in 1902/


### PR DESCRIPTION
closes #712 
### Issue
- Move the extent value, if it exists for the result item, to come directly after the result item label, on the same line
- Style the extent label as a Bootstrap badge, using the styling we currently use for the result item header section (see CSS class al-document-title-bar)

### Solution
- Moved the extent value into the arclight_search_index_header partial
- Updated the styles to match .al-document-title-bar

### Demo
On same line as header:
<a href="https://cl.ly/add15e22059e" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/1q1C1X3g2f1Y3Q3Q213b/Screen%20Shot%202019-09-10%20at%2012.55.22%20PM.png" style="display: block;height: auto;width: 100%;"/></a>

On new line when longer:
<a href="https://cl.ly/e0adc1bccc0d" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/2U3j1z2Z3J3W391B1s1n/Screen%20Shot%202019-09-10%20at%2012.55.05%20PM.png" style="display: block;height: auto;width: 100%;"/></a>