### PR TITLE
update div to nav element

### DIFF
--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,4 +1,4 @@
-<div class='al-search-breadcrumb' role='navigation' aria-label=<%= t('arclight.breadcrumbs.aria_label') %> >
+<nav class='al-search-breadcrumb' role='navigation' aria-label=<%= t('arclight.breadcrumbs.aria_label') %> >
   <%= link_to t('arclight.routes.home'), root_path %>
   <span aria-hidden="true"><%= t('arclight.breadcrumb_separator') %></span>
   <% if collection_active? %>
@@ -12,4 +12,4 @@
   <% else %>
     <%= t('arclight.routes.search_results') %>
   <% end %>
-</div>
+</nav>


### PR DESCRIPTION
While reviewing accessibility tickets for demo, I realized I made a mistake on ticket #839 

- Update the div tag to use nav tag for the search breadcrumbs.

<a href="https://cl.ly/79e8eaca7a4a" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/0e0P2R2T0T3g2A1y0R0b/Screen%20Shot%202019-09-30%20at%204.47.43%20PM.png" style="display: block;height: auto;width: 100%;"/></a>