### PR TITLE
Bugfix: index digital objects even if component <dao> is not in the <…

### DIFF
--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -379,13 +379,13 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
       .map(&:text))
   end
 
-  to_field 'digital_objects_ssm', extract_xpath('./dao') do |record, accumulator|
-    accumulator.concat(record.xpath('.//dao').map do |dao|
+  to_field 'digital_objects_ssm', extract_xpath('.//dao', to_text: false) do |_record, accumulator|
+    accumulator.map! do |dao|
       label = dao.attributes['title']&.value ||
-        dao.xpath('daodesc/p')&.text
+              dao.xpath('daodesc/p')&.text
       href = (dao.attributes['href'] || dao.attributes['xlink:href'])&.value
       Arclight::DigitalObject.new(label: label, href: href).to_json
-    end.to_a)
+    end
   end
 
   to_field 'date_range_sim', extract_xpath('./did/unitdate/@normal', to_text: false) do |_record, accumulator|
@@ -432,6 +432,7 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
       accumulator << [node.attribute('type'), node.text].join(' ').strip
     end
   end
+
   SEARCHABLE_NOTES_FIELDS.map do |selector|
     to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']")
     to_field "#{selector}_heading_ssm", extract_xpath("./#{selector}/head")

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -567,6 +567,45 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
   end
 
+  describe 'digital objects' do
+    let(:fixture_path) do
+      Arclight::Engine.root.join('spec', 'fixtures', 'ead', 'nlm', 'alphaomegaalpha.xml')
+    end
+
+    context 'when <dao> is direct child of <c0x> component' do
+      let(:component) { result['components'].find { |c| c['id'] == ['aoa271aspace_e6db65d47e891d61d69c2798c68a8f02'] } }
+
+      it 'gets the digital object' do
+        expect(component['digital_objects_ssm']).to eq(
+          [
+            JSON.generate(
+              label: 'Example diary',
+              href: 'https://idn.duke.edu/ark:/87924/r3d39z'
+            )
+          ]
+        )
+      end
+    end
+    context 'when <dao> is child of the <did> in a <c0x> component' do
+      let(:component) { result['components'].find { |c| c['id'] == ['aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'] } }
+
+      it 'gets the digital objects' do
+        expect(component['digital_objects_ssm']).to eq(
+          [
+            JSON.generate(
+              label: 'Folder of digitized stuff',
+              href: 'https://collections.nlm.nih.gov/bookviewer?PID=nlm:nlmuid-100957835-bk'
+            ),
+            JSON.generate(
+              label: 'Letter from Christian B. Anfinsen (to the owner of the reel of yellow nylon rope [behind the bar])',
+              href: 'https://profiles.nlm.nih.gov/ps/access/KKBBFL.pdf'
+            )
+          ]
+        )
+      end
+    end
+  end
+
   describe 'for EAD Documents without XML namespaces' do
     let(:fixture_without_namespaces) do
       doc = Nokogiri::XML.parse(fixture_file.to_s)

--- a/spec/fixtures/ead/nlm/alphaomegaalpha.xml
+++ b/spec/fixtures/ead/nlm/alphaomegaalpha.xml
@@ -313,6 +313,7 @@
             <container id="aspace_4b9fef8e13c68338317e50cc7d5b4c14"
               parent="aspace_cb0ce54fec31ceb66bcb46ff50143d54" type="folder">2</container>
           </did>
+          <dao xlink:actuate="onRequest" xlink:href="https://idn.duke.edu/ark:/87924/r3d39z" xlink:role="image-service" xlink:show="new" xlink:title="Example diary" xpointer="ark:/87924/r3d39z"/>
         </c>
         <c id="aspace_4e7f6dfada4b6e243f6f29f92d765073" level="otherlevel">
           <did>


### PR DESCRIPTION
…did>. Fixes #771.