### PR TITLE
Restructures the Context Navigation JavaScript functionality for expanding/collapsing sibling Document <li> elements

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -170,7 +170,7 @@
     }
   }
 
-  .prev-siblings li {
+  .prev-siblings li, li.al-collection-context {
     visibility: visible;
     opacity: 1;
     transition: visibility 0s, height 0.5s, opacity 0.5s linear;

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -274,7 +274,7 @@ module ArclightHelper
     document.parent_ids.reverse.reduce(''.html_safe) do |acc, parent_id|
       content_tag(
         :ul,
-        class: ['parent', 'collection-context'],
+        class: %w[parent collection-context],
         data: { 'data-collapse': I18n.t('arclight.views.show.collapse'), 'data-expand': I18n.t('arclight.views.show.expand') }
       ) do
         content_tag(:li, id: parent_id) do

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -274,7 +274,7 @@ module ArclightHelper
     document.parent_ids.reverse.reduce(''.html_safe) do |acc, parent_id|
       content_tag(
         :ul,
-        class: 'parent',
+        class: ['parent', 'collection-context'],
         data: { 'data-collapse': I18n.t('arclight.views.show.collapse'), 'data-expand': I18n.t('arclight.views.show.expand') }
       ) do
         content_tag(:li, id: parent_id) do

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe 'Component Page', type: :feature do
           'li.al-hierarchy-highlight',
           text: 'Constitution - notes on drafting of constitution, c.1902-1903'
         )
+        first('.btn-secondary', text: 'Expand').click
         expect(page).to have_css '.document-title-heading', text: 'Statements of purpose, c.1902'
         expect(page).to have_css '.document-title-heading', text: 'Constitution and by-laws - drafts, 1902-1904'
       end
@@ -168,28 +169,30 @@ RSpec.describe 'Component Page', type: :feature do
 
       it 'hides all but the first previous sibling document items' do
         within '#collection-context' do
+          expect(page).to have_css '.document-title-heading', text: 'Pages 273-353'
           expect(page).to have_css '.document-title-heading', text: 'Pages 171-272'
-          expect(page).to have_css '.document-title-heading', text: 'Pages 79-170'
-          expect(page).not_to have_css '.document-title-heading', text: 'Pages 1-78'
+          expect(page).not_to have_css '.document-title-heading', text: 'Pages 79-170'
+          expect(page).to have_css '.document-title-heading', text: 'Pages 1-78'
         end
       end
 
       it 'offers a button for displaying the hidden sibling document items' do
         within '#collection-context' do
           expect(page).to have_css '.btn-secondary', text: 'Expand'
+          expect(page).to have_css '.document-title-heading', text: 'Pages 1-78'
+          expect(page).not_to have_css '.document-title-heading', text: 'Pages 79-170'
           expect(page).to have_css '.document-title-heading', text: 'Pages 171-272'
-          expect(page).to have_css '.document-title-heading', text: 'Pages 79-170'
-          expect(page).not_to have_css '.document-title-heading', text: 'Pages 1-78'
+          expect(page).to have_css '.document-title-heading', text: 'Pages 273-353'
 
-          find('.btn-secondary', text: 'Expand').click
+          first('.btn-secondary', text: 'Expand').click
 
           expect(page).to have_css '.btn-secondary', text: 'Collapse'
-          expect(page).to have_css '.document-title-heading', text: 'Pages 1-78'
+          expect(page).to have_css '.document-title-heading', text: 'Pages 79-170'
 
-          find('.btn-secondary', text: 'Collapse').click
+          first('.btn-secondary', text: 'Collapse').click
 
           expect(page).to have_css '.btn-secondary', text: 'Expand'
-          expect(page).not_to have_css '.document-title-heading', text: 'Pages 1-78'
+          expect(page).not_to have_css '.document-title-heading', text: 'Pages 79-170'
         end
       end
     end


### PR DESCRIPTION
Advances #812 by restructuring the Context Navigation JavaScript functionality in order to use an ExampleButton class, three separate ContextNavigation methods for
modifying the <ul> in the DOM, and ensuring that <li> elements for
sibling Documents are hidden and "expandable"

Please see the following screenshots for cases where sibling <li> elements precede the current (highlighted) Document:

![image](https://user-images.githubusercontent.com/1443986/66106488-fd09bf00-e58b-11e9-9ffb-d686947a5a79.png)
![image](https://user-images.githubusercontent.com/1443986/66106448-e5323b00-e58b-11e9-99ed-3cd4bf59022b.png)
