### PR TITLE
Tab presence & contents by component level #891

### DIFF
--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -5,7 +5,7 @@
         <ul class='nav nav-tabs nav-fill' role='tablist' aria-label='<%= t('arclight.views.show.tablist_nav') %>'>
           <li class='nav-item flex-fill'>
             <a class='nav-link p-1 p-sm-2 active' data-toggle='tab' href='#context' role='tab'>
-              <%= t 'arclight.views.show.context' %>
+              <%= t 'arclight.views.show.overview' %>
             </a>
           </li>
           <li class='nav-item flex-fill'>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -6,13 +6,6 @@
           <%= t 'arclight.views.show.context' %>
         </a>
       </li>
-      <% if document.children? %>
-        <li class='nav-item flex-fill'>
-          <a class='nav-link p-1 p-sm-2 disabled' data-toggle='tab' href='#contents' role='tab' data-hierarchy-enable-me='true'>
-            <%= t 'arclight.views.show.no_contents' %>
-          </a>
-        </li>
-      <% end %>
       <li class='nav-item flex-fill'>
         <a class='nav-link p-1 p-sm-2 <%= 'disabled' unless document.online_content? %>' data-toggle='tab' href='#online-content' role='tab' data-arclight-online-content-tab='true'>
           <% if document.online_content? %>
@@ -32,9 +25,6 @@
       <div class='tab-pane active' id='context' role='tabpanel'>
         <%= render 'component_context' %>
       </div>
-      <div class='tab-pane' id='contents' role='tabpanel'>
-        <%= render 'component_contents' %>
-      </div>
       <div class='tab-pane' id='online-content' role='tabpanel'>
         <%= render_document_partial(document, 'arclight_viewer') %>
       </div>
@@ -49,5 +39,4 @@
       </div>
     </div>
   </div>
-
 </div>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -69,6 +69,7 @@ en:
         no_online_content: No online content
         online_content: Online content
         our_collections: Our Collections
+        overview: Overview
         sections:
           access_field: Access and Use
           background_field: Background

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe 'Collection Page', type: :feature do
         expect(page).to have_css '#contents', visible: true
         expect(page).to have_css '#context', visible: false
         expect(page).to have_css '#access', visible: false
-        click_link 'Collection context'
+        click_link 'Overview'
         expect(page).to have_css '#context', visible: true
         expect(page).to have_css '#contents', visible: false
         expect(page).to have_css '#access', visible: false

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Component Page', type: :feature do
   end
 
   describe 'tabbed display' do
-    it 'clicking contents toggles visibility', js: true do
+    it 'clicking context toggles visibility', js: true do
       expect(page).to have_css '#context', visible: true
       expect(page).to have_css '#online-content', visible: false
       expect(page).to have_css '#access', visible: false
@@ -35,20 +35,7 @@ RSpec.describe 'Component Page', type: :feature do
       expect(page).to have_css '#access', visible: false
       click_link 'Access'
       expect(page).to have_css '#context', visible: false
-      expect(page).to have_css '#contents', visible: false
       expect(page).to have_css '#access', visible: true
-    end
-
-    describe 'contents tab', js: true do
-      let(:doc_id) { 'aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671' }
-
-      it 'is present and accessible' do
-        expect(page).to have_css('li.nav-item a', text: 'Contents', visible: true)
-        click_link 'Contents'
-        expect(page).to have_css '#context', visible: false
-        expect(page).to have_css '#contents', visible: true
-        expect(page).to have_css '#online-content', visible: false
-      end
     end
   end
 


### PR DESCRIPTION
Closed #891.

Per the issue, this PR:
In app/views/catalog/_show_collection.html.erb change the first tab from "Collection Context" to be "Overview" (only for the collection show page).
In app/views/catalog/_show_default.html.erb, remove the "Contents" tab.

**_UPDATE (especially for Jennifer ;-)) Jack cleared up my concern by pointing out that Esty's work to add the expands pluses/minuses would enable us to see the subseries and file levels._**