### PR TITLE
grouped search breadcrumbs no longer truncated

### DIFF
--- a/app/views/catalog/_arclight_index_group_document_default.html.erb
+++ b/app/views/catalog/_arclight_index_group_document_default.html.erb
@@ -1,5 +1,5 @@
 <article class="document">
-  <% breadcrumbs = component_top_level_parent_to_links(document) %>
+  <% breadcrumbs = parents_to_links(document) %>
   <div class="documentHeader row">
     <div class="col-auto">
       <%= blacklight_icon document_header_icon(document) %>
@@ -11,7 +11,7 @@
       <div class='breadcrumb-links media'>
         <% unless breadcrumbs.nil? %>
           <span class="media-body" aria-hidden="true"><%= blacklight_icon :folder, classes: 'al-folder-icon' %></span>
-          <span class="col" ><%= component_top_level_parent_to_links(document) %></span>
+          <span class="col" ><%= parents_to_links(document) %></span>
         <% end %>
     </div>
   </div>

--- a/spec/features/grouped_results_spec.rb
+++ b/spec/features/grouped_results_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Grouped search results', type: :feature do
   it 'displays icons for results' do
     visit search_catalog_path q: 'alpha', group: 'true'
     within '.grouped-documents' do
-      expect(page).to have_css '.blacklight-icons', count: 5
+      expect(page).to have_css '.blacklight-icons', count: 6
     end
   end
 


### PR DESCRIPTION
closes #900 
### Issue
Breadcrumb links were being truncated in both the compact and list views when choosing Grouped option. Breadcrumbs <i>should not be</i> truncated in the grouped list view. Breadcrumbs <i>should be</i> truncated in the grouped compact view. 

### Demo
List View:
<a href="https://cl.ly/49ff51d02937" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/1X3m0M0U3E0I1u0I2j3N/Screen%20Shot%202019-10-01%20at%205.51.08%20PM.png" style="display: block;height: auto;width: 100%;"/></a>

No change made to grouped compact view:
<a href="https://cl.ly/310f8b5c76e1" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/3G353r140346332e2x1T/Screen%20Shot%202019-10-01%20at%205.50.33%20PM.png" style="display: block;height: auto;width: 100%;"/></a>