### PR TITLE
Optimize to_field 'parent_unittitles_ssm'

### DIFF
--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -311,11 +311,10 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
 
     # other components
     if parent_ssm && components
-      ancestors = parent_ssm.drop(1).map{ |x| [x] }
-      accumulator.concat components.select { |c| ancestors.include? c['ref_ssi'] }.flat_map{ |c| c['normalized_title_ssm'] }
+      ancestors = parent_ssm.drop(1).map { |x| [x] }
+      accumulator.concat components.select { |c| ancestors.include? c['ref_ssi'] }.flat_map { |c| c['normalized_title_ssm'] }
     end
   end
-
 
   to_field 'parent_unittitles_teim' do |_record, accumulator, context|
     accumulator.concat context.output_hash['parent_unittitles_ssm']

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -303,16 +303,19 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
     accumulator << context.output_hash['parent_ssm'].last
   end
 
-  to_field 'parent_unittitles_ssm' do |_record, accumulator, context|
-    ## Top level document
+  to_field 'parent_unittitles_ssm' do |_rec, accumulator, context|
+    # top level document
     accumulator.concat context.clipboard[:parent].output_hash['normalized_title_ssm']
-    ## Other components
-    context.output_hash['parent_ssm']&.drop(1)&.each do |id|
-      accumulator.concat Array
-        .wrap(context.clipboard[:parent].output_hash['components'])
-        .select { |c| c['ref_ssi'] == [id] }.map { |c| c['normalized_title_ssm'] }.flatten
+    parent_ssm = context.output_hash['parent_ssm']
+    components = context.clipboard[:parent].output_hash['components']
+
+    # other components
+    if parent_ssm && components
+      ancestors = parent_ssm.drop(1).map{ |x| [x] }
+      accumulator.concat components.select { |c| ancestors.include? c['ref_ssi'] }.flat_map{ |c| c['normalized_title_ssm'] }
     end
   end
+
 
   to_field 'parent_unittitles_teim' do |_record, accumulator, context|
     accumulator.concat context.output_hash['parent_unittitles_ssm']


### PR DESCRIPTION
Quick benchmarking showed `parent_unittitles_ssm` to be taking up a huge proportion of the indexing time. This refactor speeds things up some.

It has larger effects with more heavily-nested documents.

`bx rake arclight:index FILE=../data/ead/umich-bhl/umich-bhl-2014150.xml` (7.3MB)
* Master (as of 20190920 5pm): 950 seconds
* This branch: 550 seconds (52% of master branch time)

`bx rake arclight:index FILE=../data/ead/InU-ewv/VAD1751.xml` (11MB)
* Master: 243 seconds
* This branch:  179 seconds (74% of master branch time)

(umich-bhl-9677.xml is the file that took @mejackreed 6,000 seconds as per https://code4lib.slack.com/archives/C43V2KVTM/p1568145216166500, so I'm not sure what I'm doing differently -- this is just on my desktop Mac)

I'm 99% sure the refactor is producing identical data (checked by indexing with both methods against a few files) but if someone else could take a look that'd be great.
