### PR TITLE
add role navigation and aria label to breadcrumbs

### DIFF
--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,4 +1,4 @@
-<div class='al-search-breadcrumb'>
+<div class='al-search-breadcrumb' role='navigation' aria-label=<%= t('arclight.breadcrumbs.aria_label') %> >
   <%= link_to t('arclight.routes.home'), root_path %>
   <span aria-hidden="true"><%= t('arclight.breadcrumb_separator') %></span>
   <% if collection_active? %>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -2,6 +2,8 @@
 en:
   arclight:
     breadcrumb_separator: " » "
+    breadcrumbs:
+      aria_label: breadcrumb
     hierarchy:
       scope_and_contents: Scope and Contents
       view_all: View

--- a/spec/arclight_spec.rb
+++ b/spec/arclight_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Arclight do
   it 'has a version number' do
     expect(Arclight::VERSION).not_to be nil
   end
+
   describe 'Custom CatalogController field accessors' do
     subject(:custom_fields) do
       Arclight::Engine.config.catalog_controller_field_accessors

--- a/spec/controllers/arclight/repositories_controller_spec.rb
+++ b/spec/controllers/arclight/repositories_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Arclight::RepositoriesController, type: :controller do
     ENV['REPOSITORY_FILE'] = 'spec/fixtures/config/repositories.yml'
   end
 
-  context '#index' do
+  describe '#index' do
     it 'displays the repositories' do
       get :index
       expect(response).to be_success
@@ -23,7 +23,7 @@ RSpec.describe Arclight::RepositoriesController, type: :controller do
     end
   end
 
-  context '#show' do
+  describe '#show' do
     it 'looks up the repository detail page' do
       get :show, params: { id: 'nlm' }
       repo = controller.instance_variable_get(:@repository)
@@ -33,6 +33,7 @@ RSpec.describe Arclight::RepositoriesController, type: :controller do
       expect(collections.first).to be_an(SolrDocument)
       expect(collections.find { |c| c.id == 'aoa271' }.unitid).to eq 'MS C 271'
     end
+
     it 'raises RecordNotFound if non-registered slug' do
       expect { get :show, params: { id: 'not-registered' } }.to raise_error(
         ActiveRecord::RecordNotFound

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe CatalogController, type: :controller do
         get :index, params: { q: 'foo', view: 'hierarchy' }
         expect(session[:history]).to be_empty
       end
+
       it 'does not store a preferred_view' do
         allow(controller).to receive(:search_results)
         session[:preferred_view] = 'list'
@@ -26,6 +27,7 @@ RSpec.describe CatalogController, type: :controller do
         get :index, params: { q: 'foo', view: 'online_contents' }
         expect(session[:history]).to be_empty
       end
+
       it 'does not store a preferred_view' do
         allow(controller).to receive(:search_results)
         session[:preferred_view] = 'list'
@@ -40,6 +42,7 @@ RSpec.describe CatalogController, type: :controller do
         get :index, params: { q: 'foo', view: 'list' }
         expect(session[:history]).not_to be_empty
       end
+
       it 'stores a preferred_view' do
         allow(controller).to receive(:search_results)
         session[:preferred_view] = 'list'

--- a/spec/controllers/concerns/arclight/field_config_helpers_spec.rb
+++ b/spec/controllers/concerns/arclight/field_config_helpers_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Arclight::FieldConfigHelpers do
       it do
         expect(helper.request_config_present(nil, document_with_repository)).to be true
       end
+
       context 'when no request config is present' do
         it do
           expect(helper.request_config_present(nil, document_without_request)).to be false

--- a/spec/features/arclight_spec.rb
+++ b/spec/features/arclight_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Arclight', type: :feature do
     visit search_catalog_path q: '', search_field: 'all_fields'
     expect(page).to have_css '.document', count: 10
   end
+
   describe 'eadid with a period' do
     it 'is visitable with a hyphen' do
       visit solr_document_path('m0198-xmlaspace_ref11_d0s')

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -196,6 +196,7 @@ RSpec.describe 'Collection Page', type: :feature do
         expect(page).to have_css '#contents', visible: false
         expect(page).to have_css '#access', visible: true
       end
+
       it 'clicking online contents toggles visibility' do
         expect(page).to have_css '#context', visible: true
         expect(page).to have_css '#online-content', visible: false
@@ -262,9 +263,11 @@ RSpec.describe 'Collection Page', type: :feature do
     it 'contents are not visible by default' do
       expect(page).to have_css '#contents', visible: false
     end
+
     it 'context is visible' do
       expect(page).to have_css '#context', visible: true
     end
+
     describe 'interactions', js: true do
       before { click_link 'Contents' }
       it 'contents contain linked level 1 components' do
@@ -273,6 +276,7 @@ RSpec.describe 'Collection Page', type: :feature do
         end
         expect(page).to have_css '.show-document', text: /Series I: Administrative Records/
       end
+
       it 'component metadata' do
         within '#contents' do
           within '.document-position-0 ' do
@@ -283,6 +287,7 @@ RSpec.describe 'Collection Page', type: :feature do
           end
         end
       end
+
       it 'sub components are viewable and expandable' do
         within '#contents' do
           within '.document-position-0' do
@@ -303,6 +308,7 @@ RSpec.describe 'Collection Page', type: :feature do
           end
         end
       end
+
       it 'includes the number of direct children of the component' do
         within '.document-position-0' do
           expect(page).to have_css(
@@ -311,6 +317,7 @@ RSpec.describe 'Collection Page', type: :feature do
           )
         end
       end
+
       it 'has bookmark controls' do
         expect(page).to have_css 'form.bookmark-toggle', count: 8
       end

--- a/spec/features/compact_search_results_spec.rb
+++ b/spec/features/compact_search_results_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Compact Search Results', type: :feature do
       expect(page).to have_css 'form.bookmark-toggle'
     end
   end
+
   it 'Shows highlights in compact view' do
     visit search_catalog_path q: 'william root', search_field: 'name'
     click_link 'Compact'

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe 'Component Page', type: :feature do
     it 'includes names dt subheading text' do
       expect(page).to have_css('dt.blacklight-names_ssim', text: 'Names:')
     end
+
     it 'includes names dd link text' do
       expect(page).to have_css('dd a', text: "Robertson's Crab House")
     end
@@ -72,6 +73,7 @@ RSpec.describe 'Component Page', type: :feature do
     it 'includes places dt subheading text' do
       expect(page).to have_css('dt.blacklight-places_ssim', text: 'Places:')
     end
+
     it 'includes places dd link text' do
       expect(page).to have_css('dd a', text: 'Popes Creek (Md.)')
     end
@@ -83,6 +85,7 @@ RSpec.describe 'Component Page', type: :feature do
     it 'includes subjects dt subheading text' do
       expect(page).to have_css('dt.blacklight-access_subjects_ssim', text: 'Subjects:')
     end
+
     it 'includes subjects dd link text' do
       expect(page).to have_css('dd.blacklight-access_subjects_ssim a', text: 'Records')
     end
@@ -94,12 +97,14 @@ RSpec.describe 'Component Page', type: :feature do
     it 'uses our rules for displaying containers' do
       expect(page).to have_css('dd', text: 'Box 1, Folder 4-5')
     end
+
     it 'shows misc notes' do
       expect(page).to have_css('dt', text: 'Appraisal information')
       expect(page).to have_css('dd', text: /^Materials for this group were selected/)
       expect(page).to have_css('dt', text: 'Custodial history')
       expect(page).to have_css('dd', text: /^These papers were maintained by the staff/)
     end
+
     it 'multivalued notes are rendered as paragaphs' do
       within 'dd.blacklight-appraisal_ssm' do
         expect(page).to have_css('p', count: 2)
@@ -118,6 +123,7 @@ RSpec.describe 'Component Page', type: :feature do
         expect(page).not_to have_css 'form.bookmark-toggle' # no bookmarks
       end
     end
+
     context 'siblings and highlighted self' do
       it 'has all siblings' do
         within '#collection-context' do
@@ -156,6 +162,7 @@ RSpec.describe 'Component Page', type: :feature do
         expect(page).to have_css '.document-title-heading', text: 'Constitution and by-laws - drafts, 1902-1904'
       end
     end
+
     context 'duplicate titles' do
       let(:doc_id) { 'lc0100aspace_c5ef89d4ae68bb77e7c641f3edb3f1c8' }
 
@@ -173,6 +180,7 @@ RSpec.describe 'Component Page', type: :feature do
       expect(page).to have_css 'dt', text: 'LOCATION OF THIS COLLECTION:'
       expect(page).to have_css 'dd', text: 'Building 38, Room 1E-21'
     end
+
     it 'has a restrictions and access' do
       click_link 'Access'
       expect(page).to have_css 'dt', text: 'PARENT RESTRICTIONS:'
@@ -180,6 +188,7 @@ RSpec.describe 'Component Page', type: :feature do
       expect(page).to have_css 'dt', text: 'TERMS OF ACCESS:'
       expect(page).to have_css 'dd', text: /^Copyright was transferred to the public domain./
     end
+
     it 'has a contact' do
       click_link 'Access'
       expect(page).to have_css 'dt', text: 'CONTACT:'

--- a/spec/features/fielded_search_results_spec.rb
+++ b/spec/features/fielded_search_results_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe 'Field-based search results', type: :feature do
   describe 'searches by' do
-    context '#all_fields' do
+    describe '#all_fields' do
       context 'for collections, fielded content is searchable by' do
         it 'title' do
           visit search_catalog_path q: 'student life', search_field: 'all_fields', f: { level_sim: ['Collection'] }
@@ -12,24 +12,28 @@ RSpec.describe 'Field-based search results', type: :feature do
             expect(page).to have_css '.index_title', text: /Stanford University student life photograph album/
           end
         end
+
         it 'biographical note' do
           visit search_catalog_path q: 'boorishness', search_field: 'all_fields'
           within('.document-position-0') do
             expect(page).to have_css '.index_title', text: /Alpha Omega Alpha Archives/
           end
         end
+
         it 'bioghist note' do
           visit search_catalog_path q: 'Hippocratic oath', search_field: 'all_fields'
           within('.document-position-0') do
             expect(page).to have_css '.index_title', text: /Alpha Omega Alpha Archives/
           end
         end
+
         it 'odd note without <p> tag' do
           visit search_catalog_path q: 'Jim Labosier', search_field: 'all_fields'
           within('.document-position-0') do
             expect(page).to have_css '.index_title', text: /Alpha Omega Alpha Archives/
           end
         end
+
         it 'relatedmaterial note with nested structured tags within a <p> tag' do
           visit search_catalog_path q: 'HMD MS ACC 496', search_field: 'all_fields'
           within('.document-position-0') do
@@ -44,12 +48,14 @@ RSpec.describe 'Field-based search results', type: :feature do
             expect(page).to have_css '.index_title', text: /A brief account/
           end
         end
+
         it 'userestrict note' do
           visit search_catalog_path q: 'Original photographs must be handled using gloves', search_field: 'all_fields'
           within('.document-position-0') do
             expect(page).to have_css '.index_title', text: /Series VI: Photographs/
           end
         end
+
         it 'unitid' do
           visit search_catalog_path q: 'MS C 271.VI', search_field: 'all_fields'
           within('.document-position-0') do
@@ -59,7 +65,7 @@ RSpec.describe 'Field-based search results', type: :feature do
       end
     end
 
-    context '#keyword' do
+    describe '#keyword' do
       it 'does a narrow search that has 1 hit' do
         visit search_catalog_path q: '"a brief account"', search_field: 'keyword'
         expect(page).to have_css '.index_title', count: 1
@@ -67,6 +73,7 @@ RSpec.describe 'Field-based search results', type: :feature do
           expect(page).to have_css '.index_title', text: /A brief account/
         end
       end
+
       it 'matches titles with a boost for multiple hits' do
         visit search_catalog_path q: 'alpha omega alpha archives', search_field: 'keyword'
         expect(page).to have_css '.index_title', count: 6

--- a/spec/features/google_form_request_spec.rb
+++ b/spec/features/google_form_request_spec.rb
@@ -22,6 +22,7 @@ xdescribe 'Google Form Request', type: :feature, js: true do
           expect(page).to have_css 'button[type="submit"]', text: 'Request'
         end
       end
+
       context 'repository is not requestable' do
         it 'form is absent' do
           visit solr_document_path 'm0198-xmlaspace_ref14_di4'
@@ -51,6 +52,7 @@ xdescribe 'Google Form Request', type: :feature, js: true do
         expect(page).to have_css 'form[action*="https://docs.google.com"]', count: 22
       end
     end
+
     it 'shows up in context' do
       visit solr_document_path 'aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'
       within '#collection-context' do

--- a/spec/features/grouped_results_spec.rb
+++ b/spec/features/grouped_results_spec.rb
@@ -22,16 +22,19 @@ RSpec.describe 'Grouped search results', type: :feature do
     end
     expect(page).to have_css '.breadcrumb-links a', text: /Series/
   end
+
   it 'displays icons for results' do
     visit search_catalog_path q: 'alpha', group: 'true'
     within '.grouped-documents' do
       expect(page).to have_css '.blacklight-icons', count: 3
     end
   end
+
   it 'has link to repository' do
     visit search_catalog_path q: 'alpha', group: 'true'
     expect(page).to have_css '.al-grouped-repository a', text: /National Library of Medicine/
   end
+
   it 'links to additional results in collection' do
     visit search_catalog_path q: 'alpha', group: 'true'
     expect(page).to have_css '.al-grouped-more', text: /Top 3 results/

--- a/spec/features/highlighted_search_results_spec.rb
+++ b/spec/features/highlighted_search_results_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe 'Highlighted search results', type: :feature do
   describe 'when querying' do
-    context '#all_fields' do
+    describe '#all_fields' do
       it 'highlights the snippets' do
         visit search_catalog_path q: 'student life', search_field: 'all_fields'
         within '.document-position-0' do
@@ -15,12 +15,14 @@ RSpec.describe 'Highlighted search results', type: :feature do
           end
         end
       end
+
       it 'does not highlight the snippets on empty query' do
         visit search_catalog_path q: '', search_field: 'all_fields'
         within '.document-position-0' do
           expect(page).not_to have_css '.al-document-highlight'
         end
       end
+
       it 'does not highlight the snippets on hierarchy query' do
         visit search_catalog_path q: 'student life', search_field: 'all_fields', view: 'hierarchy'
         within '.document-position-0' do
@@ -28,7 +30,7 @@ RSpec.describe 'Highlighted search results', type: :feature do
         end
       end
     end
-    context '#name' do
+    describe '#name' do
       it 'highlights the snippets' do
         visit search_catalog_path q: 'william root', search_field: 'name'
         within '.document-position-0' do

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -7,24 +7,31 @@ RSpec.describe 'Home Page', type: :feature do
   it 'has a custom heading' do
     expect(page).to have_css 'h1', text: 'Archival Collections at Institution'
   end
+
   it 'has a search with a jumbotron' do
     expect(page).to have_css '.jumbotron .search-query-form'
   end
+
   it 'does not have a sidebar' do
     expect(page).not_to have_css '#sidebar'
   end
+
   it 'does not have content' do
     expect(page).not_to have_css '#content'
   end
+
   it 'does have a navbar-nav' do
     expect(page).to have_css '.navbar-nav'
   end
+
   it 'has a Respository link' do
     expect(page).to have_css '.nav-link', text: 'Repositories'
   end
+
   it 'has a Collections link' do
     expect(page).to have_css '.nav-link', text: 'Collections'
   end
+
   it 'has a title of Arclight' do
     expect(page.body).to include('<title>Archival Collections at Institution - Arclight</title>')
   end
@@ -35,6 +42,7 @@ RSpec.describe 'Home Page', type: :feature do
         expect(page).to have_css 'option', text: 'All Fields'
       end
     end
+
     it 'has several fielded' do
       within('.search-field') do
         expect(page).to have_css 'option', text: 'Keyword'

--- a/spec/features/item_breadcrumbs_spec.rb
+++ b/spec/features/item_breadcrumbs_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Item breadcrumb', type: :feature do
     end
     expect(page).to have_css 'h1', text: 'Expansion Plan'
   end
+
   it 'show page breadcrumbs' do
     visit solr_document_path id: 'aoa271aspace_e8755922a9336970292ca817983e7139'
     expect(page).to have_css 'li.breadcrumb-item a', count: 5

--- a/spec/features/many_component_ead_spec.rb
+++ b/spec/features/many_component_ead_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Many component EAD', type: :feature do
         expect(page).to have_css '.blacklight-file', count: 202
       end
     end
+
     it 'includes all children' do
       click_link 'Contents'
       within '#contents' do

--- a/spec/features/masthead_links_spec.rb
+++ b/spec/features/masthead_links_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Masthead links', type: :feature do
         expect(page).not_to have_css 'li.nav-item.active', text: 'Collections'
       end
     end
+
     it 'is active when collection search is activated' do
       visit search_catalog_path f: { level_sim: ['Collection'] }, search_field: 'all_fields'
       within '.al-masthead' do

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Search results', type: :feature do
       visit search_catalog_path q: 'a brief', search_field: 'all_fields'
       expect(page).to have_css '.index_title', text: /A brief account/
     end
+
     it 'renders the expected metadata for a collection' do
       visit search_catalog_path q: '', search_field: 'all_fields'
 
@@ -129,6 +130,7 @@ RSpec.describe 'Search results', type: :feature do
         end
       end
     end
+
     it 'renders the repository card when faceted on repository' do
       visit search_catalog_path f: {
         repository_sim: ['National Library of Medicine. History of Medicine Division']
@@ -138,11 +140,13 @@ RSpec.describe 'Search results', type: :feature do
       expect(page).to have_css('.al-repository')
       expect(page).not_to have_css('.al-repository-extra')
     end
+
     it 'does not include repository card if not faceted on repository' do
       visit search_catalog_path q: '', search_field: 'all_fields'
 
       expect(page).not_to have_css('.al-repository-card')
     end
+
     it 'does not include repository card if faceted on something that is not repository' do
       visit search_catalog_path f: {
         names_ssim: ['Owner of the reel of yellow nylon rope']

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -45,16 +45,19 @@ describe 'EAD 2 traject indexing', type: :feature do
       expect(result['id'].first).to eq 'a0011-xml'
       expect(result['ead_ssi'].first).to eq_ignoring_whitespace 'a0011.xml'
     end
+
     it 'title' do
       %w[title_ssm title_teim].each do |field|
         expect(result[field]).to include_ignoring_whitespace 'Stanford University student life photograph album'
       end
       expect(result['normalized_title_ssm']).to include 'Stanford University student life photograph album, circa 1900-1906'
     end
+
     it 'level' do
       expect(result['level_ssm']).to eq ['collection']
       expect(result['level_sim']).to eq ['Collection']
     end
+
     it 'dates' do
       expect(result['normalized_date_ssm']).to include_ignoring_whitespace 'circa 1900-1906'
       expect(result['unitdate_bulk_ssim']).to be_nil
@@ -118,12 +121,15 @@ describe 'EAD 2 traject indexing', type: :feature do
           expect(first_component[field]).to include 'aspace_ref6_lx4'
         end
       end
+
       it 'id' do
         expect(first_component).to include 'id' => ['a0011-xmlaspace_ref6_lx4']
       end
+
       it 'ead_ssi should be parents' do
         expect(first_component['ead_ssi']).to eq result['ead_ssi']
       end
+
       it 'repository' do
         %w[repository_sim repository_ssm].each do |field|
           expect(first_component[field]).to include 'Stanford University Libraries. Special Collections and University Archives'
@@ -156,11 +162,13 @@ describe 'EAD 2 traject indexing', type: :feature do
           expect(first_component[field]).to include_ignoring_whitespace 'Stanford University student life photograph album, circa 1900-1906'
         end
       end
+
       it 'creator' do
         %w[collection_creator_ssm].each do |field|
           expect(first_component[field]).to equal_array_ignoring_whitespace ['Stanford University']
         end
       end
+
       it 'collection_unitid' do
         expect(first_component['collection_unitid_ssm']).to eq ['A0011']
       end
@@ -379,6 +387,7 @@ describe 'EAD 2 traject indexing', type: :feature do
           expect(component_inheriting_accessrestrict_from_grandparent['parent_access_restrict_ssm'])
             .to include(a_string_matching(/RESTRICTED: Access to these folders requires prior written approval./))
         end
+
         it 'gets accessrestrict from collection' do
           expect(component_inheriting_accessrestrict_from_collection['accessrestrict_ssm']).to be_nil
           expect(component_inheriting_accessrestrict_from_collection['parent_access_restrict_ssm'])
@@ -511,6 +520,7 @@ describe 'EAD 2 traject indexing', type: :feature do
         expect(result['names_ssim']).to include_ignoring_whitespace 'Root, William Webster, 1867-1932'
         expect(result['names_ssim']).to include_ignoring_whitespace 'Robertson\'s Crab House'
       end
+
       it 'indexes all names at any level in a type-specific name field' do
         expect(result['persname_ssm']).to include_ignoring_whitespace 'Anfinsen, Christian B.'
         expect(result['corpname_ssm']).to include_ignoring_whitespace 'Robertson\'s Crab House'

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -197,6 +197,7 @@ RSpec.describe ArclightHelper, type: :helper do
       expect(helper.parents_to_links(document)).to include 'GHI'
       expect(helper.parents_to_links(document)).to include solr_document_path('abc123ghi')
     end
+
     it 'properly delimited' do
       expect(helper.parents_to_links(document)).to include '<span aria-hidden="true"> » </span>'
       expect(helper.parents_to_links(SolrDocument.new)).not_to include '»'
@@ -218,6 +219,7 @@ RSpec.describe ArclightHelper, type: :helper do
       expect(helper.component_parents_to_links(document)).to include 'GHI'
       expect(helper.component_parents_to_links(document)).to include solr_document_path('abc123ghi')
     end
+
     it 'properly delimited' do
       expect(helper.component_parents_to_links(document)).to include '<span aria-hidden="true"> » </span>'
     end
@@ -404,11 +406,12 @@ RSpec.describe ArclightHelper, type: :helper do
       end
     end
   end
-  context '#hierarchy_component_context?' do
+  describe '#hierarchy_component_context?' do
     it 'requires a parameter to enable' do
       allow(helper).to receive(:params).and_return(hierarchy_context: 'component')
       expect(helper.hierarchy_component_context?).to be_truthy
     end
+
     it 'omission is disabled' do
       allow(helper).to receive(:params).and_return({})
       expect(helper.hierarchy_component_context?).to be_falsey

--- a/spec/lib/arclight/repository_spec.rb
+++ b/spec/lib/arclight/repository_spec.rb
@@ -8,20 +8,24 @@ RSpec.describe Arclight::Repository do
       repos = described_class.all
       expect(repos.map(&:slug)).to include 'sample', 'nlm', 'sul-spec'
     end
+
     it '#find_by(slug)' do
       expect(described_class.find_by(slug: 'sample').slug).to eq 'sample'
       expect(described_class.find_by(slug: 'not_there')).to be_nil
       expect { described_class.find_by(slug: nil) }.to raise_error(ArgumentError)
     end
+
     it '#find_by(name)' do
       expect(described_class.find_by(name: 'My Repository').slug).to eq 'sample'
       expect(described_class.find_by(name: 'not_there')).to be_nil
       expect { described_class.find_by(name: nil) }.to raise_error(ArgumentError)
     end
+
     it '#find_by!(slug)' do
       expect(described_class.find_by!(slug: 'sample').slug).to eq 'sample'
       expect { described_class.find_by!(slug: 'not_there') }.to raise_error(ActiveRecord::RecordNotFound)
     end
+
     it '#find_by!(name)' do
       expect(described_class.find_by!(name: 'My Repository').slug).to eq 'sample'
       expect { described_class.find_by!(name: 'not_there') }.to raise_error(ActiveRecord::RecordNotFound)
@@ -34,46 +38,60 @@ RSpec.describe Arclight::Repository do
     it 'in a YAML file' do
       expect(repo.slug).to eq 'sample'
     end
+
     context 'fields' do
       it '#name' do
         expect(repo.name).to eq 'My Repository'
       end
+
       it '#visit_note' do
         expect(repo.visit_note).to eq 'Containers are stored offsite and must be pages 2 to 3 days in advance'
       end
+
       it '#description' do
         expect(repo.description).to eq 'Lorem ipsum'
       end
+
       it '#building' do
         expect(repo.building).to eq 'My Building'
       end
+
       it '#address1' do
         expect(repo.address1).to eq 'My Street Address'
       end
+
       it '#address2' do
         expect(repo.address2).to eq 'My Extra Address'
       end
+
       it '#city' do
         expect(repo.city).to eq 'My City'
       end
+
       it '#state' do
         expect(repo.state).to eq 'My State'
       end
+
       it '#zip' do
         expect(repo.zip).to eq '12345'
       end
+
       it '#country' do
         expect(repo.country).to eq 'My Country'
       end
+
       it '#city_state_zip_country' do
         expect(repo.city_state_zip_country).to eq 'My City, My State 12345, My Country'
       end
+
       it '#phone' do
         expect(repo.phone).to eq '123-456-7890'
       end
+
       it '#contact_info' do
         expect(repo.contact_info).to eq 'My Contact Info'
       end
+
       it '#thumbnail_url' do
         expect(repo.thumbnail_url).to eq 'http://example.com/thumbnail_ABC.jpg'
       end
@@ -82,15 +100,19 @@ RSpec.describe Arclight::Repository do
       it '#request_config_present?' do
         expect(repo.request_config_present?).to be true
       end
+
       it '#request_config_present_for_type? is present' do
         expect(repo.request_config_present_for_type?('google_form')).to be true
       end
+
       it '#request_config_present_for_type? is not present' do
         expect(repo.request_config_present_for_type?('fake_type')).to be false
       end
+
       it '#request_url_for_type' do
         expect(repo.request_url_for_type('google_form')).to eq 'https://docs.google.com/abc123'
       end
+
       it '#request_mappings_for_type' do
         expect(repo.request_mappings_for_type('google_form')).to eq 'collection_name=abc&eadid=123'
       end

--- a/spec/lib/arclight/year_range_spec.rb
+++ b/spec/lib/arclight/year_range_spec.rb
@@ -5,130 +5,157 @@ require 'spec_helper'
 RSpec.describe Arclight::YearRange do
   subject(:range) { described_class.new }
 
-  context '#initialize' do
+  describe '#initialize' do
     it 'takes blanks' do
       expect(described_class.new.years.length).to eq 0
     end
+
     it 'takes ranges' do
       expect(described_class.new(%w[1999 2002/2003]).years.length).to eq 3
     end
   end
 
-  context '#to_year_from_iso8601' do
+  describe '#to_year_from_iso8601' do
     it 'blanks' do
       expect(range.to_year_from_iso8601(nil)).to be_nil
       expect(range.to_year_from_iso8601('   ')).to be_nil
     end
+
     it 'YYYY' do
       expect(range.to_year_from_iso8601('1999')).to eq 1999
     end
+
     it 'YYYY-MM' do
       expect(range.to_year_from_iso8601('1999-01')).to eq 1999
     end
+
     it 'YYYY-MM-DD' do
       expect(range.to_year_from_iso8601('1999-01-02')).to eq 1999
     end
+
     it 'YYYYMM' do
       expect(range.to_year_from_iso8601('199901')).to eq 1999
     end
+
     it 'YYYYMMDD' do
       expect(range.to_year_from_iso8601('19990102')).to eq 1999
     end
+
     it 'tiny YYYY' do
       expect(range.to_year_from_iso8601('1')).to eq 1
     end
   end
 
-  context '#parse_range' do
+  describe '#parse_range' do
     it 'blanks' do
       expect(range.parse_range(nil)).to be_nil
       expect(range.parse_range('   ')).to be_nil
     end
+
     it 'YYYY' do
       expect(range.parse_range('1999')).to eq((1999..1999).to_a)
     end
+
     it 'YYYY/YYYY' do
       expect(range.parse_range('1999/2000')).to eq((1999..2000).to_a)
     end
+
     it 'YYYY-MM/YYYY' do
       expect(range.parse_range('1999-12/2000')).to eq((1999..2000).to_a)
     end
+
     it 'YYYY-MM-DD/YYYY' do
       expect(range.parse_range('1999-12-31/2000')).to eq((1999..2000).to_a)
     end
+
     it 'YYYYMMDD/YYYY' do
       expect(range.parse_range('19991231/2000')).to eq((1999..2000).to_a)
     end
+
     it 'inverted YYYY/YYYY' do
       expect { range.parse_range('1999/1998') }.to raise_error(ArgumentError, /inverted/i)
     end
+
     it 'too large YYYY/YYYY' do
       expect { range.parse_range('1999/9999') }.to raise_error(ArgumentError, /too large/i)
     end
   end
 
-  context '#parse_ranges' do
+  describe '#parse_ranges' do
     it 'empty call' do
       expect(range.parse_ranges([])).to be_empty
     end
+
     it 'single range' do
       expect(range.parse_ranges(%w[1999/2000])).to eq [1999, 2000]
     end
+
     it 'simple multiple ranges' do
       expect(range.parse_ranges(%w[1999/2000 2002/2003])).to eq [1999, 2000, 2002, 2003]
     end
+
     it 'multiple ranges with overlaps' do
       expect(range.parse_ranges(%w[1999/2005 2002/2003 2004/2004])).to eq [1999, 2000, 2001, 2002, 2003, 2004, 2005]
     end
   end
 
-  context '#gaps?' do
+  describe '#gaps?' do
     it 'single year' do
       range << [1999]
       expect(range.gaps?).to be_falsey
     end
+
     it 'simple range' do
       range << [1999, 2000]
       expect(range.gaps?).to be_falsey
     end
+
     it 'multiple ranges with gaps' do
       range << [1999, 2000] << [2002, 2003]
       expect(range.gaps?).to be_truthy
     end
   end
 
-  context '#to_s' do
+  describe '#to_s' do
     it 'no years' do
       expect(described_class.new.to_s).to be_nil
     end
+
     it 'single year' do
       range << [1999]
       expect(range.to_s).to eq '1999'
     end
+
     it 'simple range' do
       range << [1999, 2000]
       expect(range.to_s).to eq '1999-2000'
     end
+
     it 'large range' do
       range << (1900..2000).to_a
       expect(range.to_s).to eq '1900-2000'
     end
+
     it 'multiple ranges' do
       range << [1999, 2000] << [2001, 2002, 2003] << [2004]
       expect(range.to_s).to eq '1999-2004'
     end
+
     it 'multiple ranges with single-year runs' do
       range << [1999] << [2002] << [2004]
       expect(range.to_s).to eq '1999, 2002, 2004'
     end
+
     it 'multiple ranges with single-year gaps' do
       range << [1999, 2000] << [2002]
       expect(range.to_s).to eq '1999-2000, 2002'
     end
+
     it 'multiple ranges with multi-year gaps and short run' do
       range << [1999] << [2002]
       expect(range.to_s).to eq '1999, 2002'
     end
+
     it 'multiple ranges with multi-year gaps and long run' do
       range << [1999, 2000] << [2002, 2003]
       expect(range.to_s).to eq '1999-2000, 2002-2003'

--- a/spec/models/arclight/parents_spec.rb
+++ b/spec/models/arclight/parents_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Arclight::Parents do
       it 'returns an instance of itself' do
         expect(good_instance).to be_an described_class
       end
+
       it 'values are appropriately set' do
         expect(good_instance.ids).to eq %w[def ghi]
         expect(good_instance.labels).to eq %w[DEF GHI]
@@ -49,12 +50,15 @@ RSpec.describe Arclight::Parents do
       it 'returns an array' do
         expect(good_instance.as_parents).to be_an Array
       end
+
       it 'the array length equals ids length' do
         expect(good_instance.as_parents.length).to eq good_instance.ids.length
       end
+
       it 'each item in array is an Arclight::Parent' do
         expect(good_instance.as_parents).to all(be_an(Arclight::Parent))
       end
+
       it 'the containing parents have the correct data' do
         expect(good_instance.as_parents.first.id).to eq 'def'
         expect(good_instance.as_parents.first.label).to eq 'DEF'

--- a/spec/models/arclight/requests/aeon_web_ead_spec.rb
+++ b/spec/models/arclight/requests/aeon_web_ead_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Arclight::Requests::AeonWebEad do
     it 'converts string from config to hash' do
       expect(form_mapping).to be_an Hash
     end
+
     it 'has valid key/value pairs' do
       expect(form_mapping).to include('Action' => '10', 'Form' => '31', 'Value' => 'http://example.com/sample.xml')
     end

--- a/spec/models/arclight/requests/google_form_spec.rb
+++ b/spec/models/arclight/requests/google_form_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Arclight::Requests::GoogleForm do
     it 'converts string from config to hash' do
       expect(form_mapping).to be_an Hash
     end
+
     it 'has valid key/value pairs' do
       expect(form_mapping).to include('collection_name' => 'abc', 'eadid' => '123')
     end

--- a/spec/routing/arclight/repositories_spec.rb
+++ b/spec/routing/arclight/repositories_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Vanity repositories routes', type: :routing do
         action: 'index'
       )
     end
+
     it '#show' do
       expect(get: '/repositories/my-slug').to route_to(
         controller: 'arclight/repositories',

--- a/spec/views/repositories/index.html.erb_spec.rb
+++ b/spec/views/repositories/index.html.erb_spec.rb
@@ -18,46 +18,56 @@ RSpec.describe 'arclight/repositories/index', type: :view do
     it 'has the header class' do
       expect(rendered).to have_css('.al-repositories', count: 1)
     end
+
     it 'has the proper title' do
       within('.al-repository:nth-of-type(1)') do
         expect(rendered).to have_css('h2', text: /My Repository/)
         expect(rendered).to have_css('h2 a @href', text: '/repositories/sample')
       end
     end
+
     it 'has the four sections' do
       expect(rendered).to have_css('.al-repository', count: 5)
       %w[thumbnail contact description].each do |f|
         expect(rendered).to have_css(".al-repository-#{f}", count: 5)
       end
     end
+
     it 'has the correct address information' do
       %w[address1 city_state_zip_country].each do |f|
         expect(rendered).to have_css(".al-repository-street-address-#{f}", count: 4)
       end
     end
+
     it 'has the correct contact information' do
       expect(rendered).to have_css('.al-repository-contact-info-contact_info a @href', count: 3, text: /mailto:/)
     end
+
     it 'handles a missing building' do
       expect(rendered).to have_css('.al-repository-street-address-building', count: 3)
     end
+
     it 'handles a missing address2' do
       expect(rendered).to have_css('.al-repository-street-address-address2', count: 1)
     end
+
     it 'handles a missing phone' do
       expect(rendered).to have_css('.al-repository-contact-info-phone', count: 2)
     end
+
     context 'collection counts' do
       it '0 collections' do
         within('.al-repository-extra-collection-count') do
           expect(rendered).to have_css('.al-repository-collection-count', text: 'No collections')
         end
       end
+
       it '1 collection' do
         within('.al-repository-extra-collection-count') do
           expect(rendered).to have_css('.al-repository-collection-count', text: '1 collection')
         end
       end
+
       it 'n collections' do
         within('.al-repository-extra-collection-count') do
           expect(rendered).to have_css('.al-repository-collection-count', text: '2 collections')
@@ -70,6 +80,7 @@ RSpec.describe 'arclight/repositories/index', type: :view do
       render
       expect(rendered).to have_css('.al-repository-extra', count: 5)
     end
+
     it 'does not show on repositories detail page' do
       assign(:repository, instance_double('repository', name: 'My Repository'))
       allow(view).to receive(:on_repositories_index?).and_return(false)
@@ -77,6 +88,7 @@ RSpec.describe 'arclight/repositories/index', type: :view do
       render
       expect(rendered).not_to have_css('.al-repository-extra')
     end
+
     it 'does not show on search page' do
       allow(view).to receive(:on_repositories_index?).and_return(false)
       render
@@ -89,6 +101,7 @@ RSpec.describe 'arclight/repositories/index', type: :view do
       render
       expect(rendered).to have_css('.al-repository-contact-info-contact_info a @href', count: 3, text: /mailto:/)
     end
+
     it 'handles a malformed email' do
       test_data.first.contact_info = 'not-an-email-address'
       render

--- a/spec/views/repositories/show.html.erb_spec.rb
+++ b/spec/views/repositories/show.html.erb_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'arclight/repositories/show', type: :view do
     it 'has the repository card' do
       expect(rendered).to have_css('.al-repository h2', text: /My Repository/)
     end
+
     it 'has breadcrumbs' do
       expect(rendered).to have_css('.al-search-breadcrumb', text: /My Repository/)
     end


### PR DESCRIPTION
Closing previous PR and resubmitting do to conflicts

closes #839 
Part of #820

 Change

> div class="al-search-breadcrumb" 

to

> nav class="al-search-breadcrumb" role="navigation" aria-label="breadcrumb"

<a href="https://cl.ly/5d67b12444e4" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/1n0z29301v2O2X062Q19/Screen%20Shot%202019-09-26%20at%2011.23.25%20AM.png" style="display: block;height: auto;width: 100%;"/></a>