### PR TITLE
Justify content between title/breadcrumb + actions box.

### DIFF
--- a/app/views/catalog/_show_actions_box_default.html.erb
+++ b/app/views/catalog/_show_actions_box_default.html.erb
@@ -1,18 +1,20 @@
 <div class='al-show-actions-box d-flex flex-column'>
   <div class=" d-flex flex-wrap">
-    <div class='al-collection-id mr-2'>
-      <% if document.unitid %>
-        <%= t(:'arclight.views.show.collection_id', id: document.unitid) %>
-      <% end %>
+    <% if document.unitid || document.containers.present? %>
+      <div class='al-collection-id mr-2'>
+        <% if document.unitid %>
+          <%= t(:'arclight.views.show.collection_id', id: document.unitid) %>
+        <% end %>
 
-      <% if document.unitid && document.containers.present? %>
-        <span> | </span>
-      <% end %>
+        <% if document.unitid && document.containers.present? %>
+          <span> | </span>
+        <% end %>
 
-      <% if document.containers.present? %>
-        <span><%= document.containers.join(', ') %></span>
-      <% end %>
-    </div>
+        <% if document.containers.present? %>
+          <span><%= document.containers.join(', ') %></span>
+        <% end %>
+      </div>
+    <% end %>
     <div class='al-show-actions-box-options mt-md-3'>
       <%= render partial: 'arclight/requests', locals: { document: document } %>
       <div class='mr-auto al-show-actions-box-bookmarks'>

--- a/app/views/catalog/_show_breadcrumbs_default.html.erb
+++ b/app/views/catalog/_show_breadcrumbs_default.html.erb
@@ -1,4 +1,4 @@
-<div class='d-md-flex al-show'>
+<div class='d-md-flex justify-content-between al-show'>
   <div class='al-show-breadcrumb'>
     <%= render partial: 'shared/show_breadcrumbs', locals: {document: document} %>
   </div>


### PR DESCRIPTION
Also ensure that we don't render an empty div w/ right margin when there are no containers/unitid.

## Before
<img width="1160" alt="before" src="https://user-images.githubusercontent.com/96776/66152087-88577480-e5cd-11e9-90a5-d42702219e9c.png">

## After
<img width="981" alt="after" src="https://user-images.githubusercontent.com/96776/66152086-87bede00-e5cd-11e9-93f0-54533e5f3226.png">


![my bad](https://media.giphy.com/media/3olKx0vzBV74pUsPnB/giphy.gif)