### PR TITLE
Bugfixes for ID-less components: prepend al_ to IDs & correctly set a…

### DIFF
--- a/lib/arclight/hash_absolute_xpath.rb
+++ b/lib/arclight/hash_absolute_xpath.rb
@@ -24,7 +24,7 @@ module Arclight
     end
 
     def to_hexdigest
-      self.class.hash_algorithm.hexdigest(absolute_xpath)
+      self.class.hash_algorithm.hexdigest(absolute_xpath).prepend('al_')
     end
 
     def absolute_xpath

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -252,6 +252,7 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
                          "The ID of this document will be #{parent_id}#{hexdigest}."
                        ].join(' ')
                      end
+                     record['id'] = hexdigest
                      hexdigest
                    else
                      record.attribute('id')&.value&.strip&.gsub('.', '-')

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -659,18 +659,24 @@ describe 'EAD 2 traject indexing', type: :feature do
     let(:fixture_path) do
       Arclight::Engine.root.join('spec', 'fixtures', 'ead', 'sample', 'no-ids-recordgrp-level.xml')
     end
+    let(:first_component) { result['components'].first }
+    let(:second_component) { result['components'].second }
 
     it 'mints component ids by hashing absolute paths' do
       expect(result).to include 'components'
       expect(result['components']).not_to be_empty
-      first_component = result['components'].first
-      second_component = result['components'].second
 
-      expect(first_component['ref_ssi']).to contain_exactly('4bf70b448ac8351a147acff1dd8b1c0b9a791980')
-      expect(first_component['id']).to contain_exactly('ehllHemingwayErnest-sample4bf70b448ac8351a147acff1dd8b1c0b9a791980')
+      expect(first_component['ref_ssi']).to contain_exactly('al_4bf70b448ac8351a147acff1dd8b1c0b9a791980')
+      expect(first_component['id']).to contain_exactly('ehllHemingwayErnest-sampleal_4bf70b448ac8351a147acff1dd8b1c0b9a791980')
 
-      expect(second_component['ref_ssi']).to contain_exactly('54b06e5ad77cab05ec7f6beeaca50022c47d9c7b')
-      expect(second_component['id']).to contain_exactly('ehllHemingwayErnest-sample54b06e5ad77cab05ec7f6beeaca50022c47d9c7b')
+      expect(second_component['ref_ssi']).to contain_exactly('al_54b06e5ad77cab05ec7f6beeaca50022c47d9c7b')
+      expect(second_component['id']).to contain_exactly('ehllHemingwayErnest-sampleal_54b06e5ad77cab05ec7f6beeaca50022c47d9c7b')
+    end
+
+    it 'indexes trail of ancestor ids' do
+      expect(second_component['parent_ssm']).to equal_array_ignoring_whitespace(
+        %w[ehllHemingwayErnest-sample al_4bf70b448ac8351a147acff1dd8b1c0b9a791980]
+      )
     end
   end
 

--- a/spec/lib/arclight/hash_absolute_xpath_spec.rb
+++ b/spec/lib/arclight/hash_absolute_xpath_spec.rb
@@ -47,18 +47,18 @@ RSpec.describe Arclight::HashAbsoluteXpath do
     expect(described_class.new(components[4]).absolute_xpath).to eq 'document/ead/archdesc/dsc/c1/c1'
   end
 
-  it 'hashes the absolute_xpath' do
-    expect(described_class.new(components[0]).to_hexdigest).to eq '9c4e84c284385184b7e3548ebe2a81a9df522a67'
-    expect(described_class.new(components[1]).to_hexdigest).to eq '73760c5f85d3691b9f537a5ca3d887825e6e0ee9'
-    expect(described_class.new(components[2]).to_hexdigest).to eq '44c3b0a0ba891df68aa056f9d3e3fcf23f64ad4e'
-    expect(described_class.new(components[3]).to_hexdigest).to eq '75fdc26f3f0a5fd30e157dbd523885a4eda7ecb3'
-    expect(described_class.new(components[4]).to_hexdigest).to eq '72636263da05d832fb4a05c90c2b2c79480af70e'
+  it 'hashes the absolute_xpath & prepends al_' do
+    expect(described_class.new(components[0]).to_hexdigest).to eq 'al_9c4e84c284385184b7e3548ebe2a81a9df522a67'
+    expect(described_class.new(components[1]).to_hexdigest).to eq 'al_73760c5f85d3691b9f537a5ca3d887825e6e0ee9'
+    expect(described_class.new(components[2]).to_hexdigest).to eq 'al_44c3b0a0ba891df68aa056f9d3e3fcf23f64ad4e'
+    expect(described_class.new(components[3]).to_hexdigest).to eq 'al_75fdc26f3f0a5fd30e157dbd523885a4eda7ecb3'
+    expect(described_class.new(components[4]).to_hexdigest).to eq 'al_72636263da05d832fb4a05c90c2b2c79480af70e'
   end
 
   it 'allows the hashing algorithm to be configured' do
     hash_algorithm = described_class.hash_algorithm
     described_class.hash_algorithm = Digest::SHA256
-    expect(described_class.new(components[0]).to_hexdigest).to eq '4b884bc407a22e7e6a41867ef4987b7c49f81c641fe0c4d1f92009a5e4b963a9'
+    expect(described_class.new(components[0]).to_hexdigest).to eq 'al_4b884bc407a22e7e6a41867ef4987b7c49f81c641fe0c4d1f92009a5e4b963a9'
     described_class.hash_algorithm = hash_algorithm
   end
 end


### PR DESCRIPTION
…ncestor trail. Fixes #895.

### Problems Solved (see #895):
- Components with missing IDs were not rendering with the correct nesting in the context tree nor in the breadcrumb area
- Many components with missing IDs would not expand/collapse their descendant nodes upon clicking +/- This was due to a limitation of Bootstrap (collapsed section IDs have to begin with a letter)

### Solutions Implemented in this PR:
- Prepend minted component IDs with `al_` so they begin with a letter (fixes the Bootstrap collapse/expand)
- Write the minted `id` back to the node's `id` attribute during indexing so it gets subsequently picked up correctly in descendant nodes' ancestor trail array (in `parent_ssm`).

![Screen Shot 2019-10-02 at 12 57 28 PM](https://user-images.githubusercontent.com/3933756/66064928-61893780-e514-11e9-829c-e07027a99b43.png)

![Screen Shot 2019-10-02 at 12 57 07 PM](https://user-images.githubusercontent.com/3933756/66064929-61893780-e514-11e9-99e2-3a67f6b7c8c3.png)

