### PR TITLE
move hit highlights under title for search results

### DIFF
--- a/app/assets/stylesheets/arclight/modules/highlights.scss
+++ b/app/assets/stylesheets/arclight/modules/highlights.scss
@@ -3,6 +3,7 @@
   padding-left: 10px;
   font-size: $font-size-sm;
   font-style: italic;
+  margin-bottom: $spacer;
   em {
     background-color: yellow;
     font-weight: bold;

--- a/app/views/catalog/_arclight_index_default.html.erb
+++ b/app/views/catalog/_arclight_index_default.html.erb
@@ -18,6 +18,13 @@
         <%= render_index_doc_actions document, wrapping_class: "col-sm-3 col-md-5 col-lg-4 text-right" %>
       </div>
     </div>
+
+    <div class="row">
+      <%= content_tag('div', class: 'al-document-highlight col') do %>
+        <%= document.highlights.join('<br/>').html_safe %>
+      <% end if document.highlights %>
+    </div>
+
     <div class="row">
       <%= content_tag('div', class: 'al-document-creator col') do %>
         <%= document.creator %>
@@ -30,12 +37,6 @@
           <%= document.abstract_or_scope %>
         <% end %>
       <% end if document.abstract_or_scope %>
-    </div>
-
-    <div class="row">
-      <%= content_tag('div', class: 'al-document-highlight col') do %>
-        <%= document.highlights.join('<br/>').html_safe %>
-      <% end if document.highlights %>
     </div>
 
     <%= render partial: 'index_breadcrumb_default', locals: { document: document } %>


### PR DESCRIPTION
Closes #714 Ref: #669 

### Issue:
Hit highlighting - If there is a snippet to show, it goes directly beneath the result item label

### Solution:
Moved document.highlights to first item beneath the title row on arclight_index_default partial

### Demo:
<a href="https://cl.ly/1f8017e9a465" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/0i3Q0f1g0k2Q3M423O2y/Screen%20Shot%202019-09-11%20at%2011.12.14%20AM.png" style="display: block;height: auto;width: 100%;"/></a>