### PR TITLE
Remove page params for grouping/ungrouping

### DIFF
--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -110,11 +110,11 @@ module ArclightHelper
   end
 
   def search_with_group
-    search_state.params_for_search.merge('group' => 'true')
+    search_state.params_for_search.merge('group' => 'true').reject { |k| k == 'page' }
   end
 
   def search_without_group
-    search_state.params_for_search.reject { |k| k == 'group' }
+    search_state.params_for_search.reject { |k| %w[group page].include? k }
   end
 
   def search_within_collection(collection_name, search)

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -114,7 +114,7 @@ module ArclightHelper
   end
 
   def search_without_group
-    search_state.params_for_search.reject { |k| %w[group page].include? k }
+    search_state.params_for_search.except('group', 'page')
   end
 
   def search_within_collection(collection_name, search)

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -110,7 +110,7 @@ module ArclightHelper
   end
 
   def search_with_group
-    search_state.params_for_search.merge('group' => 'true').reject { |k| k == 'page' }
+    search_state.params_for_search.merge('group' => 'true').except('page')
   end
 
   def search_without_group

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ArclightHelper, type: :helper do
     let(:search_state) do
       instance_double(
         'Blacklight::SearchState',
-        params_for_search: { 'q' => 'hello' }
+        params_for_search: { 'q' => 'hello', 'page' => '2' }
       )
     end
 
@@ -89,7 +89,7 @@ RSpec.describe ArclightHelper, type: :helper do
     let(:search_state) do
       instance_double(
         'Blacklight::SearchState',
-        params_for_search: { 'q' => 'hello', 'group' => 'true' }
+        params_for_search: { 'q' => 'hello', 'group' => 'true', 'page' => '2' }
       )
     end
 


### PR DESCRIPTION
I noticed that grouping/ungrouping can get into a strange state if page params are persisted. This PR removes them.