### PR TITLE
Collection context: Remove list-style from lists #907

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -126,6 +126,10 @@
     font-size: $h5-font-size;
   }
 
+  ul {
+    list-style: none;
+  }
+
   .documents-hierarchy,
   .documents-online_contents {
     .documentHeader {

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'Component Page', type: :feature do
           expect(page).to have_css 'li:nth-child(2)', text: 'Statements of purpose, c.1902'
           expect(page).to have_css 'li:nth-child(3)',
                                    text: 'Constitution - notes on drafting of constitution, c.1902-1903'
-          expect(page).to have_css 'li', count: 33
+          expect(page).to have_css 'li', count: 32
         end
       end
     end


### PR DESCRIPTION
Closes #907 

Updated app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss to add:

> #collection-context {
>   ul {
>     list-style: none;
>   }