### PR TITLE
Add badge to show number of children in document hierarchy

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -12,12 +12,6 @@
 
   .al-toggle-view-all {
     color: $gray-600;
-
-    &:before {
-      color: $gray-600;
-      content: "\2022";
-      padding-right: 3px;
-    }
   }
 
   .al-hierarchy-children-status {

--- a/app/views/catalog/_index_header_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_header_hierarchy_default.html.erb
@@ -9,12 +9,12 @@
     <% counter = document_counter_with_offset(document_counter) %>
     <%= link_to_document document, document_show_link_field(document), counter: counter %>
     <% if document.children? %>
-      <span class="badge badge-pill badge-secondary"><%= document.number_of_children %></span>
+      <span class="badge badge-pill badge-secondary al-number-of-children-badge"><%= document.number_of_children %></span>
     <% end %>
     <%= render_document_partial(document, 'arclight_online_content_indicator') %>
     <% if document.children? %>
       <div class='al-hierarchy-children-status'>
-        <span class='badge badge-default al-number-of-children-badge'>
+        <span class='badge badge-default'>
           <% unless hierarchy_component_context? %>
             <%= link_to(
               t('arclight.hierarchy.view_all'),

--- a/app/views/catalog/_index_header_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_header_hierarchy_default.html.erb
@@ -9,7 +9,7 @@
     <% counter = document_counter_with_offset(document_counter) %>
     <%= link_to_document document, document_show_link_field(document), counter: counter %>
     <% if document.children? %>
-      <span class="badge badge-pill badge-secondary al-number-of-children-badge"><%= document.number_of_children %></span>
+      <span class="badge badge-pill badge-secondary al-number-of-children-badge"><%= document.number_of_children %><span class="sr-only"><%= t(:'arclight.views.index.number_of_components', count: document.number_of_children) %></span></span>
     <% end %>
     <%= render_document_partial(document, 'arclight_online_content_indicator') %>
     <% if document.children? %>

--- a/app/views/catalog/_index_header_hierarchy_default.html.erb
+++ b/app/views/catalog/_index_header_hierarchy_default.html.erb
@@ -8,11 +8,13 @@
     <% end %>
     <% counter = document_counter_with_offset(document_counter) %>
     <%= link_to_document document, document_show_link_field(document), counter: counter %>
+    <% if document.children? %>
+      <span class="badge badge-pill badge-secondary"><%= document.number_of_children %></span>
+    <% end %>
     <%= render_document_partial(document, 'arclight_online_content_indicator') %>
     <% if document.children? %>
       <div class='al-hierarchy-children-status'>
         <span class='badge badge-default al-number-of-children-badge'>
-          <%= t(:'arclight.views.index.number_of_children', count: document.number_of_children) %>
           <% unless hierarchy_component_context? %>
             <%= link_to(
               t('arclight.hierarchy.view_all'),

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -31,6 +31,9 @@ en:
           one: 1 result
           other: "%{count} results"
           zero: 0 results
+        number_of_components:
+          one: component
+          other: components
         top_group_results:
           one: Top %{count} result
           other: Top %{count} results

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -31,10 +31,6 @@ en:
           one: 1 result
           other: "%{count} results"
           zero: 0 results
-        number_of_children:
-          one: 1 child
-          other: "%{count} children"
-          zero: No children
         top_group_results:
           one: Top %{count} result
           other: Top %{count} results

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -273,11 +273,11 @@ RSpec.describe 'Collection Page', type: :feature do
           end
         end
       end
-      it 'includes the number of direct children of the component and View link' do
+      it 'includes the number of direct children of the component' do
         within '.document-position-0' do
           expect(page).to have_css(
-            '.al-hierarchy-children-status .al-number-of-children-badge',
-            text: /25 children\s+View/
+            '.al-number-of-children-badge',
+            text: /25/
           )
         end
       end

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -98,8 +98,7 @@ RSpec.describe 'Component Page', type: :feature do
             'article a',
             text: 'Series I: Administrative Records, 1902-1976'
           )
-          expect(page).to have_css('.al-number-of-children-badge', text: '25 children')
-          expect(page).not_to have_css('.al-number-of-children-badge', text: /View/)
+          expect(page).to have_css('.al-number-of-children-badge', text: '25')
           expect(page).not_to have_css 'form.bookmark-toggle' # no bookmarks
         end
       end


### PR DESCRIPTION
Closes #814.

The badge text scales in size with the text it's next to. It may want more specific styling to better match the mockups.

![image](https://user-images.githubusercontent.com/10409866/65182389-2f190e00-da2f-11e9-8ee1-4916a6180bf6.png)

![image](https://user-images.githubusercontent.com/10409866/65182409-38a27600-da2f-11e9-9e0c-b832ab58fe42.png)
