### PR TITLE
Bugfix for nested component browse UI when components are numbered (e…

### DIFF
--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -353,8 +353,8 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
   to_field 'has_online_content_ssim', extract_xpath('.//dao') do |_record, accumulator|
     accumulator.replace([accumulator.any?])
   end
-  to_field 'child_component_count_isim', extract_xpath('c') do |_record, accumulator|
-    accumulator.replace([accumulator.length])
+  to_field 'child_component_count_isim' do |record, accumulator|
+    accumulator << NokogiriXpathExtensions.new.is_component(record.children).count
   end
 
   to_field 'ref_ssm' do |record, accumulator|

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -231,16 +231,21 @@ describe 'EAD 2 traject indexing', type: :feature do
         expect(nested_component['parent_unittitles_ssm']).to eq ['Large collection sample, 1843-1872', 'File 1']
       end
     end
+  end
 
-    context 'with nested numbered c componenets' do
-      let(:fixture_path) do
-        Arclight::Engine.root.join('spec', 'fixtures', 'ead', 'nlm', 'ncaids544-id-test.xml')
-      end
-      let(:nested_component) { result['components'].find { |c| c['id'] == ['ncaids544-testd0e631'] } }
+  describe 'nested numbered c components' do
+    let(:fixture_path) do
+      Arclight::Engine.root.join('spec', 'fixtures', 'ead', 'nlm', 'ncaids544-id-test.xml')
+    end
+    let(:component_with_descendants) { result['components'].find { |c| c['id'] == ['ncaids544-testd0e452'] } }
+    let(:nested_component) { result['components'].find { |c| c['id'] == ['ncaids544-testd0e631'] } }
 
-      it 'correctly gets the component levels' do
-        expect(nested_component['component_level_isim']).to eq [3]
-      end
+    it 'counts child components' do
+      expect(component_with_descendants['child_component_count_isim']).to eq [9]
+    end
+
+    it 'correctly gets the component levels' do
+      expect(nested_component['component_level_isim']).to eq [3]
     end
   end
 


### PR DESCRIPTION
….g., <c03>). Fixes #817. Related to #852.