### PR TITLE
Update the group toggle to be a button group…

### DIFF
--- a/app/views/catalog/_group_toggle.html.erb
+++ b/app/views/catalog/_group_toggle.html.erb
@@ -1,4 +1,10 @@
-<%= link_to t('arclight.views.index.group_by_collection'),
-            search_catalog_path(grouped? ? search_without_group : search_with_group),
-            class: "btn btn-outline-secondary #{grouped? ? 'active' : ''}"
-%>
+<div class="result-type-group mb-2 mb-lg-0 btn-group float-lg-left float-md-right" role="group" aria-label="<%= t('arclight.views.index.group_results') %>">
+  <%= link_to t('arclight.views.index.all_results'),
+              search_catalog_path(search_without_group),
+              class: "btn btn-outline-secondary #{'active' unless grouped?}"
+  %>
+  <%= link_to t('arclight.views.index.group_by_collection'),
+              search_catalog_path(search_with_group),
+              class: "btn btn-outline-secondary #{'active' if grouped?}"
+  %>
+</div>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,0 +1,8 @@
+<% # overidden from Blacklight to handle our responsive needs %>
+<div id="sortAndPerPage" class="sort-pagination clearfix">
+  <div>
+    <%= render partial: "paginate_compact", object: @response if show_pagination? %>
+  </div>
+  <%= render partial: 'group_toggle' %>
+  <%= render_results_collection_tools wrapping_class: "search-widgets float-md-right" %>
+</div>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -22,9 +22,11 @@ en:
     views:
       index:
         all_group_results: view all %{count}
+        all_results: All results
         collection_search:
           count: collection
-        group_by_collection: Group by collection
+        group_by_collection: Grouped by collection
+        group_results: Group results
         group_results_count:
           one: 1 result
           other: "%{count} results"

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -49,7 +49,6 @@ class CatalogController < ApplicationController
 
     config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
 
-    config.add_results_collection_tool :group_toggle
     config.add_results_collection_tool(:sort_widget)
     config.add_results_collection_tool(:per_page_widget)
     config.add_results_collection_tool(:view_type_group)


### PR DESCRIPTION
…(w/ two buttons instead of a single on/off button).

Closes #793 

Also overrides Blacklight's sort_and_per_page partial so that we can make the group toggle responsive.

![responsive-group-button](https://user-images.githubusercontent.com/96776/65076582-26044000-d94e-11e9-95cb-7cb8d740b433.gif)
