### PR TITLE
use translations for expand and collapse button

### DIFF
--- a/app/assets/javascripts/arclight/context_navigation.js
+++ b/app/assets/javascripts/arclight/context_navigation.js
@@ -87,7 +87,10 @@ class ContextNavigation {
 
         // Add the "expand" button
         // @todo this needs to be refactored
-        const $expandButton = $('<button class="my-3 btn btn-secondary btn-sm">Expand</button>');
+        const parentUl = $('ul.parent');
+        const collapseText = parentUl[0].dataset.dataCollapse;
+        const expandText = parentUl[0].dataset.dataExpand;
+        const $expandButton = $(`<button class="my-3 btn btn-secondary btn-sm">${expandText}</button>`);
         const prevSiblingContainer = $('<ul class="pl-0 prev-siblings"></ul>');
         prevSiblingContainer.append($expandButton);
         $expandButton.click((event) => {
@@ -96,7 +99,7 @@ class ContextNavigation {
           const targetedChildren = children.slice(0, -1);
           targetedChildren.toggleClass('collapsed');
           $target.toggleClass('collapsed');
-          const targetText = $target.hasClass('collapsed') ? 'Collapse' : 'Expand';
+          const targetText = $target.hasClass('collapsed') ? collapseText : expandText;
           $target.text(targetText);
         });
 

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -270,7 +270,11 @@ module ArclightHelper
   # the collection / component / subcomponent structure
   def nested_component_lists(document)
     document.parent_ids.reverse.reduce(''.html_safe) do |acc, parent_id|
-      content_tag(:ul) do
+      content_tag(
+        :ul,
+        class: 'parent',
+        data: { 'data-collapse': I18n.t('arclight.views.show.collapse'), 'data-expand': I18n.t('arclight.views.show.expand') }
+      ) do
         content_tag(:li, id: parent_id) do
           safe_join(
             [context_navigator_content(document, parent_id), acc]

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -52,6 +52,7 @@ en:
         view_more: View more
       show:
         access: Access
+        collapse: Collapse
         collection_id: 'Collection ID: %{id}'
         context: Collection context
         context_nav:
@@ -64,6 +65,7 @@ en:
           default: Download (%{size})
           ead: Download EAD (%{size})
           pdf: Download finding aid (%{size})
+        expand: Expand
         has_content: Contents
         no_contents: No content inventory
         no_online_content: No online content


### PR DESCRIPTION
closes #893 
### Description
Use internationalizations for the expand/collpase button on the collection context view

### Changes

- added expand and collapse translations
- added data attributes to the parent ul element containing the translations
- used data attributes in the javascript for the button text