### PR TITLE
Surround masthead title in a span on non-home pages …

### DIFF
--- a/app/assets/stylesheets/arclight/modules/mastheads.scss
+++ b/app/assets/stylesheets/arclight/modules/mastheads.scss
@@ -40,7 +40,8 @@
 }
 
 .al-masthead {
-  h1 {
+  h1, .h1 {
+    display: block;
     font-size: $h2-font-size;
     margin: 0;
     padding: ($spacer * 1.5) ($spacer / 2);

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -40,7 +40,7 @@
       <div class="container">
         <div class="row align-items-center">
           <div class="col-md-8" >
-            <h1><%= t('arclight.masthead_heading') %></h1>
+            <span class="h1"><%= t('arclight.masthead_heading') %></span>
           </div>
 
           <div class="col-md-4 nav-links d-flex justify-content-end" >


### PR DESCRIPTION
…(but style it the same as the h1 on the home page).

Closes #821 

## Home Page (before)
<img width="965" alt="home-page-before" src="https://user-images.githubusercontent.com/96776/65267766-8b7d3b80-daca-11e9-86fd-121320eede96.png">

## Home Page (after)
<img width="965" alt="home-page-after" src="https://user-images.githubusercontent.com/96776/65267769-8b7d3b80-daca-11e9-9ad0-fcef9100305b.png">

## Results (before)
<img width="964" alt="results-before" src="https://user-images.githubusercontent.com/96776/65267767-8b7d3b80-daca-11e9-8888-f4959f9e2a6f.png">

## Results (after)
<img width="952" alt="results-after" src="https://user-images.githubusercontent.com/96776/65267768-8b7d3b80-daca-11e9-84eb-ad6ba5f7262c.png">

_These are to show that there is no visual change before/after_