### PR TITLE
Use _nest_path_ instead of sort_ii for figuring out the original order..

### DIFF
--- a/app/models/concerns/arclight/search_behavior.rb
+++ b/app/models/concerns/arclight/search_behavior.rb
@@ -27,7 +27,7 @@ module Arclight
     ##
     # For the hierarchy view, set the sort order to preserve the order of components
     def add_hierarchy_sort(solr_params)
-      solr_params[:sort] = 'sort_ii asc' if %w[hierarchy online_contents].include? blacklight_params[:view]
+      solr_params[:sort] = '_nest_path_ asc' if %w[hierarchy online_contents].include? blacklight_params[:view]
       solr_params
     end
 

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -55,6 +55,7 @@ describe 'EAD 2 traject indexing', type: :feature do
       expect(result['level_ssm']).to eq ['collection']
       expect(result['level_sim']).to eq ['Collection']
     end
+
     it 'dates' do
       expect(result['normalized_date_ssm']).to include_ignoring_whitespace 'circa 1900-1906'
       expect(result['unitdate_bulk_ssim']).to be_nil

--- a/spec/models/concerns/arclight/search_behavior_spec.rb
+++ b/spec/models/concerns/arclight/search_behavior_spec.rb
@@ -35,14 +35,14 @@ describe Arclight::SearchBehavior do
       let(:user_params) { { view: 'hierarchy' } }
 
       it 'adds component-order sort to query' do
-        expect(search_builder_instance.add_hierarchy_sort(solr_params)).to include(sort: 'sort_ii asc')
+        expect(search_builder_instance.add_hierarchy_sort(solr_params)).to include(sort: '_nest_path_ asc')
       end
     end
     context 'when in online_contents view' do
       let(:user_params) { { view: 'online_contents' } }
 
       it 'adds component-order sort to query' do
-        expect(search_builder_instance.add_hierarchy_sort(solr_params)).to include(sort: 'sort_ii asc')
+        expect(search_builder_instance.add_hierarchy_sort(solr_params)).to include(sort: '_nest_path_ asc')
       end
     end
     context 'when not in hierarchy view' do


### PR DESCRIPTION
… of components within a document.

`sort_ii` indexing was dropped in the switch to traject, and seems redundant with the `_nest_path_` information (which contains e.g. `/component#5` for the 6th (5th? i've assumed it's 0-indexed, but it doesn't really matter..) child of the collection)