### PR TITLE
Use the bookmark icons when an item is already bookmarked.

### DIFF
--- a/app/views/catalog/_arclight_bookmark_control.html.erb
+++ b/app/views/catalog/_arclight_bookmark_control.html.erb
@@ -21,11 +21,11 @@
   <% else %>
     <%= form_tag(bookmark_path(document),
                  method: :delete,
-                 class: "bookmark-toggle",
+                 class: "bookmark-toggle col-auto",
                  data: {
                    'doc-id' => document.id,
-                   present: t('blacklight.search.bookmarks.present'),
-                   absent: t('blacklight.search.bookmarks.absent'),
+                   present: blacklight_icon(:bookmark),
+                   absent: blacklight_icon(:bookmark),
                    inprogress: t('blacklight.search.bookmarks.inprogress')
                 }) do %>
       <%= submit_tag(t('blacklight.bookmarks.remove.button'),


### PR DESCRIPTION
Previously we would get the correct bookmark icon via JS, but when the user came back to the page and the partial was rendered we were still using the blacklight text.

