### PR TITLE
make grouped title a link

### DIFF
--- a/app/views/catalog/_group_header_compact_default.html.erb
+++ b/app/views/catalog/_group_header_compact_default.html.erb
@@ -6,7 +6,7 @@
           <%= link_to(document.repository_config.name, arclight_engine.repository_path(document.repository_config.slug)) %>
         </div>
       <% end %>
-      <h3><%= show_presenter(document).heading %></h3>
+      <h3><%= link_to_document document, document_show_link_field(document) %></h3>
       <%= content_tag('span', class: 'badge badge-light') do %>
         <%= document.extent %>
       <% end if document.extent %>

--- a/app/views/catalog/_group_header_default.html.erb
+++ b/app/views/catalog/_group_header_default.html.erb
@@ -6,7 +6,7 @@
           <%= link_to(document.repository_config.name, arclight_engine.repository_path(document.repository_config.slug)) %>
         </div>
       <% end %>
-      <h3><%= show_presenter(document).heading %></h3>
+      <h3><%= link_to_document document, document_show_link_field(document) %></h3>
       <%= content_tag('span', class: 'badge badge-light') do %>
         <%= document.extent %>
       <% end if document.extent %>

--- a/spec/features/grouped_results_spec.rb
+++ b/spec/features/grouped_results_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Grouped search results', type: :feature do
   it 'displays collection group information' do
     visit search_catalog_path q: 'alpha', group: 'true'
     within '.al-grouped-title-bar' do
-      expect(page).to have_css 'h3', text: /Alpha/
+      expect(page).to have_css 'h3 a', text: /Alpha/
       expect(page).to have_css '.al-document-abstract-or-scope', text: /founded in 1902/
       expect(page).to have_css '.badge', text: '15.0 linear feet (36 boxes + oversize folder)'
     end
@@ -49,7 +49,7 @@ RSpec.describe 'Grouped search results', type: :feature do
       visit search_catalog_path q: 'alpha', group: 'true', view: 'compact'
 
       within '.al-grouped-title-bar' do
-        expect(page).to have_css 'h3', text: /Alpha/
+        expect(page).to have_css 'h3 a', text: /Alpha/
         expect(page).not_to have_css '.al-document-abstract-or-scope', text: /founded in 1902/
         expect(page).to have_css '.badge', text: '15.0 linear feet (36 boxes + oversize folder)'
       end


### PR DESCRIPTION
Closes #787 
### Issue 
Currently the Collection title in the grouped search results page is not linked to  the collection. It is recommended to add the link. Use default styling as styling is to be determined later

### Demo
Grouped List View:
<a href="https://cl.ly/c729500267c2" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/1Q1j3K333H1E0B0u1A1V/Screen%20Shot%202019-10-01%20at%207.30.27%20PM.png" style="display: block;height: auto;width: 100%;"/></a>

Grouped Compact View:
<a href="https://cl.ly/60ec3ab53eb1" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/1o37383n0m3b391b0o3l/Screen%20Shot%202019-10-01%20at%207.30.12%20PM.png" style="display: block;height: auto;width: 100%;"/></a>