### PR TITLE
Replace all hardcoded colors with variable equivalents

### DIFF
--- a/app/assets/stylesheets/arclight/modules/context_navigation.scss
+++ b/app/assets/stylesheets/arclight/modules/context_navigation.scss
@@ -6,7 +6,7 @@ li.al-collection-context  {
   flex-grow: 1;
   padding-left: 15px;
   max-width: 100%;
-  
+
   .documentHeader {
     flex-grow: 1;
     margin-bottom: $spacer;
@@ -23,13 +23,13 @@ li.al-collection-context  {
   .al-document-abstract-or-scope {
     max-width: 45em;
   }
-  
+
   .blacklight-icons svg {
-    fill: #797d81;
+    fill: $gray-600;
   }
 
   .al-online-content-icon svg {
-    fill: #28a745;
+    fill: $green;
   }
   @media (max-width: 767px) {
     padding-left: 0;
@@ -49,5 +49,3 @@ li.al-collection-context  {
     padding-left: 40px;
   }
 }
-
-

--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -23,7 +23,7 @@
 
   // Component title + children badge
   .documentHeader {
-    border-bottom: $border-width dashed #ccc;
+    border-bottom: $border-width dashed $gray-400;
     margin-bottom: ($spacer / 2);
     margin-top: ($spacer * 2);
   }

--- a/app/assets/stylesheets/arclight/modules/highlights.scss
+++ b/app/assets/stylesheets/arclight/modules/highlights.scss
@@ -5,7 +5,7 @@
   font-style: italic;
   margin-bottom: $spacer;
   em {
-    background-color: yellow;
+    background-color: $background-highlight;
     font-weight: bold;
   }
 }

--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -14,7 +14,7 @@
 }
 
 .al-show-actions-box {
-  border: $result-item-border-styling;
+  border: $default-border-styling;
   background-color: $gray-200;
   font-size: $font-size-sm;
   height: 100%;

--- a/app/assets/stylesheets/arclight/modules/mastheads.scss
+++ b/app/assets/stylesheets/arclight/modules/mastheads.scss
@@ -1,5 +1,5 @@
 .al-homepage-masthead.jumbotron {
-  border-bottom: $result-item-border-styling;
+  border-bottom: $default-border-styling;
   padding: ($spacer * 2) $spacer $spacer;
 
   .navbar-nav {
@@ -57,8 +57,8 @@
   }
 
   + .navbar-search {
-    border-bottom: $result-item-border-styling;
-    border-top: $result-item-border-styling;
+    border-bottom: $default-border-styling;
+    border-top: $default-border-styling;
     margin-bottom: ($spacer / 2);
 
     a {
@@ -71,7 +71,7 @@
 
     .navbar-toggler {
       background-color: $white;
-      border: $result-item-border-styling;
+      border: $default-border-styling;
     }
 
     .navbar-toggler-icon {

--- a/app/assets/stylesheets/arclight/modules/repositories.scss
+++ b/app/assets/stylesheets/arclight/modules/repositories.scss
@@ -13,7 +13,7 @@
   }
 
   .al-document-title-bar {
-    border-top: $result-item-border-styling;
+    border-top: $default-border-styling;
     margin-bottom: $spacer;
     padding-top: ($spacer / 2);
 

--- a/app/assets/stylesheets/arclight/modules/repository_card.scss
+++ b/app/assets/stylesheets/arclight/modules/repository_card.scss
@@ -1,6 +1,6 @@
 .al-repository {
   background-color: $gray-200;
-  border: $result-item-border-styling;
+  border: $default-border-styling;
   margin-bottom: $spacer;
 
   .al-repository-information {
@@ -33,7 +33,7 @@
       padding-left: $spacer * 2;
 
       @media (min-width: 992px) {
-        border-left: $result-item-border-styling;
+        border-left: $default-border-styling;
       }
     }
 

--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -4,7 +4,7 @@
   // Result item header
   .al-document-title-bar {
     background-color: $gray-200;
-    border: $result-item-border-styling;
+    border: $default-border-styling;
     font-size: $font-size-sm;
     margin: 0 (-$result-item-body-padding - 1px) 0.5rem;
     padding: 3px $result-item-body-padding;
@@ -20,7 +20,7 @@
       font-size: $h5-font-size;
       .al-document-extent {
         background-color: $gray-200;
-        border: $result-item-border-styling;
+        border: $default-border-styling;
         font-size: $font-size-sm;
         margin-bottom: 0.25rem;
         padding: 2px $result-item-body-padding;
@@ -52,8 +52,8 @@ article.document {
   .blacklight-icons.al-online-content-icon svg {
     fill: $green;
   }
-  div.breadcrumb-links, 
-  div.al-document-abstract-or-scope, 
+  div.breadcrumb-links,
+  div.al-document-abstract-or-scope,
   div.al-document-creator {
     margin-top: ($spacer * .5);
   }
@@ -100,8 +100,8 @@ article.document {
 
 .documents-hierarchy {
   .al-number-of-children-badge {
-    background-color: #eee;
-    border: 1px solid #ccc;
+    background-color: $gray-200;
+    border: $default-border-styling;
     color: $gray-600;
     vertical-align: top;
   }
@@ -121,11 +121,11 @@ article.document {
   margin-bottom: $spacer;
 
   .document {
-    border-bottom: $result-item-border-styling;
+    border-bottom: $default-border-styling;
     padding: $spacer 0;
 
     &:first-child {
-      border-top: $result-item-border-styling;
+      border-top: $default-border-styling;
     }
   }
 }
@@ -135,7 +135,7 @@ article.document {
 }
 
 .al-document-container.text-muted {
-  color: #ADB5BD !important;
+  color: $gray-600 !important;
 }
 
 .col-no-left-padding {
@@ -167,5 +167,5 @@ article.document {
 }
 
 .btn-outline-secondary:not(:disabled):not(.disabled).active svg, .btn-outline-secondary:hover svg {
-  fill: #fff;
+  fill: $white;
 }

--- a/app/assets/stylesheets/arclight/modules/show_collection.scss
+++ b/app/assets/stylesheets/arclight/modules/show_collection.scss
@@ -1,12 +1,12 @@
 // Collection header
 .al-show-header-section {
-  border: $result-item-border-styling;
+  border: $default-border-styling;
   margin-bottom: $spacer;
   padding: 0 $spacer;
 
   .al-document-title-bar {
     background-color: $gray-200;
-    border-bottom: $result-item-border-styling;
+    border-bottom: $default-border-styling;
     font-size: $font-size-sm;
     margin: 0 (-$spacer) $spacer;
     padding: 3px $result-item-body-padding;

--- a/app/assets/stylesheets/arclight/variables.scss
+++ b/app/assets/stylesheets/arclight/variables.scss
@@ -1,2 +1,9 @@
+// Colors
+$background-highlight: #ffffaa;
+$default-border-color: $gray-400;
+
+// Spacing
 $result-item-body-padding: 12px;
-$result-item-border-styling: 1px solid #ccc;
+
+// Mixins
+$default-border-styling: 1px solid $default-border-color;


### PR DESCRIPTION
This PR shouldn't cause any visible change in the UI. All updates are to `scss` files so it shouldn't affect any tests.

This is just a preliminary step of the styling updates we want to make and it isn't focused on actually improving any visible styling; I'm only trying to get the `scss` files a bit more correct and organized so that later, more focused styling will be easier to do.

- Replaced all occurrences of hardcoded color values with either Bootstrap or ArcLight-specific color variables.
- Made a couple of variable and mixin name updates
