### PR TITLE
Allow for download URLs to be configured in a programatic way

### DIFF
--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -121,17 +121,6 @@ module ArclightHelper
     search.merge(f: { collection_sim: [collection_name] })
   end
 
-  ##
-  # Looks for `document.unitid` in the downloads configuration
-  # @param [SolrDocument] `document`
-  # @param [Hash] `config` metadata for downloadable files
-  # @return [Hash] with `:href` and `:size` keys
-  def collection_downloads(document, config = load_download_config)
-    config = config[document.unitid] if config.present?
-    return {} if config.blank?
-    parse_collection_downloads(config)
-  end
-
   def on_repositories_show?
     controller_name == 'repositories' && action_name == 'show'
   end
@@ -163,33 +152,6 @@ module ArclightHelper
 
   def hierarchy_component_context?
     params[:hierarchy_context] == 'component'
-  end
-
-  # @return [Hash] loaded from config/downloads.yml, or `{}` if missing file
-  def load_download_config(filename = Rails.root.join('config', 'downloads.yml'))
-    YAML.safe_load(File.read(filename))
-  rescue Errno::ENOENT
-    {}
-  end
-
-  # @return [Hash] the downloads for the given configuration using Hash symbols
-  # @example `{ pdf: { href: 'http://...', size: '123 KB' } }`
-  def parse_collection_downloads(config, results = {})
-    %w[pdf ead].each do |type|
-      next if config[type].blank?
-      results[type.to_sym] = {
-        href: config[type]['href'],
-        size: display_size(config[type]['size'])
-      }
-    end
-    results
-  end
-
-  # Show a human readable size, or if it's already a string, show that
-  # @return [String] human readable siz
-  def display_size(size)
-    size = number_to_human_size(size.to_i + 1) if size.is_a?(Numeric) || size =~ /^[0-9]+$/ # assumes bytes
-    size.to_s
   end
 
   # determine which icon to show in search results header

--- a/app/models/arclight/collection_downloads.rb
+++ b/app/models/arclight/collection_downloads.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module Arclight
+  ##
+  # Model the Download links that can be configured (via YAML) for a collection
+  class CollectionDownloads
+    attr_reader :document
+
+    def initialize(document)
+      @document = document
+    end
+
+    def id
+      document.unitid
+    end
+
+    def files
+      data = self.class.config[id] || self.class.config['default']
+      return [] if data['disabled']
+
+      @files ||= data.map do |file_type, file_data|
+        Arclight::CollectionDownloads::File.new(type: file_type, data: file_data, document: document)
+      end.compact
+    end
+
+    def to_partial_path
+      'catalog/collection_downloads'
+    end
+
+    class << self
+      def config
+        @config ||= begin
+                      YAML.safe_load(::File.read(config_filename))
+                    rescue Errno::ENOENT
+                      {}
+                    end
+      end
+
+      def config_filename
+        Rails.root.join('config', 'downloads.yml')
+      end
+    end
+
+    ##
+    # Model a single file configured in downloads.yml
+    class File
+      attr_reader :type, :document
+      def initialize(type:, data:, document:)
+        @type = type
+        @data = data
+        @document = document
+      end
+
+      def href
+        return data['href'] if data['href']
+
+        format_template
+      end
+
+      def size
+        return data['size'] if data['size']
+
+        document.send(data['size_accessor'].to_sym) if data['size_accessor']
+      end
+
+      private
+
+      attr_reader :data
+
+      def format_template
+        return unless template
+
+        template % template_interpolations
+      end
+
+      def template
+        data['template']
+      end
+
+      def template_interpolations
+        escaped_document_interpolations.merge(custom_interpolations).symbolize_keys
+      end
+
+      def custom_interpolations
+        { 'repository_id' => document.repository_config&.slug }
+      end
+
+      def template_variables
+        data['template'].scan(/%{(\w+)}/).flatten.uniq
+      end
+
+      def escaped_document_interpolations
+        non_custom_template_variables.map do |method_name|
+          [method_name, escape_non_url_doc_value(document.send(method_name))]
+        end.to_h
+      end
+
+      def escape_non_url_doc_value(value)
+        value = Array.wrap(value).first || '' # Handle single values/arrays and nil
+        return value if value.start_with?(/https?:/)
+
+        CGI.escape(value)
+      end
+
+      def non_custom_template_variables
+        template_variables.reject do |v|
+          custom_interpolations.keys.include?(v)
+        end
+      end
+    end
+  end
+end

--- a/app/views/catalog/_collection_downloads.html.erb
+++ b/app/views/catalog/_collection_downloads.html.erb
@@ -1,15 +1,16 @@
-<% if downloads.present? && (downloads[:pdf].present? || downloads[:ead].present?) %>
-<div class='dropdown al-collection-actions-menu'>
-  <button class='btn btn-secondary btn-sm dropdown-toggle' type="button" id="download-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    <%= t 'arclight.views.show.download.default' %>
-  </button>
-  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="download-dropdown">
-    <% if downloads[:pdf].present? %>
-      <a class="dropdown-item" href="<%= downloads[:pdf][:href] %>"><%= t('arclight.views.show.download.pdf', size: downloads[:pdf][:size]) %></a>
-    <% end %>
-    <% if downloads[:ead].present? %>
-      <a class="dropdown-item" href="<%= downloads[:ead][:href] %>"><%= t('arclight.views.show.download.ead', size: downloads[:ead][:size]) %></a>
-    <% end  %>
+<% if collection_downloads.files.present? %>
+  <div class='dropdown al-collection-actions-menu'>
+    <button class='btn btn-secondary btn-sm dropdown-toggle' type="button" id="download-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <%= t 'arclight.views.show.download.default' %>
+    </button>
+    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="download-dropdown">
+      <% collection_downloads.files.each do |file| %>
+        <% if file.size %>
+          <%= link_to(t("arclight.views.show.download_with_size.#{file.type}", size: file.size), file.href, class: 'dropdown-item') %>
+        <% else %>
+          <%= link_to(t("arclight.views.show.download.#{file.type}"), file.href, class: 'dropdown-item') %>
+        <% end %>
+      <% end %>
+    </div>
   </div>
-</div>
 <% end %>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -49,6 +49,10 @@ en:
         collection_id: 'Collection ID: %{id}'
         download:
           default: Download
+          ead: Collection EAD
+          pdf: Collection PDF
+        download_with_size:
+          default: Download (%{size})
           ead: Collection EAD (%{size})
           pdf: Collection PDF (%{size})
         no_contents: No content inventory

--- a/lib/generators/arclight/templates/config/downloads.yml
+++ b/lib/generators/arclight/templates/config/downloads.yml
@@ -3,6 +3,11 @@
 #                 provide the PDF and/or EAD (.xml) links. The
 #                 size value should be a String (shown as-is) or
 #                 the number of bytes in the download.
+#               - Pass a template key to use a formatted string
+#                 which interpolates document accessors into the
+#                 url using the %{accessor} syntax.
+#               - Pass a size_accessor key to pull the size of
+#                 the file from an accessor in the solr document
 #
 sample_unitid:
   pdf:
@@ -11,3 +16,10 @@ sample_unitid:
   ead:
     href: 'http://example.com/sample.xml'
     size: 123456
+    # size_accessor: 'level'
+default:
+  disabled: true
+  pdf:
+    template: 'http://example.com/%{unitid}.pdf'
+  ead:
+    template: 'http://example.com/%{unitid}.xml'

--- a/spec/fixtures/config/downloads.yml
+++ b/spec/fixtures/config/downloads.yml
@@ -12,3 +12,10 @@ MS C 271:
   ead:
     href: 'http://example.com/MS+C+271.xml'
     size: 123456
+default:
+  # disabled: true
+  pdf:
+    template: 'http://example.com/%{unitid}.pdf'
+    # size_accessor: finding_aid_size
+  ead:
+    template: 'http://example.com/%{unitid}.xml'

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -383,29 +383,4 @@ RSpec.describe ArclightHelper, type: :helper do
       expect(helper.hierarchy_component_context?).to be_falsey
     end
   end
-  context '#collection_downloads' do
-    let(:document) { SolrDocument.new('unitid_ssm' => 'MS C 271') }
-    let(:config_file) { File.join('spec', 'fixtures', 'config', 'downloads.yml') }
-    let(:config_data) { YAML.safe_load(File.read(config_file)) }
-
-    it 'no download metadata' do
-      allow(File).to receive(:read).and_raise(Errno::ENOENT)
-      expect(helper.collection_downloads(document)).to eq({})
-    end
-    it 'handles no downloads' do
-      expect(helper.collection_downloads(document, {})).to eq({})
-    end
-    it 'handles PDF downloads' do
-      expect(helper.collection_downloads(document, config_data)[:pdf]).to include(
-        href: 'http://example.com/MS+C+271.pdf',
-        size: '1.23MB'
-      )
-    end
-    it 'handles EAD downloads' do
-      expect(helper.collection_downloads(document, config_data)[:ead]).to include(
-        href: 'http://example.com/MS+C+271.xml',
-        size: '121 KB'
-      )
-    end
-  end
 end

--- a/spec/models/arclight/collection_downloads_spec.rb
+++ b/spec/models/arclight/collection_downloads_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Arclight::CollectionDownloads do
+  subject(:downloads) { described_class.new(document) }
+
+  let(:document) do
+    SolrDocument.new(
+      id: 'abc123',
+      unitid_ssm: ['sample_unitid'],
+      userestrict_ssm: ['The Terms of the Collection'],
+      extent_ssm: ['42GB'], # This field does not typically hold file size, but for test purposes..
+      level_ssm: ['collection'],
+      ref_ssm: ['http://example.com/finding-aid.pdf'] # This field does not typically hold URLs, but for test purposes..
+    )
+  end
+
+  describe '#files' do
+    it 'returns an array of Arclight::CollectionDownloads::File objects' do
+      expect(downloads.files.length).to eq 2
+      expect(downloads.files).to be_all(Arclight::CollectionDownloads::File)
+    end
+  end
+
+  context 'when disabled' do
+    let(:document) do
+      SolrDocument.new(
+        id: 'abc123',
+        unitid_ssm: ['not_a_real_unitid']
+      )
+    end
+
+    it 'return an empty array of files' do
+      expect(downloads.files).to eq []
+    end
+  end
+
+  describe 'Arclight::CollectionDownloads::File' do
+    let(:file_params) { {} }
+    let(:file) do
+      described_class::File.new(
+        type: 'pdf',
+        data: { 'href' => 'http://example.com/sample.pdf', 'size' => '1.23MB' },
+        document: document,
+        **file_params
+      )
+    end
+
+    it 'has accessors for type, size, and href' do
+      expect(file.type).to eq 'pdf'
+      expect(file.size).to eq '1.23MB'
+      expect(file.href).to eq 'http://example.com/sample.pdf'
+    end
+
+    context 'when a size_accessor is provided for the size' do
+      let(:file_params) do
+        {
+          data: {
+            'size_accessor' => 'extent',
+            'href' => 'http://example.com/finding-aid.pdf'
+          }
+        }
+      end
+
+      it 'gets the value of the accessor from the provided document for the size value' do
+        expect(file.size).to eq '42GB'
+      end
+    end
+
+    context 'when a template is provided for the href' do
+      before do
+        allow(document).to receive(:repository_config).and_return(
+          instance_double('Arclight::Repository', slug: 'the-repo-id')
+        )
+      end
+
+      let(:file_params) do
+        {
+          data: {
+            'size' => '1.23MB',
+            'template' => 'http://example.com/%{repository_id}/%{level}/%{terms}/download.pdf'
+          }
+        }
+      end
+
+      it 'interpolates custom mappings' do
+        expect(file.href).to include '/the-repo-id/'
+      end
+
+      it 'interpolates requested accessors from the solr document' do
+        expect(file.href).to include '/collection/'
+      end
+
+      it 'escapes values from the document for usage in a URL' do
+        expect(file.href).to include '/The+Terms+of+the+Collection/'
+      end
+
+      context 'when the document value returns a URL' do
+        let(:file_params) do
+          {
+            data: {
+              'size' => '1.23MB',
+              'template' => '%{reference}'
+            }
+          }
+        end
+
+        it 'is not escaped' do
+          expect(file.href).to eq 'http://example.com/finding-aid.pdf'
+        end
+      end
+    end
+  end
+end

--- a/spec/views/_collection_downloads.html.erb_spec.rb
+++ b/spec/views/_collection_downloads.html.erb_spec.rb
@@ -3,47 +3,41 @@
 require 'spec_helper'
 
 RSpec.describe 'catalog/_collection_downloads', type: :view do
+  let(:document) { SolrDocument.new(id: 'abc123') }
+
   context 'when on collection show page' do
-    let(:pdf_data) { { href: '/documents/abc123.pdf', size: 123 } }
-    let(:ead_data) { { href: '/documents/abc123.xml', size: 456 } }
-    let(:downloads) { { pdf: pdf_data, ead: ead_data } }
+    let(:pdf_data) { { 'href' => 'http://example.com/documents/abc123.pdf', 'size' => 123 } }
+    let(:ead_data) { { 'href' => 'http://example.com/documents/abc123.xml', 'size' => 456 } }
+    let(:downloads) do
+      instance_double(
+        'Arclight::CollectionDownloads',
+        files: [
+          Arclight::CollectionDownloads::File.new(type: 'pdf', data: pdf_data, document: document),
+          Arclight::CollectionDownloads::File.new(type: 'ead', data: ead_data, document: document)
+        ]
+      )
+    end
 
     before do
-      allow(view).to receive(:downloads).and_return(downloads)
+      allow(view).to receive(:collection_downloads).and_return(downloads)
       render
     end
 
-    context 'with both downloads' do
+    context 'with downloads' do
       it 'shows the menu items' do
         expect(rendered).to have_css('.dropdown')
         expect(rendered).to have_css('button', text: 'Download')
         expect(rendered).to have_css('a', text: 'Collection PDF (123)')
-        expect(rendered).to have_css('a[@href="/documents/abc123.pdf"]')
+        expect(rendered).to have_css('a[@href="http://example.com/documents/abc123.pdf"]')
         expect(rendered).to have_css('a', text: 'Collection EAD (456)')
-        expect(rendered).to have_css('a[@href="/documents/abc123.xml"]')
+        expect(rendered).to have_css('a[@href="http://example.com/documents/abc123.xml"]')
       end
     end
-    context 'with PDF download' do
-      let(:ead_data) { {} }
 
-      it 'shows the menu item' do
-        expect(rendered).to have_css('.dropdown')
-        expect(rendered).to have_css('a', text: 'Collection PDF (123)')
-        expect(rendered).not_to have_css('a', text: 'Collection EAD (456)')
-      end
-    end
-    context 'with EAD download' do
-      let(:pdf_data) { {} }
-
-      it 'shows the menu item' do
-        expect(rendered).to have_css('.dropdown')
-        expect(rendered).not_to have_css('a', text: 'Collection PDF (123)')
-        expect(rendered).to have_css('a', text: 'Collection EAD (456)')
-      end
-    end
     context 'with no downloads' do
-      let(:pdf_data) { {} }
-      let(:ead_data) { {} }
+      let(:downloads) do
+        instance_double('Arclight::CollectionDownloads', files: [])
+      end
 
       it 'omits the dropdown' do
         expect(rendered).not_to have_css '.dropdown'


### PR DESCRIPTION
Closes #683 

The download links (which are not currently rendered anywhere) can now be rendered by executing this line:

```ruby
render Arclight::CollectionDownloads.new(document)
```

If/when this is merged I'll add a wiki page about configuring download links with more info.
