### PR TITLE
Make page <title> match its <h1> #842

### DIFF
--- a/app/views/arclight/repositories/index.html.erb
+++ b/app/views/arclight/repositories/index.html.erb
@@ -1,4 +1,5 @@
 <div class="al-repositories">
+  <% @page_title = t('arclight.views.repositories.title') %>
   <%= render 'shared/breadcrumbs' %>
   <%= render @repositories %>
 </div>

--- a/app/views/arclight/repositories/show.html.erb
+++ b/app/views/arclight/repositories/show.html.erb
@@ -1,3 +1,4 @@
+<% @page_title = t(:'arclight.views.repositories.show', name: @repository.name) %>
 <%= render 'shared/breadcrumbs' %>
 <%= render @repository %>
 <div class="row al-repository-show-header">

--- a/app/views/catalog/_home.html.erb
+++ b/app/views/catalog/_home.html.erb
@@ -1,1 +1,1 @@
-
+<% @page_title = t('arclight.views.home.title') %>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -21,6 +21,8 @@ en:
       view_less: view less ▼
       view_more: view more ▶
     views:
+      home:
+        title: Archival Collections at Institution - Arclight
       index:
         all_group_results: view all %{count}
         all_results: All results
@@ -43,6 +45,8 @@ en:
           one: 1 collection
           other: "%{count} collections"
           zero: No collections
+        show: "%{name} - Arclight"
+        title: Repositories - Arclight
         view_all_collections: View all of our collections
         view_more: View more
       show:

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Home Page', type: :feature do
     expect(page).to have_css '.nav-link', text: 'Collections'
   end
   it 'has a title of Arclight' do
-    expect(page.body).to include('<title>Arclight</title>')
+    expect(page.body).to include('<title>Archival Collections at Institution - Arclight</title>')
   end
 
   context 'search dropdown' do

--- a/spec/features/repositories_page_spec.rb
+++ b/spec/features/repositories_page_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'Repositores Page', type: :feature do
     within '.al-repositories' do
       expect(page).to have_css('.al-repository h2 a', text: 'My Repository')
     end
+
+    expect(page.body).to include('<title>Repositories - Arclight</title>')
   end
 
   describe 'Repostory Show Page' do
@@ -45,6 +47,14 @@ RSpec.describe 'Repositores Page', type: :feature do
           text: 'Stanford University Libraries. Special Collections and University Archives'
         )
       end
+    end
+
+    it 'has a title title starting with the repository name ' do
+      visit '/repositories'
+
+      click_link 'Stanford University Libraries. Special Collections and University Archives'
+
+      expect(page.body).to include('<title>Stanford University Libraries. Special Collections and University Archives - Arclight</title>')
     end
   end
 end


### PR DESCRIPTION
Closes #842

Issue is part of #820

Adjusted the titles for these pages:

  Home page: <title>Archival Collections at Institution - Arclight</title>
  Repositories: <title>Repositories - Arclight</title>
https://arclight-demo.projectblacklight.org/repositories
  Individual repository: <title>[repository name] - Arclight</title>
https://arclight-demo.projectblacklight.org/repositories/duke-rubenstein