### PR TITLE
Bugfix: add IDs to components missing them; add an id-less fixture; improve test coverage for minting IDs. 

### DIFF
--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -230,10 +230,11 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
                      parent_id = context.clipboard[:parent].output_hash['id'].first
                      logger.warn('MISSING ID WARNING') do
                        [
-                         "A component in #{parent_id} did not have and ID so one was minted using the #{strategy} strategy.",
+                         "A component in #{parent_id} did not have an ID so one was minted using the #{strategy} strategy.",
                          "The ID of this document will be #{parent_id}#{hexdigest}."
                        ].join(' ')
                      end
+                     hexdigest
                    else
                      record.attribute('id')&.value&.strip&.gsub('.', '-')
                    end

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -81,10 +81,10 @@ to_field 'unitdate_inclusive_ssm', extract_xpath('/ead/archdesc/did/unitdate[@ty
 to_field 'unitdate_other_ssim', extract_xpath('/ead/archdesc/did/unitdate[not(@type)]')
 
 to_field 'level_ssm' do |record, accumulator|
-  accumulator << record.at_xpath('/ead/archdesc').attribute('level').value
+  accumulator << record.at_xpath('/ead/archdesc').attribute('level')&.value
 end
 to_field 'level_sim' do |record, accumulator|
-  accumulator << record.at_xpath('/ead/archdesc').attribute('level').value&.capitalize
+  accumulator << record.at_xpath('/ead/archdesc').attribute('level')&.value&.capitalize
 end
 
 to_field 'unitid_ssm', extract_xpath('/ead/archdesc/did/unitid')
@@ -285,7 +285,7 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
 
   to_field 'parent_ssm' do |record, accumulator, context|
     accumulator << context.clipboard[:parent].output_hash['id'].first
-    accumulator.concat NokogiriXpathExtensions.new.is_component(record.ancestors).reverse.map { |n| n.attribute('id').value }
+    accumulator.concat NokogiriXpathExtensions.new.is_component(record.ancestors).reverse.map { |n| n.attribute('id')&.value }
   end
 
   to_field 'parent_ssi' do |_record, accumulator, context|

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -606,6 +606,25 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
   end
 
+  describe 'EAD without component IDs' do
+    let(:fixture_path) do
+      Arclight::Engine.root.join('spec', 'fixtures', 'ead', 'sample', 'no-ids-recordgrp-level.xml')
+    end
+
+    it 'mints component ids by hashing absolute paths' do
+      expect(result).to include 'components'
+      expect(result['components']).not_to be_empty
+      first_component = result['components'].first
+      second_component = result['components'].second
+
+      expect(first_component['ref_ssi']).to contain_exactly('4bf70b448ac8351a147acff1dd8b1c0b9a791980')
+      expect(first_component['id']).to contain_exactly('ehllHemingwayErnest-sample4bf70b448ac8351a147acff1dd8b1c0b9a791980')
+
+      expect(second_component['ref_ssi']).to contain_exactly('54b06e5ad77cab05ec7f6beeaca50022c47d9c7b')
+      expect(second_component['id']).to contain_exactly('ehllHemingwayErnest-sample54b06e5ad77cab05ec7f6beeaca50022c47d9c7b')
+    end
+  end
+
   describe 'for EAD Documents without XML namespaces' do
     let(:fixture_without_namespaces) do
       doc = Nokogiri::XML.parse(fixture_file.to_s)

--- a/spec/fixtures/ead/sample/no-ids-recordgrp-level.xml
+++ b/spec/fixtures/ead/sample/no-ids-recordgrp-level.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd">
+  <eadheader audience="internal" langencoding="iso639-2b" repositoryencoding="iso15511" dateencoding="iso8601" relatedencoding="Dublin Core">
+    <eadid publicid="us//::mi-HC//TXT us::ehll::HemingwayErnest.xml//EN" encodinganalog="identifier">ehllHemingwayErnest-sample</eadid>
+    <filedesc>
+      <titlestmt>
+        <titleproper encodinganalog="title">
+          Finding Aid for Ernest Hemingway Collection
+        </titleproper>
+      </titlestmt>
+      <publicationstmt>
+        <publisher encodinganalog="publisher">Clarke Historical Library</publisher>
+        <date encodinganalog="date">
+          2003, 2009, ongoing
+        </date>
+      </publicationstmt>
+    </filedesc>
+    <profiledesc>
+      <creation>These are modified excerpts from a Central Michigan University finding aid, converted from EAD2002 DTD to EAD2002 W3C Schema (XSD), for the purpose of testing the ArcLight application.</creation>
+      <langusage>The finding aid is written in 
+        <language langcode="eng">English</language>
+      </langusage>
+    </profiledesc>
+  </eadheader>
+  <frontmatter>
+    <titlepage>
+      <publisher>Clarke Historical Library<lb/>Central Michigan University</publisher>
+      <titleproper>Finding aid for <lb/>Ernest Hemingway Collection</titleproper>
+      <author>Finding aid created by <lb/>Marian Matyn</author>
+    </titlepage>
+  </frontmatter>
+  <archdesc level="recordgrp" audience="external" type="inventory" relatedencoding="marc21">
+    <did>
+      <origination>
+        <persname source="lcnaf" encodinganalog="100">Hemingway, Ernest, 1899-1961.</persname>
+      </origination>
+      <unittitle encodinganalog="245">
+        Ernest Hemingway Collection,
+        <unitdate type="inclusive" encodinganalog="245$f">
+          1901, 2014, and undated
+        </unitdate></unittitle>
+      <physdesc>
+        <extent encodinganalog="300">
+          6 cubic feet (in 7 boxes, 8 Oversized folders, 4 reels in 4 boxes, and 52 framed items)
+        </extent>
+      </physdesc>
+      <unitid encodinganalog="099" type="call number">
+        MSS.
+      </unitid>
+      <langmaterial>The material is in <language langcode="eng" encodinganalog="041">English</language></langmaterial>
+      <abstract>
+        This artificial collection includes articles by or about Hemingway, movie posters and photographs, manuscript letters, printed and miscellaneous materials about Ernest Hemingway and his books, diaries of Ernest's uncle, George R. Hemingway, and the organizational records of the Michigan Hemingway Society. 
+      </abstract>
+      <repository>
+        <corpname encodinganalog="852"><subarea>Clarke Historical Library</subarea>, Central Michigan University</corpname>
+        <extptr xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" xlink:href="CHLadd"/>
+      </repository>
+    </did>
+    <descgrp type="admin">
+      <acqinfo encodinganalog="541">
+        <p>Acc# many</p>
+      </acqinfo>
+      <accessrestrict encodinganalog="506">
+        <p>Ernest Hemingway Collection is open for research.</p>
+      </accessrestrict>
+      <userestrict encodinganalog="540">
+        <p>
+          Some published materials in the collection are still under copyright. Some of the photographs are copies from the John F. Kennedy Presidential Library. Copyright and intellectual rights for Hemingway collections are complex. Regarding these photographic copies please refer to the John F. Kennedy Presidential Library online finding at https://www.jfklibrary.org/sites/default/files/archives/EHPP/EHPP-FA.xml.
+        </p>
+      </userestrict>
+      <prefercite encodinganalog="524">
+        <p>
+          Ernest Hemingway Collection, 1901, 2006, and undated, Folder # , Box #, Clarke Historical Library, Central Michigan University
+        </p>
+      </prefercite>
+    </descgrp>
+    <bioghist encodinganalog="545">
+      <p>Biography:</p>
+      <p>Ernest Hemingway was born July 21, 1899 in Oak Park, Illinois, the son of Clarence E. Hemingway, a doctor, and Grace Hall-Hemingway, a musician and voice teacher. He had four sisters and a brother. Every summer, the family summered at the family cottage, named Windemere, on Walloon Lake near Petoskey, Michigan.</p>
+      <p>After Ernest graduated from high school in June 1917, he joined the Missouri Home Guard. Before it was called to active duty, he served as a volunteer ambulance driver for the American Red Cross. On July 8, 1918 Hemingway was wounded by an Austrian trench mortar. He spent the subsequent summer and fall recovering from his leg wounds in the Milan Red Cross hospital. In Europe, Hemingway met nurse Agnes Von Kurowsky. He thought they were engaged when he returned to the U.S. on January 21, 1919, but she broke off whatever relationship they had had in March 1919.</p>
+      <p>In January 1920, the city editor of the Toronto Star agreed to buy Hemingway’s stories on a piece by piece basis as they suited the paper. The paper regularly printed his features on dental schools, prizefights, free shaves, trout fishing, rum-running and, later, on Chicago gangsters. He returned to Chicago in May 1920.</p>
+      <p>In September 1921, Hemingway married Hadley Richardson at Horton Bay, Michigan. They had planned to live in Italy, but were advised by Sherwood Anderson that a would-be-writer should live in Paris. In January 1922, the couple moved into an apartment in Paris’ Latin Quarter.</p>
+      <p>The Hemingways later returned to Toronto, where Ernest found that the new editor of the Star did not like him.  His first assignment upon his return was to cover a prison escape. He used one prisoner as the basis for his male, loner, anti-social characters, which later appeared in a number of his stories.</p>
+    </bioghist>
+    <arrangement encodinganalog="351">
+      <p>The collection is divided into three series: materials by and about Ernest Hemingway, the diaries of his uncle, George R. Hemingway, and the organizational records of the Michigan Hemingway Society.</p>
+    </arrangement>
+    <scopecontent encodinganalog="520">
+      <p>Materials by and about Ernest Hemingway in the collection include numerous periodicals with Articles by or about Hemingway, his books, and movies based on his books; numerous Movie Posters; other Posters of Hemingway, his homes, books, or exhibits about him; Photographs (copies), mostly from movies based on his books and some from the John F. Kennedy Presidential Library; the (Film) ‘Adventures of a Young Man’, undated (4 reels): Manuscript Correspondence, four Letters written by Hemingway, one to Jim Gamble written on April 18 and 27, 1919, one dated Oct. 28, 1919 to Ernest's father, Dr. Clarence Hemingway (framed), one dated Nov. 12, 1919 to his mother, Mrs. Grace H. Hemingway (framed), and one dated 2 Feb. 1960 to his son, J. H. N. Hemingway, as well as copies of two letters written by Hemingway to Owen Wister dated March 1 and 11, 1929 (the originals are in the Library of Congress). Brochures; Advertisements; Exhibit Brochures; Postcards; Auction Catalogs; Sheet Music; Miscellaneous materials. Biographical Information (copies) and ramed Items for exhibits, including posters, photographs, and other materials.</p>
+      <p>Of particular interest is the first letter (original six p., and a copy) written by Hemingway on April 18 and 27, 1919 to his friend Jim Gamble, the Proctor and Gamble heir, detailing his desire to write even though submissions for publication were rejected, his dashed hopes for marriage, his hunger for recognition, his love of northern Michigan and trout fishing, and notes about people whose company he enjoyed while staying at Windemere Cottage, near Petoskey, Michigan. During this time, Hemingway was recovering from war wounds and a broken heart. The letter is typed with his signature. Included with the letter are copies of two Hemingway letters to Owen Wister, March 1 (6 p.) and 11 (5 p.), 1929, copied from the Library of Congress, and a letter to Henry M. Watts from Theodore Voorhees, December 11, 1979, concerning the copied letters. (Note: This letter is housed separately from the rest of the collection.)</p>
+      <p>User Note: The collection has a decidedly musty to lightly moldy smell and patrons with allergies or breathing problems should use the collection with care.</p>
+      <p>Processing Note: Most of the numerous books that came to the Clarke with the collection have been cataloged. Those few books for which no catalog record could be found have been added to this manuscript collection. Later Oversized additions will be added at the end of the collection.</p>
+    </scopecontent>
+    <controlaccess>
+      <p>
+        <extptr xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad" xlink:href="accnote"/>
+      </p>
+      <controlaccess>
+        <head>Subjects:</head>
+        <corpname encodinganalog="610" source="lcnaf">Michigan Hemingway Society.</corpname>
+        <persname encodinganalog="600" source="lcnaf">Hemingway, Ernest, 1899-1961--Biography.</persname>
+        <persname encodinganalog="600" source="lcnaf">Hemingway, Ernest, 1899-1961--Correspondence.</persname>
+        <persname encodinganalog="600" source="lcnaf">Hemingway, Ernest, 1899-1961--Criticism and Interpretation.</persname>
+        <persname encodinganalog="600" source="lcnaf">Hemingway, Ernest, 1899-1961--Exhibitions.</persname>
+        <persname encodinganalog="600" source="lcnaf">Hemingway, Ernest, 1899-1961--Farewell to arms.</persname>
+        <persname encodinganalog="600" source="lcnaf">Hemingway, Ernest, 1899-1961--For whom the bell tolls.</persname>
+        <persname encodinganalog="600" source="lcnaf">Hemingway, Ernest, 1899-1961--Homes and haunts--Cuba--Havana--Pictorial works.</persname>
+        <persname encodinganalog="600" source="lcnaf">Hemingway, Ernest, 1899-1961--Homes and haunts--Florida--Key West--Pictorial works.</persname>
+        <persname encodinganalog="600" source="lcnaf">Hemingway, Ernest, 1899-1961--Moveable feast.</persname>
+        <persname encodinganalog="600" source="lcnaf">Hemingway, Ernest, 1899-1961--Old man and the sea.</persname>
+        <persname encodinganalog="600" source="lcnaf">Hemingway, Ernest, 1899-1961--Pictorial works.</persname>
+        <persname encodinganalog="600" source="lcnaf">Hemingway, Ernest, 1899-1961--Portraits--Exhibitions.</persname>
+        <persname encodinganalog="600" source="lcnaf">Hemingway, Ernest, 1899-1961--Sun also rises.</persname>
+        <persname encodinganalog="600" source="lcnaf">Hemingway, Ernest, 1899-1961--Correspondence.</persname>
+        <persname encodinganalog="700" source="lcnaf">Hemingway, Ernest, 1899-1961.</persname>
+        <subject encodinganalog="650" source="lcsh">Authors, American--20th century.</subject>
+        <subject encodinganalog="650" source="lcsh">War and society--United States--History--20th century.</subject>
+        <subject encodinganalog="650" source="lcsh">World War, 1914-1918--Veterans.</subject>
+        <geogname encodinganalog="651" source="lcsh">Petoskey (Mich.)--History.</geogname>
+        <famname encodinganalog="600" source="lcnaf">Hemingway family.</famname>
+        <corpname encodinganalog="710" source="lcnaf">Michigan Hemingway Society.</corpname>
+        <persname encodinganalog="700" source="lcnaf">Hemingway, Ernest, 1899-1961.</persname>
+      </controlaccess>
+    </controlaccess>
+    <dsc type="combined">
+      <c01 level="series">
+        <did>
+          <unittitle>Ernest Hemingway Collection</unittitle>
+        </did>
+        <c02 level="file">
+          <did>
+            <container type="Box" label="Box">1</container>
+            <container type="Folder" label="F">1</container>
+            <unittitle>
+              Biographical Information,<unitdate type="inclusive">2003</unitdate>
+            </unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="Box" label="Box">1</container>
+            <container type="Folder" label="F">2</container>
+            <unittitle>
+              Sample Advertisements for, At the Hemingways, <unitdate type="inclusive">1999</unitdate>
+            </unittitle>
+          </did>
+        </c02>
+        <c02 level="file">
+          <did>
+            <container type="Box" label="Box">1</container>
+            <container type="Folder" label="F">3</container>
+            <unittitle>
+              Sample Advertisements for, (The) Complete stories of Ernest Hemingway, the Finca Vigia edition,<unitdate type="inclusive">1988</unitdate>
+            </unittitle>
+          </did>
+        </c02>
+      </c01>
+    </dsc>
+  </archdesc>
+</ead>

--- a/spec/lib/arclight/hash_absolute_xpath_spec.rb
+++ b/spec/lib/arclight/hash_absolute_xpath_spec.rb
@@ -17,46 +17,48 @@ RSpec.describe Arclight::HashAbsoluteXpath do
         xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd"
       >
         <archdesc>
-          <c>
-            <did><unittitle>C0</unittitle></did>
+          <dsc>
             <c>
-              <did><unittitle>C0.0</unittitle></did>
-            </c>
-          </c>
-          <c>
-            <did><unittitle>C1</unittitle></did>
-            <c>
-              <did><unittitle>C1.0</unittitle></did>
+              <did><unittitle>C0</unittitle></did>
+              <c>
+                <did><unittitle>C0.0</unittitle></did>
+              </c>
             </c>
             <c>
-              <did><unittitle>C1.1</unittitle></did>
+              <did><unittitle>C1</unittitle></did>
+              <c>
+                <did><unittitle>C1.0</unittitle></did>
+              </c>
+              <c>
+                <did><unittitle>C1.1</unittitle></did>
+              </c>
             </c>
-          </c>
+          </dsc>
         </archdesc>
       </ead>
     XML
   end
 
   it 'returns the absolute xpath of node passed in (adding indexes to all the c nodes)' do
-    expect(described_class.new(components[0]).absolute_xpath).to eq 'document/ead/archdesc/c0'
-    expect(described_class.new(components[1]).absolute_xpath).to eq 'document/ead/archdesc/c0/c0'
-    expect(described_class.new(components[2]).absolute_xpath).to eq 'document/ead/archdesc/c1'
-    expect(described_class.new(components[3]).absolute_xpath).to eq 'document/ead/archdesc/c1/c0'
-    expect(described_class.new(components[4]).absolute_xpath).to eq 'document/ead/archdesc/c1/c1'
+    expect(described_class.new(components[0]).absolute_xpath).to eq 'document/ead/archdesc/dsc/c0'
+    expect(described_class.new(components[1]).absolute_xpath).to eq 'document/ead/archdesc/dsc/c0/c0'
+    expect(described_class.new(components[2]).absolute_xpath).to eq 'document/ead/archdesc/dsc/c1'
+    expect(described_class.new(components[3]).absolute_xpath).to eq 'document/ead/archdesc/dsc/c1/c0'
+    expect(described_class.new(components[4]).absolute_xpath).to eq 'document/ead/archdesc/dsc/c1/c1'
   end
 
   it 'hashes the absolute_xpath' do
-    expect(described_class.new(components[0]).to_hexdigest).to eq 'c015cba710557ac75e1c9b4da33e37fbdee41e82'
-    expect(described_class.new(components[1]).to_hexdigest).to eq '0e6141f0e5d704f223e254e26a62c954643f5553'
-    expect(described_class.new(components[2]).to_hexdigest).to eq '24494999c8c5a300dabdcd74f0885f1f380a71f3'
-    expect(described_class.new(components[3]).to_hexdigest).to eq '76229094a02f4644b05317e51ecaa5dfc950d811'
-    expect(described_class.new(components[4]).to_hexdigest).to eq '20fb448f390a0e3a5da9f2506c782a62e6264fc9'
+    expect(described_class.new(components[0]).to_hexdigest).to eq '9c4e84c284385184b7e3548ebe2a81a9df522a67'
+    expect(described_class.new(components[1]).to_hexdigest).to eq '73760c5f85d3691b9f537a5ca3d887825e6e0ee9'
+    expect(described_class.new(components[2]).to_hexdigest).to eq '44c3b0a0ba891df68aa056f9d3e3fcf23f64ad4e'
+    expect(described_class.new(components[3]).to_hexdigest).to eq '75fdc26f3f0a5fd30e157dbd523885a4eda7ecb3'
+    expect(described_class.new(components[4]).to_hexdigest).to eq '72636263da05d832fb4a05c90c2b2c79480af70e'
   end
 
   it 'allows the hashing algorithm to be configured' do
     hash_algorithm = described_class.hash_algorithm
     described_class.hash_algorithm = Digest::SHA256
-    expect(described_class.new(components[0]).to_hexdigest).to eq '0b77f8ad4db958f29236f78bd367f466c82b45800ffae72a1cec91742fa37a59'
+    expect(described_class.new(components[0]).to_hexdigest).to eq '4b884bc407a22e7e6a41867ef4987b7c49f81c641fe0c4d1f92009a5e4b963a9'
     described_class.hash_algorithm = hash_algorithm
   end
 end


### PR DESCRIPTION
Fixes #785 . Changes in this PR include:
- Adds a test fixture sample EAD that lacks component IDs. For this I used a truncated/revised version (< 200 lines of EAD) of the CMU Hemingway finding aid mentioned in #785 as that has a few characteristics not yet accounted for in our fixtures (notably: missing IDs, and `archdesc[@level="recordgrp"]`). I also had to convert this finding aid from using EAD2002 DTD to using EAD2002 W3C Schema (XSD), else it [would fail validation in our CI pipeline](https://github.com/projectblacklight/arclight/commit/33dbee3fd39ea7b1a2822a05b93dc29610c130db#diff-354f30a63fb0907d4ad57269548329e3).
- Addresses the bug preventing the component IDs from being written to the index once minted
- Adds tests to verify minted IDs get written correctly
- Revises existing test example for ID hashing so it's valid EAD (note addition of `<dsc>` between the `<archdesc>` & `<c>` elements).
- Improves resiliency for indexing levels & parent IDs by adding a few safe navigation operators.