### PR TITLE
Update various heading around repositories and search results

### DIFF
--- a/app/assets/stylesheets/arclight/modules/repository_card.scss
+++ b/app/assets/stylesheets/arclight/modules/repository_card.scss
@@ -11,13 +11,12 @@
       padding-left: 0;
     }
 
-    h2 {
-      font-size: $h5-font-size;
-      margin-bottom: $spacer;
-    }
-
     address {
       margin-bottom: 0;
+    }
+
+    .repo-name {
+      margin-bottom: $spacer;
     }
 
     .al-repository-contact,

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -85,6 +85,17 @@ module ArclightHelper
     )
   end
 
+  # Returns the i18n-ed string to be used as the h1 in search results
+  def search_results_header_text
+    if (repo = repository_faceted_on).present?
+      t('arclight.search.repository_header', repository: repo.name)
+    elsif collection_active?
+      t('arclight.search.collections_header')
+    else
+      t('blacklight.search.header')
+    end
+  end
+
   ##
   # Classes used for customized show page in arclight
   def custom_show_content_classes

--- a/app/views/arclight/repositories/_repository.html.erb
+++ b/app/views/arclight/repositories/_repository.html.erb
@@ -6,9 +6,9 @@
       </div>
 
       <div class="col-sm-12 col-lg-10 al-repository-information">
-        <h2>
+        <%= content_tag(params[:id] == repository.slug ? :h1 : :h2, class: 'h5 repo-name') do %>
           <%= link_to_unless(params[:id] == repository.slug, repository.name, arclight_engine.repository_path(repository.slug)) %>
-        </h2>
+        <% end %>
         <div class='row no-gutters justify-content-md-center'>
           <div class='col-4 col-md-3 al-repository-contact'>
             <address>

--- a/app/views/arclight/repositories/index.html.erb
+++ b/app/views/arclight/repositories/index.html.erb
@@ -1,3 +1,5 @@
+<h1 class="sr-only"><%= t('arclight.repositories') %></h1>
+
 <div class="al-repositories">
   <%= render 'shared/breadcrumbs' %>
   <%= render @repositories %>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,5 +1,3 @@
-<h2 class="sr-only top-content-title"><%= t('blacklight.search.search_results_header') %></h2>
-
 <% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params), :application_name => application_name) %>
 
 <% content_for(:head) do %>
@@ -9,6 +7,7 @@
 <% end %>
 
 <% content_for(:container_header) do %>
+  <h1 class="sr-only top-content-title"><%= t('blacklight.search.header') %></h1>
   <%= render 'shared/breadcrumbs' %>
   <%= render 'search_results_repository' %>
   <%= render 'collection_count' %>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <% content_for(:container_header) do %>
-  <h1 class="sr-only top-content-title"><%= t('blacklight.search.header') %></h1>
+  <h1 class="sr-only top-content-title"><%= search_results_header_text %></h1>
   <%= render 'shared/breadcrumbs' %>
   <%= render 'search_results_repository' %>
   <%= render 'collection_count' %>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -17,6 +17,9 @@ en:
       home: Home
       repositories: Repositories
       search_results: Search results
+    search:
+      collections_header: Collections
+      repository_header: 'Collections : [%{repository}]'
     show_breadcrumb_label: Repository
     truncation:
       view_less: view less ▼

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -9,6 +9,7 @@ en:
       scope_and_contents: Scope and Contents
       view_all: View
     masthead_heading: Archival Collections at Institution
+    repositories: Repositories
     request:
       container: Request
     routes:

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -306,6 +306,37 @@ RSpec.describe ArclightHelper, type: :helper do
     end
   end
 
+  describe '#search_results_header_text' do
+    let(:text) { helper.search_results_header_text }
+
+    context 'when searching within a repository' do
+      before do
+        expect(helper).to receive_messages(
+          repository_faceted_on: instance_double('Arclight::Repostory', name: 'Repository Name')
+        )
+      end
+
+      it { expect(text).to eq 'Collections : [Repository Name]' }
+    end
+
+    context 'when searching all collections' do
+      before do
+        expect(helper).to receive_messages(
+          facets_from_request: [],
+          search_state: instance_double(
+            'Blacklight::SearchState', params_for_search: { 'f' => { 'level_sim' => ['Collection'] } }
+          )
+        )
+      end
+
+      it { expect(text).to eq 'Collections' }
+    end
+
+    context 'all other non-special search behavior' do
+      it { expect(text).to eq 'Search' }
+    end
+  end
+
   describe 'document_header_icon' do
     let(:document) { SolrDocument.new('level_ssm': ['collection']) }
 


### PR DESCRIPTION
Closes #834 

## Repositories List
<img width="426" alt="repositories-landing" src="https://user-images.githubusercontent.com/96776/65367591-84e4e600-dbe8-11e9-83fc-91fdbb6bf655.png">

## Single Repository Display
<img width="551" alt="repository-show" src="https://user-images.githubusercontent.com/96776/65367590-84e4e600-dbe8-11e9-9cf2-e12b296fc413.png">

## Standard search result
<img width="636" alt="standard-search" src="https://user-images.githubusercontent.com/96776/65367587-84e4e600-dbe8-11e9-984f-66fdfff8070a.png">

## Collections Search
<img width="683" alt="collections-search" src="https://user-images.githubusercontent.com/96776/65367588-84e4e600-dbe8-11e9-9dc2-6a79200ea88c.png">

## View All Collections (from repository)
<img width="807" alt="search-within-repo" src="https://user-images.githubusercontent.com/96776/65367589-84e4e600-dbe8-11e9-8ea8-02ff1df11e54.png">

This last one seems potentially suspect to me since we're now getting the name of the repository as an `<h2>` there (since all those partials are shared).  Not sure if that should be a heading at all or not.
