### PR TITLE
Give collection title matches a little boost over other fields

### DIFF
--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -126,6 +126,9 @@ end
 to_field 'collection_ssi' do |_record, accumulator, context|
   accumulator.concat context.output_hash.fetch('normalized_title_ssm', [])
 end
+to_field 'collection_title_tesim' do |_record, accumulator, context|
+  accumulator.concat context.output_hash.fetch('normalized_title_ssm', [])
+end
 
 to_field 'repository_ssm' do |_record, accumulator, context|
   accumulator << context.clipboard[:repository]

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -85,6 +85,7 @@
        -->
 
        <str name="qf">
+         collection_title_tesim^150
          title_tesim^100
          name_tesim^10
          place_tesim^10
@@ -93,6 +94,7 @@
          text
        </str>
        <str name="pf">
+         collection_title_tesim^150
          title_tesim^100
          name_tesim^10
          place_tesim^10

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -108,7 +108,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'collection has normalized_title' do
-      %w[collection_ssm collection_sim collection_ssi].each do |field|
+      %w[collection_ssm collection_sim collection_ssi collection_title_tesim].each do |field|
         expect(result[field]).to include_ignoring_whitespace 'Stanford University student life photograph album, circa 1900-1906'
       end
     end


### PR DESCRIPTION
Fixes #723  (probably...)

This PR adds a new field (`collection_title_tesim`) that has a slight boost compared to the regular title field. This should cause relevant collection matches to show up higher in search results for equally relevant documents.



