### PR TITLE
Wrap breadcrumb separator in aria-hidden span

### DIFF
--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -3,6 +3,16 @@
 ##
 # Generic Helpers used in Arclight
 module ArclightHelper
+  def aria_hidden_breadcrumb_separator
+    safe_join(
+      [
+        '<span aria-hidden="true">'.html_safe,
+        t('arclight.breadcrumb_separator'),
+        '</span>'.html_safe
+      ]
+    )
+  end
+
   ##
   # @param [SolrDocument]
   def parents_to_links(document)
@@ -14,7 +24,7 @@ module ArclightHelper
       link_to parent.label, solr_document_path(parent.global_id)
     end
 
-    safe_join(breadcrumb_links, t('arclight.breadcrumb_separator'))
+    safe_join(breadcrumb_links, aria_hidden_breadcrumb_separator)
   end
 
   ##
@@ -37,7 +47,7 @@ module ArclightHelper
 
     safe_join(
       breadcrumb_links,
-      t('arclight.breadcrumb_separator')
+      aria_hidden_breadcrumb_separator
     )
   end
 
@@ -49,7 +59,7 @@ module ArclightHelper
 
     safe_join(parents.slice(1, 999).map do |parent|
       link_to parent.label, solr_document_path(parent.global_id)
-    end, t('arclight.breadcrumb_separator'))
+    end, aria_hidden_breadcrumb_separator)
   end
 
   ##
@@ -64,7 +74,7 @@ module ArclightHelper
     safe_join(
       [
         parent_link,
-        t('arclight.breadcrumb_separator'),
+        aria_hidden_breadcrumb_separator,
         '&hellip;'.html_safe
       ]
     )

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,13 +1,13 @@
 <div class='al-search-breadcrumb'>
   <%= link_to t('arclight.routes.home'), root_path %>
-  <%= t('arclight.breadcrumb_separator') %>
+  <span aria-hidden="true"><%= t('arclight.breadcrumb_separator') %></span>
   <% if collection_active? %>
     <%= t('arclight.routes.collections') %>
   <% elsif on_repositories_index? %>
     <%= t('arclight.routes.repositories') %>
   <% elsif on_repositories_show? %>
     <%= link_to t('arclight.routes.repositories'), arclight_engine.repositories_path %>
-    <%= t('arclight.breadcrumb_separator') %>
+    <span aria-hidden="true"><%= t('arclight.breadcrumb_separator') %></span>
     <%= @repository.name %>
   <% else %>
     <%= t('arclight.routes.search_results') %>

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe ArclightHelper, type: :helper do
       expect(helper.parents_to_links(document)).to include solr_document_path('abc123ghi')
     end
     it 'properly delimited' do
-      expect(helper.parents_to_links(document)).to include '»'
+      expect(helper.parents_to_links(document)).to include '<span aria-hidden="true"> » </span>'
       expect(helper.parents_to_links(SolrDocument.new)).not_to include '»'
     end
   end
@@ -219,7 +219,7 @@ RSpec.describe ArclightHelper, type: :helper do
       expect(helper.component_parents_to_links(document)).to include solr_document_path('abc123ghi')
     end
     it 'properly delimited' do
-      expect(helper.component_parents_to_links(document)).to include '»'
+      expect(helper.component_parents_to_links(document)).to include '<span aria-hidden="true"> » </span>'
     end
   end
 
@@ -238,7 +238,7 @@ RSpec.describe ArclightHelper, type: :helper do
         expect(helper.regular_compact_breadcrumbs(document)).to include 'my repository'
         expect(helper.regular_compact_breadcrumbs(document)).to include 'DEF'
         expect(helper.regular_compact_breadcrumbs(document)).to include solr_document_path('abc123def')
-        expect(helper.regular_compact_breadcrumbs(document)).to include '»'
+        expect(helper.regular_compact_breadcrumbs(document)).to include '<span aria-hidden="true"> » </span>'
         expect(helper.regular_compact_breadcrumbs(document)).not_to include '&hellip;'
       end
     end
@@ -256,7 +256,7 @@ RSpec.describe ArclightHelper, type: :helper do
       it 'links to the top level component and does include an ellipsis' do
         expect(helper.regular_compact_breadcrumbs(document)).to include 'DEF'
         expect(helper.regular_compact_breadcrumbs(document)).to include solr_document_path('abc123def')
-        expect(helper.regular_compact_breadcrumbs(document)).to include '»'
+        expect(helper.regular_compact_breadcrumbs(document)).to include '<span aria-hidden="true"> » </span>'
         expect(helper.regular_compact_breadcrumbs(document)).to include '&hellip;'
       end
     end
@@ -300,7 +300,7 @@ RSpec.describe ArclightHelper, type: :helper do
       it 'links to the top level component and joins it with an ellipsis' do
         expect(helper.component_top_level_parent_to_links(document)).to include 'GHI'
         expect(helper.component_top_level_parent_to_links(document)).to include solr_document_path('abc123ghi')
-        expect(helper.component_top_level_parent_to_links(document)).to include '»'
+        expect(helper.component_top_level_parent_to_links(document)).to include '<span aria-hidden="true"> » </span>'
         expect(helper.component_top_level_parent_to_links(document)).to include '&hellip;'
       end
     end


### PR DESCRIPTION
Should not be read by screen readers.

Fixes #854.