### PR TITLE
Implements an "expand" button for cases where the Collection Context interface contains more than 1 previous sibling document for items within a Collection

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,6 @@
+---
+version: "2"
+exclude_patterns:
+  - "app/assets/javascripts/arclight/context_navigation.js"
+  - "vendor/assets/javascripts/**/*.js"
+  - "spec/**/*.rb"

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,6 +28,8 @@ Metrics/BlockLength:
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/MethodLength:
   Max: 11
+  Exclude:
+    - 'app/helpers/arclight_helper.rb'
 
 # Offense count: 1
 # Configuration parameters: Blacklist.

--- a/app/assets/javascripts/arclight/context_navigation.js
+++ b/app/assets/javascripts/arclight/context_navigation.js
@@ -75,24 +75,32 @@ class ContextNavigation {
     if (originalDocumentIndex !== -1) {
       newDocs[originalDocumentIndex].setAsHighlighted();
 
-      // Hide all but the first previous sibling
-      const prevSiblingDocs = newDocs.slice(0, originalDocumentIndex - 1);
+      const prevSiblingDocs = newDocs.slice(0, originalDocumentIndex);
       let nextSiblingDocs = [];
 
+      // If there are more than 1 siblings, hide them all but the first
       if (prevSiblingDocs.length > 1 && originalDocumentIndex > 0) {
-        prevSiblingDocs.forEach(function (siblingDoc) {
+        const hiddenPrevSiblingDocs = prevSiblingDocs.slice(0, -1);
+        hiddenPrevSiblingDocs.forEach(function (siblingDoc) {
           siblingDoc.collapse();
         });
 
-        const prevSiblingContainer = $('<ul class="pl-0 prev-siblings"><button class="my-3 btn btn-secondary btn-sm">Expand</button></ul>');
-        prevSiblingContainer.click((event) => {
-          const $container = $(event.target);
-          $container.parent().children('li').toggleClass('collapsed');
-          $container.toggleClass('collapsed');
-          const containerText = $container.hasClass('collapsed') ? 'Collapse' : 'Expanded';
-          $container.text(containerText);
+        // Add the "expand" button
+        // @todo this needs to be refactored
+        const $expandButton = $('<button class="my-3 btn btn-secondary btn-sm">Expand</button>');
+        const prevSiblingContainer = $('<ul class="pl-0 prev-siblings"></ul>');
+        prevSiblingContainer.append($expandButton);
+        $expandButton.click((event) => {
+          const $target = $(event.target);
+          const children = $target.parent().children('li');
+          const targetedChildren = children.slice(0, -1);
+          targetedChildren.toggleClass('collapsed');
+          $target.toggleClass('collapsed');
+          const targetText = $target.hasClass('collapsed') ? 'Collapse' : 'Expanded';
+          $target.text(targetText);
         });
 
+        // Render the docs as <li> elements and append them to the DOM
         const renderedPrevSiblingItems = prevSiblingDocs.map(doc => doc.render()).join('');
         prevSiblingContainer.append(renderedPrevSiblingItems);
         that.parentLi.before(prevSiblingContainer);

--- a/app/assets/javascripts/arclight/context_navigation.js
+++ b/app/assets/javascripts/arclight/context_navigation.js
@@ -11,6 +11,10 @@ class NavigationDocument {
     this.el.find('li.al-collection-context').addClass('al-hierarchy-highlight');
   }
 
+  collapse() {
+    this.el.find('li.al-collection-context').addClass('collapsed');
+  }
+
   render() {
     return this.el.html();
   }
@@ -37,6 +41,7 @@ class ContextNavigation {
     const that = this;
     // Add a placeholder so flashes of text are not as significant
     this.el.after(ContextNavigation.placeholder());
+
     $.ajax({
       url: this.data.arclight.path,
       data: {
@@ -58,33 +63,78 @@ class ContextNavigation {
       .find('article')
       .toArray().map(el => new NavigationDocument(el));
 
+    // Filter for only the <article> element which encodes the information for
+    // the child or parent Solr Document
     const originalDocumentIndex = newDocs
       .findIndex(doc => doc.id === that.data.arclight.originalDocument);
     that.parentLi.find('.al-hierarchy-placeholder').remove();
 
     // Case where this is the sibling tree of the current document
+    // If the response does contain any <article> elements for the child or
+    // parent Solr Documents, then the documents are treated as sibling nodes
     if (originalDocumentIndex !== -1) {
       newDocs[originalDocumentIndex].setAsHighlighted();
-      that.parentLi.before(newDocs.map(newDoc => newDoc.render()).join('')).fadeIn(500);
+
+      // Hide all but the first previous sibling
+      const prevSiblingDocs = newDocs.slice(0, originalDocumentIndex - 1);
+      let nextSiblingDocs = [];
+
+      if (prevSiblingDocs.length > 1 && originalDocumentIndex > 0) {
+        prevSiblingDocs.forEach(function (siblingDoc) {
+          siblingDoc.collapse();
+        });
+
+        const prevSiblingContainer = $('<ul class="pl-0 prev-siblings"><button class="my-3 btn btn-secondary btn-sm">Expand</button></ul>');
+        prevSiblingContainer.click((event) => {
+          const $container = $(event.target);
+          $container.parent().children('li').toggleClass('collapsed');
+          $container.toggleClass('collapsed');
+          const containerText = $container.hasClass('collapsed') ? 'Collapse' : 'Expanded';
+          $container.text(containerText);
+        });
+
+        const renderedPrevSiblingItems = prevSiblingDocs.map(doc => doc.render()).join('');
+        prevSiblingContainer.append(renderedPrevSiblingItems);
+        that.parentLi.before(prevSiblingContainer);
+        nextSiblingDocs = newDocs.slice(originalDocumentIndex);
+      } else {
+        nextSiblingDocs = newDocs;
+      }
+
+      const renderedNextSiblingItems = nextSiblingDocs.map(newDoc => newDoc.render()).join('');
+
+      // Insert the rendered sibling documents before the <li> elements
+      that.parentLi.before(renderedNextSiblingItems).fadeIn(500);
     } else {
-    // Case where this is a parent list and needs to be filed correctly
+      // Case where this is a parent list and needs to be filed correctly
+      //
+      // Otherwise, retrieve the parent...
       const parentIndex = that.data.arclight.originalParents.indexOf(that.data.arclight.parent);
       const currentId = `${that.data.arclight.originalParents[0]}${that.data.arclight.originalParents[parentIndex + 1]}`;
       const newDocIndex = newDocs.findIndex(doc => doc.id === currentId);
 
       // Update the docs before the item
       // TODO: Add a class or something that doesn't display these until the expando is clicked
+      // Retrieves the documents up to and including the "new document"
       const beforeDocs = newDocs.slice(0, newDocIndex);
-      that.parentLi.before(beforeDocs.map(newDoc => newDoc.render()).join('')).fadeIn(500);
+
+      let renderedBeforeDocs = beforeDocs.map(newDoc => newDoc.render()).join('');
+      that.parentLi.before(renderedBeforeDocs).fadeIn(500);
+
+      let itemDoc = newDocs.slice(newDocIndex, newDocIndex + 1);
+      let renderedItemDoc = itemDoc.map(doc => doc.render()).join('');
+
       // Update the item
-      const $itemDoc = $(newDocs.slice(newDocIndex, newDocIndex + 1).map(doc => doc.render()).join(''));
+      const $itemDoc = $(renderedItemDoc);
       // Update the id, add classes of the classes. Prepend the current children.
       that.parentLi.attr('id', $itemDoc.attr('id'));
       that.parentLi.addClass($itemDoc.attr('class'));
       that.parentLi.prepend($itemDoc.children()).fadeIn(500);
       // Update the docs after the item
       const afterDocs = newDocs.slice(newDocIndex + 1, newDocs.length);
-      that.parentLi.after(afterDocs.map(newDoc => newDoc.render()).join('')).fadeIn(500);
+      const renderedAfterDocs = afterDocs.map(newDoc => newDoc.render()).join('');
+      // Insert the documents after the current
+      that.parentLi.after(renderedAfterDocs).fadeIn(500);
     }
   }
 }

--- a/app/assets/javascripts/arclight/context_navigation.js
+++ b/app/assets/javascripts/arclight/context_navigation.js
@@ -96,7 +96,7 @@ class ContextNavigation {
           const targetedChildren = children.slice(0, -1);
           targetedChildren.toggleClass('collapsed');
           $target.toggleClass('collapsed');
-          const targetText = $target.hasClass('collapsed') ? 'Collapse' : 'Expanded';
+          const targetText = $target.hasClass('collapsed') ? 'Collapse' : 'Expand';
           $target.text(targetText);
         });
 

--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -156,6 +156,18 @@
       }
     }
   }
+
+  .prev-siblings li {
+    visibility: visible;
+    opacity: 1;
+    transition: visibility 0s, height 0.5s, opacity 0.5s linear;
+
+    &.collapsed {
+      visibility: hidden;
+      height: 0;
+      opacity: 0;
+    }
+  }
 }
 
 // Indentation styling for all level hierarchies

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -284,12 +284,16 @@ module ArclightHelper
     content_tag(
       :div, '',
       class: "context-navigator al-hierarchy-level-#{document.component_level} documents-hierarchy",
-      data: { arclight: {
-        level: document.parent_ids.index(parent_id) + 1,
-        path: search_catalog_path(hierarchy_context: 'component'),
-        name: document.collection_name, parent: parent_id,
-        originalDocument: document.id, originalParents: document.parent_ids
-      } }
+      data: {
+        arclight: {
+          level: document.parent_ids.index(parent_id) + 1,
+          path: search_catalog_path(hierarchy_context: 'component'),
+          name: document.collection_name,
+          parent: parent_id,
+          originalDocument: document.id,
+          originalParents: document.parent_ids
+        }
+      }
     )
   end
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "eslint-plugin-import": "^2.2.0"
   },
   "scripts": {
+    "lint": "eslint './app/assets/javascripts/**/*.{js,es6}'",
+    "lint:fix": "eslint --fix './app/assets/javascripts/**/*.{js,es6}'",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -172,6 +172,37 @@ RSpec.describe 'Component Page', type: :feature do
         end
       end
     end
+
+    context 'when there are more than two previous sibling documents for the current document' do
+      let(:doc_id) { 'm0198-xmlaspace_ref13_yl7' }
+
+      it 'hides all but the first previous sibling document items' do
+        within '#collection-context' do
+          expect(page).to have_css '.document-title-heading', text: 'Pages 171-272'
+          expect(page).to have_css '.document-title-heading', text: 'Pages 79-170'
+          expect(page).not_to have_css '.document-title-heading', text: 'Pages 1-78'
+        end
+      end
+
+      it 'offers a button for displaying the hidden sibling document items' do
+        within '#collection-context' do
+          expect(page).to have_css '.btn-secondary', text: 'Expand'
+          expect(page).to have_css '.document-title-heading', text: 'Pages 171-272'
+          expect(page).to have_css '.document-title-heading', text: 'Pages 79-170'
+          expect(page).not_to have_css '.document-title-heading', text: 'Pages 1-78'
+
+          find('.btn-secondary', text: 'Expand').click
+
+          expect(page).to have_css '.btn-secondary', text: 'Collapse'
+          expect(page).to have_css '.document-title-heading', text: 'Pages 1-78'
+
+          find('.btn-secondary', text: 'Collapse').click
+
+          expect(page).to have_css '.btn-secondary', text: 'Expand'
+          expect(page).not_to have_css '.document-title-heading', text: 'Pages 1-78'
+        end
+      end
+    end
   end
 
   describe 'access tab', js: true do


### PR DESCRIPTION
Advances #811, please see the following screenshots for the updated interface:

![image](https://user-images.githubusercontent.com/1443986/65795822-287a4d00-e139-11e9-91d6-1a6dd24de195.png)
![image](https://user-images.githubusercontent.com/1443986/65795857-3fb93a80-e139-11e9-8da7-07da49b274c2.png)

Please note that I am using the fixture referenced in https://github.com/projectblacklight/arclight/issues/457#issuecomment-522094674.  Shall I include this, or might there be a preferred fixture for these cases?