### PR TITLE
add nav landmark to breadcrumbs

### DIFF
--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,4 +1,4 @@
-<div class='al-search-breadcrumb'>
+<div class='al-search-breadcrumb' role='navigation' aria-label='breadcrumb'>
   <%= link_to t('arclight.routes.home'), root_path %>
   <span aria-hidden="true"><%= t('arclight.breadcrumb_separator') %></span>
   <% if collection_active? %>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,4 +1,4 @@
-<div class='al-search-breadcrumb' role='navigation' aria-label='breadcrumb'>
+<div class='al-search-breadcrumb' role='navigation' aria-label=<%= t('arclight.breadcrumbs.aria_label') %>>
   <%= link_to t('arclight.routes.home'), root_path %>
   <span aria-hidden="true"><%= t('arclight.breadcrumb_separator') %></span>
   <% if collection_active? %>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -1,9 +1,9 @@
 ---
 en:
   arclight:
+    breadcrumb_separator: " » "
     breadcrumbs:
       aria_label: breadcrumb
-    breadcrumb_separator: " » "
     date_range_histogram:
       hide: Hide date distribution
       show: Show date distribution

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -1,6 +1,8 @@
 ---
 en:
   arclight:
+    breadcrumbs:
+      aria_label: breadcrumb
     breadcrumb_separator: " » "
     date_range_histogram:
       hide: Hide date distribution

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -4,9 +4,6 @@ en:
     breadcrumb_separator: " » "
     breadcrumbs:
       aria_label: breadcrumb
-    date_range_histogram:
-      hide: Hide date distribution
-      show: Show date distribution
     hierarchy:
       scope_and_contents: Scope and Contents
       view_all: View
@@ -61,12 +58,12 @@ en:
           title: Collection context navigation
         download:
           default: Download
-          ead: Collection EAD
-          pdf: Collection PDF
+          ead: Download EAD
+          pdf: Download finding aid
         download_with_size:
           default: Download (%{size})
-          ead: Collection EAD (%{size})
-          pdf: Collection PDF (%{size})
+          ead: Download EAD (%{size})
+          pdf: Download finding aid (%{size})
         no_contents: No content inventory
         no_online_content: No online content
         online_content: Online content


### PR DESCRIPTION
closes #839 
Part of #820

 Change

> div class="al-search-breadcrumb" 

to

> nav class="al-search-breadcrumb" role="navigation" aria-label="breadcrumb"

<a href="https://cl.ly/5d67b12444e4" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/1n0z29301v2O2X062Q19/Screen%20Shot%202019-09-26%20at%2011.23.25%20AM.png" style="display: block;height: auto;width: 100%;"/></a>