### PR TITLE
moved container label into header row on search results page

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -28,6 +28,10 @@
       }
     }
 
+    .al-document-container.text-muted {
+      color: #ADB5BD !important;
+    }
+
     .breadcrumb-links,
     .al-document-creator,
     .al-document-extent,

--- a/app/views/catalog/_arclight_index_default.html.erb
+++ b/app/views/catalog/_arclight_index_default.html.erb
@@ -7,15 +7,16 @@
     <div class="row">
       <%= render partial: 'arclight_search_index_header', locals: { document: document, counter: counter }  %>
       <div class="col-auto">
+        <%= content_tag('span', class: 'al-document-container col-auto text-muted') do %>
+          <%= document.containers.join(', ') %>
+        <% end if document.containers %>
         <% if document.online_content? %>
           <span class='badge badge-success'>
             <%= t(:'arclight.views.online_content_indicator') %>
           </span>
         <% end %>
-        <%= content_tag('div', class: 'al-document-container col') do %>
-          <%= document.containers.join(', ') %>
-        <% end if document.containers %>
-        <%= render_index_doc_actions document, wrapping_class: "col-sm-3 col-md-5 col-lg-4 text-right" %>
+        
+        <%= render_index_doc_actions document, wrapping_class: "text-right" %>
       </div>
     </div>
 


### PR DESCRIPTION
closes #711 ref #669 

### Issue
On the search results page:
Container label - If the result item has a container label:
- Display the label value on the same line as the result item title
- Use a muted text color for the container label: #ADB5BD

### Solution
- moved container label into the header row 
- changed text color to #ADB5BD

### Notes
Please ignore styling/placement of bookmark/actions. This will be fixed on a separate ticket.

### Demo
<a href="https://cl.ly/3e032f755622" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/2q2w1z1x1n2Z3A0u2g0s/Screen%20Shot%202019-09-11%20at%201.09.37%20PM.png" style="display: block;height: auto;width: 100%;"/></a>
