### PR TITLE
Add online content icon to compact view

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -60,7 +60,6 @@
 
 .bookmark-toggle {
   display: inline;
-  float: right;
 }
 
 .al-hierarchy-side-content {

--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -28,14 +28,6 @@
       }
     }
 
-    .al-document-container.text-muted {
-      color: #ADB5BD !important;
-    }
-
-    div .bookmark-toggle .toggle-bookmark, div .index-document-functions {
-      display: inline;
-    }
-
     form.bookmark-toggle.col-auto {
       padding-right: 0;
     }
@@ -133,6 +125,14 @@ article.document {
   }
 }
 
+.index-document-functions {
+  display: flex;
+}
+
+.al-document-container.text-muted {
+  color: #ADB5BD !important;
+}
+
 .col-no-left-padding {
   padding-left: 0 !important;
 }
@@ -157,4 +157,3 @@ article.document {
     background-color: #6c757d;
     border-color: #6c757d;
 }
-

--- a/app/views/catalog/_arclight_index_compact_default.html.erb
+++ b/app/views/catalog/_arclight_index_compact_default.html.erb
@@ -7,6 +7,11 @@
       <h3 class="d-flex">
         <%= link_to_document document, document_show_link_field(document), counter: document_counter %>
       </h3>
+      <% if document.online_content? %>
+        <span class='badge badge-success col-auto'>
+          <%= t(:'arclight.views.online_content_indicator') %>
+        </span>
+      <% end %>
       <div class="d-flex">
         <%= render_index_doc_actions document %>
       </div>

--- a/app/views/catalog/_arclight_index_compact_default.html.erb
+++ b/app/views/catalog/_arclight_index_compact_default.html.erb
@@ -2,14 +2,12 @@
   <div class="col-auto">
     <%= blacklight_icon document_header_icon(document) %>
   </div>
-  <div class="col col-no-left-padding">
+  <div class="col col-no-left-padding col-no-right-padding">
     <div class="d-flex justify-content-between">
-      <h3 class="d-flex">
+      <h3 class="col col-no-left-padding">
         <%= link_to_document document, document_show_link_field(document), counter: document_counter %>
       </h3>
-      <div class="d-flex">
-        <%= render_index_doc_actions document %>
-      </div>
+      <%= render_index_doc_actions document %>
     </div>
     <div class="row">
       <%= content_tag('div', class: 'al-document-highlight col') do %>

--- a/app/views/catalog/_arclight_index_compact_default.html.erb
+++ b/app/views/catalog/_arclight_index_compact_default.html.erb
@@ -7,11 +7,6 @@
       <h3 class="d-flex">
         <%= link_to_document document, document_show_link_field(document), counter: document_counter %>
       </h3>
-      <% if document.online_content? %>
-        <span class='badge badge-success col-auto'>
-          <%= t(:'arclight.views.online_content_indicator') %>
-        </span>
-      <% end %>
       <div class="d-flex">
         <%= render_index_doc_actions document %>
       </div>

--- a/app/views/catalog/_arclight_index_default.html.erb
+++ b/app/views/catalog/_arclight_index_default.html.erb
@@ -6,12 +6,7 @@
   <div class="col col-no-left-padding">
     <div class="row">
       <%= render partial: 'arclight_search_index_header', locals: { document: document, counter: counter }  %>
-      <div class="col-auto">
-        <%= content_tag('span', class: 'al-document-container col-auto text-muted') do %>
-          <%= document.containers.join(', ') %>
-        <% end if document.containers %>
-        <%= render_index_doc_actions document %>
-      </div>
+      <%= render_index_doc_actions document %>
     </div>
 
     <div class="row">

--- a/app/views/catalog/_arclight_index_default.html.erb
+++ b/app/views/catalog/_arclight_index_default.html.erb
@@ -10,9 +10,6 @@
         <%= content_tag('span', class: 'al-document-container col-auto text-muted') do %>
           <%= document.containers.join(', ') %>
         <% end if document.containers %>
-        <% if document.online_content? %>
-          <%= blacklight_icon :online, classes: 'al-online-content-icon' %>
-        <% end %>
         <%= render_index_doc_actions document %>
       </div>
     </div>

--- a/app/views/catalog/_containers.html.erb
+++ b/app/views/catalog/_containers.html.erb
@@ -1,0 +1,3 @@
+<%= content_tag('div', class: 'al-document-container col text-muted') do %>
+  <%= document.containers.join(', ') %>
+<% end if document.containers.present? %>

--- a/app/views/catalog/_online_content_label.html.erb
+++ b/app/views/catalog/_online_content_label.html.erb
@@ -1,0 +1,5 @@
+<% if document.online_content? %>
+  <div>
+    <%= blacklight_icon :online, classes: 'al-online-content-icon' %>
+  </div>
+<% end %>

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -199,6 +199,7 @@ class CatalogController < ApplicationController
 
     ##
     # Configuration for index actions
+    config.index.document_actions << :online_content_label
     config.add_results_document_tool :arclight_bookmark_control, partial: 'arclight_bookmark_control'
     config.index.document_actions.delete(:bookmark)
 

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -199,6 +199,7 @@ class CatalogController < ApplicationController
 
     ##
     # Configuration for index actions
+    config.index.document_actions << :containers
     config.index.document_actions << :online_content_label
     config.add_results_document_tool :arclight_bookmark_control, partial: 'arclight_bookmark_control'
     config.index.document_actions.delete(:bookmark)

--- a/spec/features/compact_search_results_spec.rb
+++ b/spec/features/compact_search_results_spec.rb
@@ -16,7 +16,14 @@ RSpec.describe 'Compact Search Results', type: :feature do
     expect(page).to have_css('.documents-compact')
     expect(page).to have_css('article.document', count: 10)
     within '.document-position-0' do
+      # Has breadcrumbs
       expect(page).to have_css '.breadcrumb-links a', text: /National Library of/
+      # Has Containers
+      expect(page).to have_css '.al-document-container', text: 'Box 1, Folder 1'
+      # Has Online Content Indicator
+      expect(page).to have_css '.al-online-content-icon'
+      # Has Bookmark Control
+      expect(page).to have_css 'form.bookmark-toggle'
     end
   end
   scenario 'Shows highlights in compact view' do


### PR DESCRIPTION
Closes #766 

This also adds the container text to the compact view as the updates to the approach caused some layout issues which I addressed via flexbox + using Blacklight's document action's functionality.  There will probably still be some responsive/layout tweaks, but I think this puts us in a good spot to move forward and keep these two views consistent.

## Default/List view
<img width="862" alt="default-view" src="https://user-images.githubusercontent.com/96776/65187926-f4f53f80-da21-11e9-928d-d031e74e16b1.png">

## Compact View
<img width="855" alt="compact-view" src="https://user-images.githubusercontent.com/96776/65187925-f58dd600-da21-11e9-918d-5340296074bc.png">

