### PR TITLE
Convert EAD formatting for lists & text to HTML tags via a Traject ma…

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -98,9 +98,21 @@ a.al-toggle-view-all{
   }
 }
 
-
 dl dd {
   overflow-wrap: break-word;
 }
 
+.chronlist-head {
+  caption-side: top;
+  font-size: 1.25rem;
+  font-weight: 500;
+}
 
+.chronlist th,
+.chronlist-item-date {
+  font-weight: 500;
+}
+
+.chronlist-item-date {
+  width: 15ch;
+}

--- a/app/controllers/concerns/arclight/field_config_helpers.rb
+++ b/app/controllers/concerns/arclight/field_config_helpers.rb
@@ -21,6 +21,7 @@ module Arclight
         helper_method :item_requestable?
         helper_method :paragraph_separator
         helper_method :link_to_name_facet
+        helper_method :render_html_tags
       end
     end
 
@@ -95,6 +96,10 @@ module Arclight
           view_context.search_action_path(f: { names_ssim: [value] })
         )
       end.to_sentence(options).html_safe
+    end
+
+    def render_html_tags(args)
+      safe_join(args[:value].map { |value| content_tag(:p, value.html_safe) })
     end
   end
 end

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -14,9 +14,11 @@ require 'arclight/digital_object'
 require 'arclight/year_range'
 require 'arclight/repository'
 require 'arclight/missing_id_strategy'
+require 'arclight/traject/macros.rb'
 require 'arclight/traject/nokogiri_namespaceless_reader'
 
 # rubocop:disable Style/MixinUsage
+extend Arclight::Traject::Macros
 extend TrajectPlus::Macros
 # rubocop:enable Style/MixinUsage
 
@@ -213,13 +215,13 @@ to_field 'date_range_sim', extract_xpath('/ead/archdesc/did/unitdate/@normal', t
 end
 
 SEARCHABLE_NOTES_FIELDS.map do |selector|
-  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']")
+  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']", to_text: false), format_tags
   to_field "#{selector}_heading_ssm", extract_xpath("/ead/archdesc/#{selector}/head") unless selector == 'prefercite'
   to_field "#{selector}_teim", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']")
 end
 
 DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
-  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/did/#{selector}")
+  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/did/#{selector}", to_text: false), format_tags
 end
 
 NAME_ELEMENTS.map do |selector|
@@ -241,6 +243,8 @@ to_field 'descrules_ssm', extract_xpath('/ead/eadheader/profiledesc/descrules')
 # =============================
 
 compose 'components', ->(record, accumulator, _context) { accumulator.concat record.xpath('//*[is_component(.)]', NokogiriXpathExtensions.new) } do
+  extend Arclight::Traject::Macros
+
   to_field 'ref_ssi' do |record, accumulator, context|
     accumulator << if record.attribute('id').blank?
                      strategy = Arclight::MissingIdStrategy.selected
@@ -456,12 +460,12 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
   end
 
   SEARCHABLE_NOTES_FIELDS.map do |selector|
-    to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']")
+    to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']", to_text: false), format_tags
     to_field "#{selector}_heading_ssm", extract_xpath("./#{selector}/head")
     to_field "#{selector}_teim", extract_xpath("./#{selector}/*[local-name()!='head']")
   end
   DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
-    to_field "#{selector}_ssm", extract_xpath("./did/#{selector}")
+    to_field "#{selector}_ssm", extract_xpath("./did/#{selector}", to_text: false), format_tags
   end
   to_field 'did_note_ssm', extract_xpath('./did/note')
 end

--- a/lib/arclight/traject/ead_formatting.xsl
+++ b/lib/arclight/traject/ead_formatting.xsl
@@ -1,0 +1,188 @@
+<?xml version="1.0" ?>
+<xsl:stylesheet version="1.0"
+     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:ead="urn:isbn:1-931666-22-9"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    exclude-result-prefixes="ead xlink"
+>
+
+  <xsl:output omit-xml-declaration="yes" encoding="UTF-8" method="html" />
+
+  <xsl:template match="/">
+      <xsl:apply-templates />
+  </xsl:template>
+
+  <!--
+  ~~~~~~~~~~~~~~~~~~~~~~~~
+  Lists
+  ~~~~~~~~~~~~~~~~~~~~~~~~
+  -->
+
+  <xsl:template match="list[@type='ordered']">
+    <xsl:apply-templates select="head" />
+    <ol><xsl:apply-templates select="item" /></ol>
+  </xsl:template>
+
+  <xsl:template match="list[@type='deflist']">
+    <table class="table deflist">
+      <xsl:apply-templates />
+    </table>
+  </xsl:template>
+
+  <xsl:template match="list[@type='deflist']/listhead">
+    <thead>
+      <tr>
+        <th scope="col">
+          <xsl:apply-templates select="head01" />
+        </th>
+        <th scope="col">
+          <xsl:apply-templates select="head02" />
+        </th>
+      </tr>
+    </thead>
+  </xsl:template>
+
+  <xsl:template match="list">
+    <xsl:apply-templates select="head"/>
+    <ul><xsl:apply-templates select="item" /></ul>
+  </xsl:template>
+
+  <xsl:template match="defitem">
+    <tr>
+      <td><xsl:apply-templates select="label" /></td>
+      <td><xsl:apply-templates select="item" /></td>
+    </tr>
+  </xsl:template>
+
+  <xsl:template match="list/head">
+    <strong><xsl:apply-templates /></strong>
+  </xsl:template>
+
+  <xsl:template match="list/item">
+    <li><xsl:apply-templates /></li>
+  </xsl:template>
+
+  <!--
+  ~~~~~~~~~~~~~~~~~~~~~~~~
+  Chronlist
+  ~~~~~~~~~~~~~~~~~~~~~~~~
+  -->
+  <xsl:template match="chronlist">
+    <table class="table chronlist">
+      <xsl:if test="head">
+        <caption class="chronlist-head">
+          <xsl:value-of select="head" />
+        </caption>
+      </xsl:if>
+      <thead>
+        <tr>
+          <th scope="col">
+            <xsl:choose>
+                <xsl:when test="listhead/head01">
+                    <xsl:apply-templates select="listhead/head01"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    Date
+                </xsl:otherwise>
+            </xsl:choose>
+          </th>
+          <th scope="col">
+            <xsl:choose>
+                <xsl:when test="listhead/head02">
+                    <xsl:apply-templates select="listhead/head02"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    Event
+                </xsl:otherwise>
+            </xsl:choose>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <xsl:apply-templates select="chronitem" />
+      </tbody>
+    </table>
+  </xsl:template>
+
+  <xsl:template match="chronlist/chronitem">
+    <tr class="chronlist-item">
+      <td class="chronlist-item-date"><xsl:apply-templates select="date"/></td>
+      <td class="chronlist-item-event"><xsl:apply-templates select="descendant::event"/></td>
+    </tr>
+  </xsl:template>
+
+  <xsl:template match="chronitem//event">
+    <xsl:choose>
+      <xsl:when test="following-sibling::*">
+        <xsl:apply-templates /><br/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!--
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Misc render styles
+  E.g., in <emph> or <title>
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  -->
+
+  <xsl:template match="emph[not(@render)]">
+    <em><xsl:apply-templates /></em>
+  </xsl:template>
+
+  <xsl:template match="*[@render='bold']">
+    <strong><xsl:value-of select="."/></strong>
+  </xsl:template>
+
+  <xsl:template match="*[@render='italic']">
+    <em><xsl:value-of select="."/></em>
+  </xsl:template>
+
+  <xsl:template match="*[@render='sub']">
+    <sub><xsl:value-of select="."/></sub>
+  </xsl:template>
+
+  <xsl:template match="*[@render='super']">
+    <sup><xsl:value-of select="."/></sup>
+  </xsl:template>
+
+  <xsl:template match="*[@render='bolditalic']">
+    <em><strong><xsl:value-of select="."/></strong></em>
+  </xsl:template>
+
+  <xsl:template match="*[@render='underline']">
+    <span class="underline"><xsl:value-of select="."/></span>
+  </xsl:template>
+
+  <xsl:template match="*[@render='boldunderline']">
+    <span class="underline"><strong><xsl:value-of select="."/></strong></span>
+  </xsl:template>
+
+  <xsl:template match="*[@render='doublequote']">
+    "<xsl:value-of select="." />"
+  </xsl:template>
+
+  <xsl:template match="*[@render='bolddoublequote']">
+    <strong>"<xsl:value-of select="." />"</strong>
+  </xsl:template>
+
+  <xsl:template match="*[@render='singlequote']">
+    '<xsl:value-of select="." />'
+  </xsl:template>
+
+  <xsl:template match="*[@render='boldsinglequote']">
+    <strong>'<xsl:value-of select="." />'</strong>
+  </xsl:template>
+
+  <xsl:template match="*[@render='smcaps']">
+    <small class="text-uppercase"><xsl:value-of select="."/></small>
+  </xsl:template>
+
+  <xsl:template match="*[@render='boldsmcaps']">
+    <small class="text-uppercase"><strong><xsl:value-of select="."/></strong></small>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/lib/arclight/traject/macros.rb
+++ b/lib/arclight/traject/macros.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Arclight
+  module Traject
+    # Traject indexing macros specific to ArcLight
+    module Macros
+      def format_tags
+        @xslt ||= Nokogiri::XSLT(File.read(File.join(File.expand_path('..', __dir__), 'traject', 'ead_formatting.xsl')))
+
+        proc do |_record, accumulator|
+          accumulator.map! do |element|
+            doc = Nokogiri::XML::Document.new
+            doc.root = element
+            value = @xslt.transform(doc).serialize.strip
+            value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -253,30 +253,30 @@ class CatalogController < ApplicationController
 
     # Collection Show Page - Summary Section
     config.add_summary_field 'creators_ssim', label: 'Creator', link_to_facet: true
-    config.add_summary_field 'abstract_ssm', label: 'Abstract', helper_method: :paragraph_separator
+    config.add_summary_field 'abstract_ssm', label: 'Abstract', helper_method: :render_html_tags
     config.add_summary_field 'extent_ssm', label: 'Extent'
     config.add_summary_field 'language_ssm', label: 'Language'
     config.add_summary_field 'prefercite_ssm', label: 'Preferred citation'
 
     # Collection Show Page - Background Section
-    config.add_background_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :paragraph_separator
-    config.add_background_field 'bioghist_ssm', label: 'Biographical / Historical', helper_method: :paragraph_separator
-    config.add_background_field 'acqinfo_ssm', label: 'Acquisition information', helper_method: :paragraph_separator
-    config.add_background_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :paragraph_separator
-    config.add_background_field 'custodhist_ssm', label: 'Custodial history', helper_method: :paragraph_separator
-    config.add_background_field 'processinfo_ssm', label: 'Processing information', helper_method: :paragraph_separator
-    config.add_background_field 'arrangement_ssm', label: 'Arrangement', helper_method: :paragraph_separator
-    config.add_background_field 'accruals_ssm', label: 'Accruals', helper_method: :paragraph_separator
-    config.add_background_field 'phystech_ssm', label: 'Physical / technical requirements', helper_method: :paragraph_separator
-    config.add_background_field 'physloc_ssm', label: 'Physical location', helper_method: :paragraph_separator
-    config.add_background_field 'descrules_ssm', label: 'Rules or conventions', helper_method: :paragraph_separator
+    config.add_background_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :render_html_tags
+    config.add_background_field 'bioghist_ssm', label: 'Biographical / Historical', helper_method: :render_html_tags
+    config.add_background_field 'acqinfo_ssm', label: 'Acquisition information', helper_method: :render_html_tags
+    config.add_background_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :render_html_tags
+    config.add_background_field 'custodhist_ssm', label: 'Custodial history', helper_method: :render_html_tags
+    config.add_background_field 'processinfo_ssm', label: 'Processing information', helper_method: :render_html_tags
+    config.add_background_field 'arrangement_ssm', label: 'Arrangement', helper_method: :render_html_tags
+    config.add_background_field 'accruals_ssm', label: 'Accruals', helper_method: :render_html_tags
+    config.add_background_field 'phystech_ssm', label: 'Physical / technical requirements', helper_method: :render_html_tags
+    config.add_background_field 'physloc_ssm', label: 'Physical location', helper_method: :render_html_tags
+    config.add_background_field 'descrules_ssm', label: 'Rules or conventions', helper_method: :render_html_tags
 
     # Collection Show Page - Related Section
-    config.add_related_field 'relatedmaterial_ssm', label: 'Related material', helper_method: :paragraph_separator
-    config.add_related_field 'separatedmaterial_ssm', label: 'Separated material', helper_method: :paragraph_separator
-    config.add_related_field 'otherfindaid_ssm', label: 'Other finding aids', helper_method: :paragraph_separator
-    config.add_related_field 'altformavail_ssm', label: 'Alternative form available', helper_method: :paragraph_separator
-    config.add_related_field 'originalsloc_ssm', label: 'Location of originals', helper_method: :paragraph_separator
+    config.add_related_field 'relatedmaterial_ssm', label: 'Related material', helper_method: :render_html_tags
+    config.add_related_field 'separatedmaterial_ssm', label: 'Separated material', helper_method: :render_html_tags
+    config.add_related_field 'otherfindaid_ssm', label: 'Other finding aids', helper_method: :render_html_tags
+    config.add_related_field 'altformavail_ssm', label: 'Alternative form available', helper_method: :render_html_tags
+    config.add_related_field 'originalsloc_ssm', label: 'Location of originals', helper_method: :render_html_tags
 
     # Collection Show Page - Indexed Terms Section
     config.add_indexed_terms_field 'access_subjects_ssim', label: 'Subjects', link_to_facet: true, separator_options: {
@@ -309,17 +309,17 @@ class CatalogController < ApplicationController
     }, if: lambda { |_context, _field_config, document|
       document.containers.present?
     }
-    config.add_component_field 'abstract_ssm', label: 'Abstract', helper_method: :paragraph_separator
+    config.add_component_field 'abstract_ssm', label: 'Abstract', helper_method: :render_html_tags
     config.add_component_field 'extent_ssm', label: 'Extent'
-    config.add_component_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :paragraph_separator
-    config.add_component_field 'acqinfo_ssm', label: 'Acquisition information', helper_method: :paragraph_separator
-    config.add_component_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :paragraph_separator
-    config.add_component_field 'custodhist_ssm', label: 'Custodial history', helper_method: :paragraph_separator
-    config.add_component_field 'processinfo_ssm', label: 'Processing information', helper_method: :paragraph_separator
-    config.add_component_field 'arrangement_ssm', label: 'Arrangement', helper_method: :paragraph_separator
-    config.add_component_field 'accruals_ssm', label: 'Accruals', helper_method: :paragraph_separator
-    config.add_component_field 'phystech_ssm', label: 'Physical / technical requirements', helper_method: :paragraph_separator
-    config.add_component_field 'physloc_ssm', label: 'Physical location', helper_method: :paragraph_separator
+    config.add_component_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :render_html_tags
+    config.add_component_field 'acqinfo_ssm', label: 'Acquisition information', helper_method: :render_html_tags
+    config.add_component_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :render_html_tags
+    config.add_component_field 'custodhist_ssm', label: 'Custodial history', helper_method: :render_html_tags
+    config.add_component_field 'processinfo_ssm', label: 'Processing information', helper_method: :render_html_tags
+    config.add_component_field 'arrangement_ssm', label: 'Arrangement', helper_method: :render_html_tags
+    config.add_component_field 'accruals_ssm', label: 'Accruals', helper_method: :render_html_tags
+    config.add_component_field 'phystech_ssm', label: 'Physical / technical requirements', helper_method: :render_html_tags
+    config.add_component_field 'physloc_ssm', label: 'Physical location', helper_method: :render_html_tags
 
     # Component Show Page - Indexed Terms Section
     config.add_component_indexed_terms_field 'access_subjects_ssim', label: 'Subjects', link_to_facet: true, separator_options: {

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -63,10 +63,8 @@ RSpec.describe 'Collection Page', type: :feature do
     end
 
     it 'multivalued notes are rendered as paragaphs' do
-      within 'dd.blacklight-bioghist_ssm' do
+      within 'dd.blacklight-relatedmaterial_ssm' do
         expect(page).to have_css('p', count: 2)
-        expect(page).to have_css('p', text: /^Alpha Omega Alpha Honor Medical Society was founded/)
-        expect(page).to have_css('p', text: /^Root and his fellow medical students/)
       end
       within 'dd.blacklight-abstract_ssm' do
         expect(page).to have_css('p', count: 2)
@@ -155,6 +153,21 @@ RSpec.describe 'Collection Page', type: :feature do
 
       it 'are not displayed' do
         expect(page).not_to have_css('.al-show-sub-heading', text: 'Related')
+      end
+    end
+  end
+
+  describe 'elements with formatting' do
+    it 'renders html tags for formatted elements' do
+      within '#background' do
+        expect(page).to have_css('ul li', text: 'June E. Osborn, M.D., Chairman')
+        expect(page).to have_css('ol li', text: /^Title: How I Love the Old Black Cat/)
+        expect(page).to have_css('ul li em', text: /^The Happy Marriage/)
+        expect(page).to have_css('table.deflist thead th', text: 'Abbreviation')
+        expect(page).to have_css('strong', text: /^College of Physicians/)
+        expect(page).to have_css('small.text-uppercase', text: /^\[Excerpted from/)
+        expect(page).to have_css('table.chronlist caption', text: 'Julia Stockton Rush')
+        expect(page).to have_css('table.chronlist tbody tr td', text: '1759')
       end
     end
   end

--- a/spec/fixtures/ead/nlm/alphaomegaalpha.xml
+++ b/spec/fixtures/ead/nlm/alphaomegaalpha.xml
@@ -112,9 +112,10 @@
     <bioghist id="aspace_ff0f836406ce214cae38e1f7c798d76e">
       <head>Historical Note</head>
       <p>Alpha Omega Alpha Honor Medical Society was founded in 1902 by William Webster Root and
-        five other medical students at the College of Physicians and Surgeons in Chicago. Root
-        viewed the society as a protest against "a condition which associated the name medical
-        student with rowdyism, boorishness, immorality, and low educational ideals." Of the
+        five other medical students at the <emph render="bold">College of Physicians and 
+        Surgeons in Chicago</emph>. Root viewed the society as a protest against
+        <emph render="italic">a condition which associated the name medical student with rowdyism,
+        boorishness, immorality, and low educational ideals."</emph> Of the
         approximately 25,000 medical students in the United States at the turn of the century, no
         more than 15 percent were college graduates. The only requirement in most schools was a high
         school diploma or its equivalent; the latter often meaning the ability to pay the fee. The
@@ -122,7 +123,7 @@
         exceptions, notably the Johns Hopkins School of Medicine, founded in 1893, the medical
         school curriculum consisted of a series of lectures, sometimes supplemented by
         demonstrations at the bedside or in the laboratory, if such existed.</p>
-      <p> Root and his fellow medical students met to form a society that would foster honesty and
+      <p>Root and his fellow medical students met to form a society that would foster honesty and
         formulate higher ideals of scholastic achievement. Chartered in 1903 by the state of
         Illinois, Alpha Omega Alpha's growth has paralleled the development of American medical
         education. Within a decade after the society was founded, chapters were established at
@@ -136,13 +137,84 @@
         teachers, to foster research and in all ways to ennoble the profession of medicine and
         advance it in public opinion. It is equally a duty to avoid that which is unworthy,
         including the commercial spirit and all practices injurious to the welfare of patients, the
-        public, or the profession." [Excerpted from Alpha Omega Alpha website.]</p>
+        public, or the profession."
+        <emph render="smcaps">[Excerpted from Alpha Omega Alpha website.]</emph></p>
+      <chronlist>
+        <head>Julia Stockton Rush</head>
+        <chronitem>
+          <date>1759</date>
+          <eventgrp>
+            <event>Born, at "Morven" family estate near Princeton, N.J.</event>
+          </eventgrp>
+        </chronitem>
+        <chronitem>
+          <date>1776</date>
+          <eventgrp>
+            <event>Married Benjamin Rush; the couple went on to have 13 children</event>
+          </eventgrp>
+        </chronitem>
+        <chronitem>
+          <date>1848</date>
+          <eventgrp>
+            <event>Died at their county property, "Sydenham" (now 15th Street and Columbus Ave,
+              Philadelphia)</event>
+          </eventgrp>
+        </chronitem>
+      </chronlist>
     </bioghist>
     <scopecontent id="aspace_00d4328c32ed5e54eac5c662aa45245f">
       <head>Collection Summary</head>
       <p>Correspondence, documents, records, photos and printed matter. Material relates to the
         history, organization, membership, meetings and publications. A large portion of the
         collection pertains to the different chapters of the Society.</p>
+      <p>Here is a simple list.</p>
+      <list type="simple">
+        <head>Commission Members List</head>
+        <item>June E. Osborn, M.D., Chairman</item>
+        <item>David E. Rogers, M.D., Vice Chairman</item>
+        <item>The Honorable Diane Ahrens</item>
+        <item>K. Scott Allen</item>
+      </list>
+      <p>Here is an ordered list.</p>
+      <list type="ordered">
+        <head>Track List</head>
+        <item>Title: How I Love the Old Black Cat, performer: Strawbridge, Mary, location:
+          Durham (N.C.) | Durham County (N.C.), running time: 00:00:37:628</item>
+        <item>Title: The Broken Heart, performer: Strawbridge, Mary | Robbins, Jewell,
+          location: Durham (N.C.) | Durham County (N.C.), running time: 00:00:18:961</item>
+        <item>Title: Farewell (You Are False), performer: Strawbridge, Mary, location:
+          Durham (N.C.) | Durham County (N.C.), running time: 00:00:38:559</item>
+      </list>
+      <p>Here is list with no type.</p>
+      <list>
+        <item>
+          <bibref>
+            <title render="italic">The Happy Marriage, and Other Poems</title> (Boston and 
+            New York: Houghton Mifflin. 79 pp.)
+          </bibref>
+        </item>
+        <item>
+          <bibref>
+            <title render="italic">The Pot of Earth</title> (Boston and New York:
+            Houghton Mifflin. 44 pp.)
+          </bibref>
+        </item>
+      </list>
+      <p>Here is a definition list with column headings.</p>
+      <list type="deflist">
+        <listhead>
+          <head01>Abbreviation</head01>
+          <head02>Expansion</head02>
+        </listhead>
+        <defitem>
+          <label>ALS</label>
+          <item>Autograph Letter Signed</item>
+        </defitem>
+        <defitem>
+          <label>TLS</label>
+          <item>Typewritten Letter Signed</item>
+        </defitem>
+      </list>
     </scopecontent>
     <arrangement id="aspace_845bb9a95be0924c3c9b33ccdc676813">
       <head>Arrangement</head>


### PR DESCRIPTION
…cro w/XSLT; render HTML for some fields. Closes #758, #760, #761

### Summary of Changes

- Adds a `format_tags` macro that can be easily added to Traject `to_field` indexing rules for fields where we'd expect to find formatting tags
- Uses an XSLT file with templates to convert formatting-related EAD XML to corresponding HTML tags during indexing
- Defines HTML transform rules for: `<list>`, `<deflist>`, `<chronlist>` and several render attributes e.g., `<emph render="bold" />`
- Adds a `render_html_tags` helper method that, if used in a field config, will use `.html_safe` to render the value as html.
- Configures all searchable note fields (`<abstract>`, `<scopecontent>`, `<bioghist>`, etc.) to index & display with these formatting rules applied (on collection and component level).

### Screenshots
![Screen Shot 2019-09-27 at 2 02 28 PM](https://user-images.githubusercontent.com/3933756/65799249-a6daed00-e141-11e9-861c-b7d547d49c05.png)

![Screen Shot 2019-09-27 at 2 04 52 PM](https://user-images.githubusercontent.com/3933756/65799252-ac383780-e141-11e9-82f6-88b6d5303068.png)

