### PR TITLE
add vertical spacing to items in the search results list view

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -52,6 +52,11 @@ article.document {
   .blacklight-icons.al-online-content-icon svg {
     fill: $green;
   }
+  div.breadcrumb-links, 
+  div.al-document-abstract-or-scope, 
+  div.al-document-creator {
+    margin-top: ($spacer * .5);
+  }
 }
 
 .documents-compact {


### PR DESCRIPTION
Closes #826 part of #669 
### Add vertical spacing between item in the search results list view

### NOTE: This is before mobile updates have been implemented for the bookmarks, online content, and containers. 

### Before
<a href="https://cl.ly/96649bf45c2d" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/3H3F0F0P2p2A3D3h2H1Z/Screen%20Shot%202019-09-19%20at%2012.14.07%20PM.png" style="display: block;height: auto;width: 100%;"/></a>

<a href="https://cl.ly/131899ba0b8b" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/1y1C2O191L231B233O3M/Screen%20Shot%202019-09-19%20at%2012.13.49%20PM.png" style="display: block;height: auto;width: 100%;"/></a>

### After
<a href="https://cl.ly/f5afe075ec1a" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/1E2w1A3N422u3k1f0U3Z/Screen%20Shot%202019-09-19%20at%2012.13.17%20PM.png" style="display: block;height: auto;width: 100%;"/></a>

<a href="https://cl.ly/ccaccb0722a0" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/3k2M0z430D001A0b340N/Screen%20Shot%202019-09-19%20at%2012.12.36%20PM.png" style="display: block;height: auto;width: 100%;"/></a>