### PR TITLE
Removes duplicate spacing classes and use aeon web ead button classes

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -16,6 +16,17 @@
   font-size: $font-size-sm;
   height: 100%;
   padding: $spacer;
+  
+  :first-child {
+    padding-top: 0;
+  }
+  :last-child {
+    padding-bottom: 0;
+  }
+
+  > div {
+    padding: ($spacer / 3) 0;
+  }
 
   &-options {
     display: flex;
@@ -102,5 +113,3 @@ a.al-toggle-view-all{
 dl dd {
   overflow-wrap: break-word;
 }
-
-

--- a/app/views/arclight/requests/_aeon_web_ead.html.erb
+++ b/app/views/arclight/requests/_aeon_web_ead.html.erb
@@ -3,5 +3,5 @@
   <% aeon_web_ead ||= Arclight::Requests::AeonWebEad.new(document, parsed_files.href) %>
   <% aeon_web_ead_url = aeon_web_ead.try(:url) %>
 
-  <%= link_to 'Request', aeon_web_ead_url %>
+  <%= link_to 'Request', aeon_web_ead_url, class: 'btn btn-secondary btn-sm' %>
 <% end %>

--- a/app/views/catalog/_document_downloads.html.erb
+++ b/app/views/catalog/_document_downloads.html.erb
@@ -1,7 +1,7 @@
 <% if document_downloads.files.present? %>
-  <div class="mt-2 mx-0 px-0 py-2 al-show-actions-box-downloads">
+  <div class=" al-show-actions-box-downloads">
     <% document_downloads.files.each do |file| %>
-      <div class="mx-0 px-0 py-1 al-show-actions-box-downloads-file">
+      <div class="py-1 al-show-actions-box-downloads-file">
         <%= blacklight_icon(file.type, classes: "al-show-actions-box-downloads-file") %>
         <% if file.size %>
           <%= link_to(t("arclight.views.show.download_with_size.#{file.type}", size: file.size), file.href) %>

--- a/app/views/catalog/_show_actions_box_default.html.erb
+++ b/app/views/catalog/_show_actions_box_default.html.erb
@@ -13,7 +13,7 @@
     <% end %>
   </div>
 
-  <div class='mt-2 mb-1 pt-1 pt-2 al-show-actions-box-options'>
+  <div class='al-show-actions-box-options'>
     <%= render partial: 'arclight/requests', locals: { document: document } %>
     <div class='mr-auto al-show-actions-box-bookmarks'>
       <%= render partial: 'catalog/bookmark_control', locals: { document: document } %>


### PR DESCRIPTION
This is a follow on based on evaluation of #640 . There seemed to be some duplicate classes here that interacted and the aim here was to overall simplify the approach for styling this area.

@ggeisler mind weighing in here?

## Before
![Screen Shot 2019-10-01 at 1 25 54 PM](https://user-images.githubusercontent.com/1656824/65993835-3852a380-e44f-11e9-8ad8-d0d21cbecdff.png)
## After
![Screen Shot 2019-10-01 at 1 26 03 PM](https://user-images.githubusercontent.com/1656824/65993834-3852a380-e44f-11e9-9b8c-15a3b8559fa6.png)
## Mocks
![](https://user-images.githubusercontent.com/101482/63729709-2b71dd00-c81d-11e9-9375-278c11b5c367.png)