### PR TITLE
Add sr-only label to bookmark icon

### DIFF
--- a/app/views/catalog/_arclight_bookmark_control.html.erb
+++ b/app/views/catalog/_arclight_bookmark_control.html.erb
@@ -10,8 +10,8 @@
                  class: 'bookmark-toggle col-auto',
                  data: {
                    'doc-id' => document.id,
-                   present: blacklight_icon(:bookmark),
-                   absent: blacklight_icon(:bookmark),
+                   present: "#{blacklight_icon(:bookmark)}<span class=\"sr-only\">#{t('blacklight.search.bookmarks.present')}",
+                   absent: "#{blacklight_icon(:bookmark)}<span class=\"sr-only\">#{t('blacklight.search.bookmarks.absent')}",
                    inprogress: t('blacklight.search.bookmarks.inprogress')
                 }) do %>
       <%= submit_tag(t('blacklight.bookmarks.add.button'),
@@ -24,8 +24,8 @@
                  class: "bookmark-toggle col-auto",
                  data: {
                    'doc-id' => document.id,
-                   present: blacklight_icon(:bookmark),
-                   absent: blacklight_icon(:bookmark),
+                   present: "#{blacklight_icon(:bookmark)}<span class=\"sr-only\">#{t('blacklight.search.bookmarks.present')}",
+                   absent: "#{blacklight_icon(:bookmark)}<span class=\"sr-only\">#{t('blacklight.search.bookmarks.absent')}",
                    inprogress: t('blacklight.search.bookmarks.inprogress')
                 }) do %>
       <%= submit_tag(t('blacklight.bookmarks.remove.button'),


### PR DESCRIPTION
Fixes #862.

This works but it is ugly. Given the form_tag context, I'm not entirely sure there's a prettier way to do it, but I imagine there is something I don't know that could help.