### PR TITLE
Convert EAD formatting tags to HTML at render time. Closes #758,…

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -155,3 +155,33 @@ a.al-toggle-view-all{
 dl dd {
   overflow-wrap: break-word;
 }
+
+dl.deflist dt {
+  text-align: left;
+}
+
+.chronlist-head, .list-head {
+  caption-side: top;
+  font-size: 1.25rem;
+  font-weight: 500;
+  margin-bottom: 1rem;
+}
+
+.chronlist th,
+.chronlist-item-date {
+  font-weight: 500;
+}
+
+.chronlist-item-date {
+  width: 15ch;
+}
+
+.chronlist-item-event {
+  div:not(:last-child) {
+    margin-bottom: 0.75rem;
+  }
+}
+
+.text-underline {
+  text-decoration: underline;
+}

--- a/app/assets/stylesheets/arclight/modules/show_collection.scss
+++ b/app/assets/stylesheets/arclight/modules/show_collection.scss
@@ -32,7 +32,7 @@
   font-size: $h6-font-size;
   text-transform: uppercase;
 
-  + dl dt {
+  + dl > dt {
     font-size: $font-size-sm;
     margin-top: 4px;
     text-transform: uppercase;

--- a/app/controllers/concerns/arclight/ead_format_helpers.rb
+++ b/app/controllers/concerns/arclight/ead_format_helpers.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+module Arclight
+  ##
+  # A module to add EAD to HTML transformation rules for Arclight
+  module EadFormatHelpers # rubocop:disable Metrics/ModuleLength
+    extend ActiveSupport::Concern
+    include ActionView::Helpers::OutputSafetyHelper
+
+    def render_html_tags(args)
+      values = args[:value] || []
+      values.map! do |value|
+        html_sanitize(transform_ead_to_html(value))
+      end
+      values.map! { |value| wrap_in_paragraph(value) } if values.count > 1
+      safe_join(values.map(&:html_safe))
+    end
+
+    private
+
+    def transform_ead_to_html(value)
+      Loofah.xml_fragment(condense_whitespace(value))
+            .scrub!(ead_to_html_scrubber).to_html
+    end
+
+    def html_sanitize(value)
+      Loofah.fragment(value).scrub!(:strip).to_html
+    end
+
+    def ead_to_html_scrubber
+      Loofah::Scrubber.new do |node|
+        format_render_attributes(node) if node.attr('render').present?
+        format_lists(node) if %w[list chronlist].include? node.name
+        node
+      end
+    end
+
+    def condense_whitespace(str)
+      str.squish.strip.gsub(/>[\n\s]+</, '><')
+    end
+
+    def wrap_in_paragraph(value)
+      if value.start_with?('<')
+        value
+      else
+        content_tag(:p, value)
+      end
+    end
+
+    def format_render_attributes(node) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
+      case node.attr('render')
+      when 'altrender'
+        node.name = 'span'
+        node['class'] = node['altrender']
+      when 'bold'
+        node.name = 'strong'
+      when 'bolddoublequote'
+        node.name = 'strong'
+        node.prepend_child '"'
+        node.add_child '"'
+      when 'bolditalic'
+        node.name = 'strong'
+        node.wrap('<em/>')
+      when 'boldsinglequote'
+        node.name = 'strong'
+        node.prepend_child '\''
+        node.add_child '\''
+      when 'boldsmcaps'
+        node.name = 'strong'
+        node.wrap('<small/>')
+        node['class'] = 'text-uppercase'
+      when 'boldunderline'
+        node.name = 'strong'
+        node['class'] = 'text-underline'
+      when 'doublequote'
+        node.name = 'span'
+        node.prepend_child '"'
+        node.add_child '"'
+      when 'italic'
+        node.name = 'em'
+      when 'nonproport'
+        node.name = 'em'
+      when 'singlequote'
+        node.name = 'span'
+        node.prepend_child '\''
+        node.add_child '\''
+      when 'smcaps'
+        node.name = 'small'
+        node['class'] = 'text-uppercase'
+      when 'sub'
+        node.name = 'sub'
+      when 'super'
+        node.name = 'sup'
+      when 'underline'
+        node.name = 'span'
+        node['class'] = 'text-underline'
+      end
+    end
+
+    def format_lists(node)
+      format_simple_lists(node) if node.name == 'list' && node['type'] != 'deflist'
+      format_deflists(node) if node.name == 'list' && node['type'] == 'deflist'
+      format_chronlists(node) if node.name == 'chronlist'
+    end
+
+    def format_simple_lists(node)
+      node.name = 'ul' if (%w[simple marked].include? node['type']) || node['type'].blank?
+      node.name = 'ol' if node['type'] == 'ordered'
+      node.remove_attribute('type')
+      head_node = node.at_css('head')
+      format_list_head(head_node) if head_node.present?
+      items = node.css('item')
+      items.each { |item_node| item_node.name = 'li' }
+    end
+
+    def format_list_head(node)
+      node['class'] = 'list-head'
+      node.name = 'div'
+      node.parent.previous = node # move it from within the list to above it
+    end
+
+    def format_deflists(node)
+      listhead_node = node.at_css('listhead')
+      labels = node.css('label')
+      items = node.css('item')
+      defitems = node.css('defitem')
+      node.remove_attribute('type')
+
+      if listhead_node.present?
+        format_deflist_as_table(node, labels, items, defitems)
+      else
+        format_deflist_as_dl(node, labels, items, defitems)
+      end
+    end
+
+    def format_deflist_as_table(node, labels, items, defitems)
+      node.name = 'table'
+      node['class'] = 'table deflist'
+      listhead_node = node.at_css('listhead')
+      format_deflist_table_head(listhead_node)
+      node.at_css('thead').next = '<tbody/>'
+      labels.each { |label_node| label_node.name = 'td' }
+      items.each { |item_node| item_node.name = 'td' }
+      defitems.each do |defitem_node|
+        defitem_node.name = 'tr'
+        defitem_node.parent = node.at_css('tbody')
+      end
+    end
+
+    def format_deflist_table_head(listhead_node)
+      listhead_node.at_css('head01').name = 'th'
+      listhead_node.at_css('head02').name = 'th'
+      listhead_node.name = 'tr'
+      listhead_node.wrap('<thead/>')
+    end
+
+    def format_deflist_as_dl(node, labels, items, defitems)
+      node.name = 'dl'
+      node['class'] = 'deflist'
+      labels.each { |label_node| label_node.name = 'dt' }
+      items.each { |item_node| item_node.name = 'dd' }
+      defitems.each { |defitem_node| defitem_node.swap(defitem_node.children) } # unwrap
+    end
+
+    def format_chronlists(node)
+      node.name = 'table'
+      node['class'] = 'table chronlist'
+      eventgrps = node.css('eventgrp')
+      single_events = node.css('chronitem > event')
+      multi_events = node.css('eventgrp > event')
+      format_chronlist_header(node)
+      node.at_css('thead').next = '<tbody/>'
+      format_chronlist_caption(node)
+      format_chronlist_chronitems(node)
+      format_chronlist_dates(node)
+      format_chronlist_events(eventgrps, single_events, multi_events)
+    end
+
+    def format_chronlist_header(node)
+      node.add_child('<thead><tr><th>Date</th><th>Event</th></tr></thead>')
+      table_head = node.at_css('thead')
+      node.children.first.add_previous_sibling(table_head)
+      listhead_node = node.at_css('listhead')
+      return unless listhead_node.present?
+
+      node.at_css('thead tr th:nth-of-type(1)').content = node.at_css('listhead/head01').content
+      node.at_css('thead tr th:nth-of-type(2)').content = node.at_css('listhead/head02').content
+      listhead_node.remove
+    end
+
+    def format_chronlist_caption(node)
+      head_node = node.at_css('head')
+      return unless head_node.present?
+
+      head_node.name = 'caption'
+      head_node['class'] = 'chronlist-head'
+      node.children.first.add_previous_sibling(head_node) # make the caption first
+    end
+
+    def format_chronlist_chronitems(node)
+      chronitems = node.css('chronitem')
+      chronitems.each do |chronitem_node|
+        chronitem_node.name = 'tr'
+        chronitem_node.parent = node.at_css('tbody')
+      end
+    end
+
+    def format_chronlist_dates(node)
+      dates = node.css('date')
+      dates.each do |date_node|
+        date_node.name = 'td'
+        date_node['class'] = 'chronlist-item-date'
+      end
+    end
+
+    def format_chronlist_events(eventgrps, single_events, multi_events)
+      eventgrps.each do |eventgrp_node|
+        eventgrp_node.name = 'td'
+        eventgrp_node['class'] = 'chronlist-item-event'
+      end
+      single_events.each do |event_node|
+        event_node.name = 'td'
+        event_node['class'] = 'chronlist-item-event'
+      end
+      multi_events.each { |event_node| event_node.name = 'div' }
+    end
+  end
+end

--- a/app/controllers/concerns/arclight/field_config_helpers.rb
+++ b/app/controllers/concerns/arclight/field_config_helpers.rb
@@ -7,6 +7,7 @@ module Arclight
     extend ActiveSupport::Concern
     include ActionView::Helpers::OutputSafetyHelper
     include ActionView::Helpers::TagHelper
+    include Arclight::EadFormatHelpers
 
     included do
       if respond_to?(:helper_method)
@@ -21,6 +22,7 @@ module Arclight
         helper_method :item_requestable?
         helper_method :paragraph_separator
         helper_method :link_to_name_facet
+        helper_method :render_html_tags
       end
     end
 

--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -5,6 +5,7 @@ module Arclight
   # Extends Blacklight::Solr::Document to provide Arclight specific behavior
   module SolrDocument
     extend Blacklight::Solr::Document
+    include Arclight::EadFormatHelpers
 
     def repository_config
       return unless repository
@@ -57,7 +58,8 @@ module Arclight
     end
 
     def abstract_or_scope
-      first('abstract_ssm') || first('scopecontent_ssm')
+      value = first('abstract_ssm') || first('scopecontent_ssm')
+      render_html_tags(value: [value]) if value.present?
     end
 
     def creator
@@ -97,17 +99,17 @@ module Arclight
     end
 
     def terms
-      first('userestrict_ssm')
+      render_html_tags(value: [first('userestrict_ssm')])
     end
 
     # Restrictions for component sidebar
     def parent_restrictions
-      first('parent_access_restrict_ssm')
+      render_html_tags(value: [first('parent_access_restrict_ssm')])
     end
 
     # Terms for component sidebar
     def parent_terms
-      first('parent_access_terms_ssm')
+      render_html_tags(value: [first('parent_access_terms_ssm')])
     end
 
     def digital_objects

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -216,13 +216,13 @@ to_field 'date_range_sim', extract_xpath('/ead/archdesc/did/unitdate/@normal', t
 end
 
 SEARCHABLE_NOTES_FIELDS.map do |selector|
-  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']")
+  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']", to_text: false)
   to_field "#{selector}_heading_ssm", extract_xpath("/ead/archdesc/#{selector}/head") unless selector == 'prefercite'
   to_field "#{selector}_teim", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']")
 end
 
 DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
-  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/did/#{selector}")
+  to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/did/#{selector}", to_text: false)
 end
 
 NAME_ELEMENTS.map do |selector|
@@ -471,12 +471,12 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
   end
 
   SEARCHABLE_NOTES_FIELDS.map do |selector|
-    to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']")
+    to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']", to_text: false)
     to_field "#{selector}_heading_ssm", extract_xpath("./#{selector}/head")
     to_field "#{selector}_teim", extract_xpath("./#{selector}/*[local-name()!='head']")
   end
   DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
-    to_field "#{selector}_ssm", extract_xpath("./did/#{selector}")
+    to_field "#{selector}_ssm", extract_xpath("./did/#{selector}", to_text: false)
   end
   to_field 'did_note_ssm', extract_xpath('./did/note')
 end

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -108,9 +108,9 @@ class CatalogController < ApplicationController
     config.add_index_field 'normalized_date_ssm', label: 'Date'
     config.add_index_field 'creator_ssm', label: 'Creator'
     config.add_index_field 'language_ssm', label: 'Language'
-    config.add_index_field 'scopecontent_ssm', label: 'Scope Content'
+    config.add_index_field 'scopecontent_ssm', label: 'Scope Content', helper_method: :render_html_tags
     config.add_index_field 'extent_ssm', label: 'Physical Description'
-    config.add_index_field 'accessrestrict_ssm', label: 'Conditions Governing Access'
+    config.add_index_field 'accessrestrict_ssm', label: 'Conditions Governing Access', helper_method: :render_html_tags
     config.add_index_field 'collection_ssm', label: 'Collection Title'
     config.add_index_field 'geogname_ssm', label: 'Place'
 
@@ -253,30 +253,30 @@ class CatalogController < ApplicationController
 
     # Collection Show Page - Summary Section
     config.add_summary_field 'creators_ssim', label: 'Creator', link_to_facet: true
-    config.add_summary_field 'abstract_ssm', label: 'Abstract', helper_method: :paragraph_separator
+    config.add_summary_field 'abstract_ssm', label: 'Abstract', helper_method: :render_html_tags
     config.add_summary_field 'extent_ssm', label: 'Extent'
     config.add_summary_field 'language_ssm', label: 'Language'
-    config.add_summary_field 'prefercite_ssm', label: 'Preferred citation'
+    config.add_summary_field 'prefercite_ssm', label: 'Preferred citation', helper_method: :render_html_tags
 
     # Collection Show Page - Background Section
-    config.add_background_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :paragraph_separator
-    config.add_background_field 'bioghist_ssm', label: 'Biographical / Historical', helper_method: :paragraph_separator
-    config.add_background_field 'acqinfo_ssm', label: 'Acquisition information', helper_method: :paragraph_separator
-    config.add_background_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :paragraph_separator
-    config.add_background_field 'custodhist_ssm', label: 'Custodial history', helper_method: :paragraph_separator
-    config.add_background_field 'processinfo_ssm', label: 'Processing information', helper_method: :paragraph_separator
-    config.add_background_field 'arrangement_ssm', label: 'Arrangement', helper_method: :paragraph_separator
-    config.add_background_field 'accruals_ssm', label: 'Accruals', helper_method: :paragraph_separator
-    config.add_background_field 'phystech_ssm', label: 'Physical / technical requirements', helper_method: :paragraph_separator
-    config.add_background_field 'physloc_ssm', label: 'Physical location', helper_method: :paragraph_separator
-    config.add_background_field 'descrules_ssm', label: 'Rules or conventions', helper_method: :paragraph_separator
+    config.add_background_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :render_html_tags
+    config.add_background_field 'bioghist_ssm', label: 'Biographical / Historical', helper_method: :render_html_tags
+    config.add_background_field 'acqinfo_ssm', label: 'Acquisition information', helper_method: :render_html_tags
+    config.add_background_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :render_html_tags
+    config.add_background_field 'custodhist_ssm', label: 'Custodial history', helper_method: :render_html_tags
+    config.add_background_field 'processinfo_ssm', label: 'Processing information', helper_method: :render_html_tags
+    config.add_background_field 'arrangement_ssm', label: 'Arrangement', helper_method: :render_html_tags
+    config.add_background_field 'accruals_ssm', label: 'Accruals', helper_method: :render_html_tags
+    config.add_background_field 'phystech_ssm', label: 'Physical / technical requirements', helper_method: :render_html_tags
+    config.add_background_field 'physloc_ssm', label: 'Physical location', helper_method: :render_html_tags
+    config.add_background_field 'descrules_ssm', label: 'Rules or conventions', helper_method: :render_html_tags
 
     # Collection Show Page - Related Section
-    config.add_related_field 'relatedmaterial_ssm', label: 'Related material', helper_method: :paragraph_separator
-    config.add_related_field 'separatedmaterial_ssm', label: 'Separated material', helper_method: :paragraph_separator
-    config.add_related_field 'otherfindaid_ssm', label: 'Other finding aids', helper_method: :paragraph_separator
-    config.add_related_field 'altformavail_ssm', label: 'Alternative form available', helper_method: :paragraph_separator
-    config.add_related_field 'originalsloc_ssm', label: 'Location of originals', helper_method: :paragraph_separator
+    config.add_related_field 'relatedmaterial_ssm', label: 'Related material', helper_method: :render_html_tags
+    config.add_related_field 'separatedmaterial_ssm', label: 'Separated material', helper_method: :render_html_tags
+    config.add_related_field 'otherfindaid_ssm', label: 'Other finding aids', helper_method: :render_html_tags
+    config.add_related_field 'altformavail_ssm', label: 'Alternative form available', helper_method: :render_html_tags
+    config.add_related_field 'originalsloc_ssm', label: 'Location of originals', helper_method: :render_html_tags
 
     # Collection Show Page - Indexed Terms Section
     config.add_indexed_terms_field 'access_subjects_ssim', label: 'Subjects', link_to_facet: true, separator_options: {
@@ -309,17 +309,17 @@ class CatalogController < ApplicationController
     }, if: lambda { |_context, _field_config, document|
       document.containers.present?
     }
-    config.add_component_field 'abstract_ssm', label: 'Abstract', helper_method: :paragraph_separator
+    config.add_component_field 'abstract_ssm', label: 'Abstract', helper_method: :render_html_tags
     config.add_component_field 'extent_ssm', label: 'Extent'
-    config.add_component_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :paragraph_separator
-    config.add_component_field 'acqinfo_ssm', label: 'Acquisition information', helper_method: :paragraph_separator
-    config.add_component_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :paragraph_separator
-    config.add_component_field 'custodhist_ssm', label: 'Custodial history', helper_method: :paragraph_separator
-    config.add_component_field 'processinfo_ssm', label: 'Processing information', helper_method: :paragraph_separator
-    config.add_component_field 'arrangement_ssm', label: 'Arrangement', helper_method: :paragraph_separator
-    config.add_component_field 'accruals_ssm', label: 'Accruals', helper_method: :paragraph_separator
-    config.add_component_field 'phystech_ssm', label: 'Physical / technical requirements', helper_method: :paragraph_separator
-    config.add_component_field 'physloc_ssm', label: 'Physical location', helper_method: :paragraph_separator
+    config.add_component_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :render_html_tags
+    config.add_component_field 'acqinfo_ssm', label: 'Acquisition information', helper_method: :render_html_tags
+    config.add_component_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :render_html_tags
+    config.add_component_field 'custodhist_ssm', label: 'Custodial history', helper_method: :render_html_tags
+    config.add_component_field 'processinfo_ssm', label: 'Processing information', helper_method: :render_html_tags
+    config.add_component_field 'arrangement_ssm', label: 'Arrangement', helper_method: :render_html_tags
+    config.add_component_field 'accruals_ssm', label: 'Accruals', helper_method: :render_html_tags
+    config.add_component_field 'phystech_ssm', label: 'Physical / technical requirements', helper_method: :render_html_tags
+    config.add_component_field 'physloc_ssm', label: 'Physical location', helper_method: :render_html_tags
 
     # Component Show Page - Indexed Terms Section
     config.add_component_indexed_terms_field 'access_subjects_ssim', label: 'Subjects', link_to_facet: true, separator_options: {
@@ -345,21 +345,21 @@ class CatalogController < ApplicationController
     # =================
 
     # Collection Show Page Access Tab - Terms and Conditions Section
-    config.add_terms_field 'accessrestrict_ssm', label: 'Restrictions', helper_method: :paragraph_separator
-    config.add_terms_field 'userestrict_ssm', label: 'Terms of Access', helper_method: :paragraph_separator
+    config.add_terms_field 'accessrestrict_ssm', label: 'Restrictions', helper_method: :render_html_tags
+    config.add_terms_field 'userestrict_ssm', label: 'Terms of Access', helper_method: :render_html_tags
 
     # Component Show Page Access Tab - Terms and Condition Section
-    config.add_component_terms_field 'accessrestrict_ssm', label: 'Restrictions', helper_method: :paragraph_separator
-    config.add_component_terms_field 'userestrict_ssm', label: 'Terms of Access', helper_method: :paragraph_separator
-    config.add_component_terms_field 'parent_access_restrict_ssm', label: 'Parent Restrictions', helper_method: :paragraph_separator
-    config.add_component_terms_field 'parent_access_terms_ssm', label: 'Parent Terms of Access', helper_method: :paragraph_separator
+    config.add_component_terms_field 'accessrestrict_ssm', label: 'Restrictions', helper_method: :render_html_tags
+    config.add_component_terms_field 'userestrict_ssm', label: 'Terms of Access', helper_method: :render_html_tags
+    config.add_component_terms_field 'parent_access_restrict_ssm', label: 'Parent Restrictions', helper_method: :render_html_tags
+    config.add_component_terms_field 'parent_access_terms_ssm', label: 'Parent Terms of Access', helper_method: :render_html_tags
 
     # Collection and Component Show Page Access Tab - In Person Section
     config.add_in_person_field 'repository_ssm', if: :repository_config_present, label: 'Location of this collection', helper_method: :context_access_tab_repository
     config.add_in_person_field 'id', if: :before_you_visit_note_present, label: 'Before you visit', helper_method: :context_access_tab_visit_note # Using ID because we know it will always exist
 
     # Collection and Component Show Page Access Tab - How to Cite Section
-    config.add_cite_field 'prefercite_ssm', label: 'Preferred citation'
+    config.add_cite_field 'prefercite_ssm', label: 'Preferred citation', helper_method: :render_html_tags
 
     # Collection and Component Show Page Access Tab - Contact Section
     config.add_contact_field 'repository_ssm', if: :repository_config_present, label: 'Contact', helper_method: :access_repository_contact

--- a/spec/controllers/concerns/arclight/ead_format_helpers_spec.rb
+++ b/spec/controllers/concerns/arclight/ead_format_helpers_spec.rb
@@ -1,0 +1,327 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+class TestController
+  include Arclight::EadFormatHelpers
+  include ActionView::Helpers::TagHelper
+end
+
+RSpec.describe Arclight::EadFormatHelpers do
+  subject(:helper) { TestController.new }
+
+  describe '#render_html_tags' do
+    describe 'sanitizes markup' do
+      it 'strips out scripts' do
+        content = helper.render_html_tags(value: ['<p onclick="do_bad_things();">Hello</p>'])
+        expect(content).to eq_ignoring_whitespace '<p>Hello</p>'
+      end
+
+      it 'strips out non-html tags but keeps the content' do
+        content = helper.render_html_tags(value: ['<bibref>Affiches americaines. San Domingo: Imprimerie royale du Cap, 1782. Nos. 30, 35.</bibref>'])
+        expect(content).to eq_ignoring_whitespace 'Affiches americaines. San Domingo: Imprimerie royale du Cap, 1782. Nos. 30, 35.'
+      end
+    end
+    describe 'multi-value field separation' do
+      it 'wraps multi-value fields in <p> if unwrapped' do
+        content = helper.render_html_tags(value: %w[Hello world])
+        expect(content).to eq_ignoring_whitespace '<p>Hello</p><p>world</p>'
+      end
+
+      it 'does not wrap in value in <p> if already wrapped' do
+        content = helper.render_html_tags(value: %w[<p>Hello</p> <p>world</p>])
+        expect(content).to eq_ignoring_whitespace '<p>Hello</p><p>world</p>'
+      end
+
+      it 'keeps single-value fields unwrapped' do
+        content = helper.render_html_tags(value: %w[Hello])
+        expect(content).to eq_ignoring_whitespace 'Hello'
+      end
+    end
+
+    describe 'nodes with @render attributes' do
+      it 'altrender custom -> html class' do
+        content = helper.render_html_tags(value: ['<emph render="altrender" altrender="my-custom-class">special text</emph>'])
+        expect(content).to eq '<span class="my-custom-class">special text</span>'
+      end
+
+      it 'bold -> strong' do
+        content = helper.render_html_tags(value: ['I <emph render="bold">strongly</emph> suggest'])
+        expect(content).to eq 'I <strong>strongly</strong> suggest'
+      end
+
+      it 'bolddoublequote -> strong & wrapped' do
+        content = helper.render_html_tags(value: ['<emph render="bolddoublequote">a strong quote</emph>'])
+        expect(content).to eq '<strong>"a strong quote"</strong>'
+      end
+
+      it 'bolditalic -> strong & em' do
+        content = helper.render_html_tags(value: ['<emph render="bolditalic">strong emphasis</emph>'])
+        expect(content).to eq '<em><strong>strong emphasis</strong></em>'
+      end
+
+      it 'boldsinglequote -> strong' do
+        content = helper.render_html_tags(value: ['<emph render="boldsinglequote">this seems rare</emph>'])
+        expect(content).to eq '<strong>\'this seems rare\'</strong>'
+      end
+
+      it 'boldsmcaps -> small & strong w/class' do
+        content = helper.render_html_tags(value: ['<emph render="boldsmcaps">doctoral research</emph>'])
+        expect(content).to eq '<small><strong class="text-uppercase">doctoral research</strong></small>'
+      end
+
+      it 'boldunderline -> strong w/class' do
+        content = helper.render_html_tags(value: ['<emph render="boldunderline">human potential</emph>'])
+        expect(content).to eq '<strong class="text-underline">human potential</strong>'
+      end
+
+      it 'doublequote -> wrapped in quotes' do
+        content = helper.render_html_tags(value: ['This is <emph render="doublequote">useful</emph>.'])
+        expect(content).to eq 'This is <span>"useful"</span>.'
+      end
+
+      it 'italic -> em' do
+        content = helper.render_html_tags(value: ['Smith was not the <emph render="italic">only</emph> guilty party.'])
+        expect(content).to eq 'Smith was not the <em>only</em> guilty party.'
+      end
+
+      it 'nonproport -> em' do
+        content = helper.render_html_tags(value: ['<emph render="nonproport">hello</emph>'])
+        expect(content).to eq '<em>hello</em>'
+      end
+
+      it 'singlequote -> wrapped in quotes' do
+        content = helper.render_html_tags(value: ['This is <emph render="singlequote">useful</emph>.'])
+        expect(content).to eq 'This is <span>\'useful\'</span>.'
+      end
+
+      it 'smcaps -> small w/class' do
+        content = helper.render_html_tags(value: ['<emph render="smcaps">excerpted</emph>'])
+        expect(content).to eq '<small class="text-uppercase">excerpted</small>'
+      end
+
+      it 'sub -> sub' do
+        content = helper.render_html_tags(value: ['H<emph render="sub">2</emph>O'])
+        expect(content).to eq 'H<sub>2</sub>O'
+      end
+
+      it 'super -> sup' do
+        content = helper.render_html_tags(value: ['E = mc<emph render="super">2</emph>'])
+        expect(content).to eq 'E = mc<sup>2</sup>'
+      end
+
+      it 'underline -> span w/class' do
+        content = helper.render_html_tags(value: ['The <emph render="underline">Mona Lisa</emph> hangs in the Louvre.'])
+        expect(content).to eq 'The <span class="text-underline">Mona Lisa</span> hangs in the Louvre.'
+      end
+    end
+
+    describe 'lists' do
+      describe 'basic unordered lists' do
+        it 'untyped list -> ul' do
+          content = helper.render_html_tags(value: ['<list><item>One</item><item>Two</item></list>'])
+          expect(content).to eq_ignoring_whitespace '<ul><li>One</li><li>Two</li></ul>'
+        end
+
+        it 'simple list -> ul' do
+          content = helper.render_html_tags(value: ['<list type="simple"><item>One</item><item>Two</item></list>'])
+          expect(content).to eq_ignoring_whitespace '<ul><li>One</li><li>Two</li></ul>'
+        end
+
+        it 'marked list -> ul' do
+          content = helper.render_html_tags(value: ['<list type="marked"><item>One</item><item>Two</item></list>'])
+          expect(content).to eq_ignoring_whitespace '<ul><li>One</li><li>Two</li></ul>'
+        end
+
+        it 'list with head -> ul' do
+          content = helper.render_html_tags(value: ['<list><head>My List</head><item>One</item><item>Two</item></list>'])
+          expect(content).to eq_ignoring_whitespace '<div class="list-head">My List</div><ul><li>One</li><li>Two</li></ul>'
+        end
+      end
+
+      describe 'ordered lists' do
+        it 'ordered list -> ol' do
+          content = helper.render_html_tags(value: ['<list type="ordered"><item>One</item><item>Two</item></list>'])
+          expect(content).to eq_ignoring_whitespace '<ol><li>One</li><li>Two</li></ol>'
+        end
+      end
+
+      describe 'lists with render attributes inside' do
+        it 'transforms nested markup' do
+          content = helper.render_html_tags(value: ['<list type="ordered">
+            <item>Item <emph render="bold">One</emph></item><item>Item <title render="italic">Two</title></item></list>'])
+          expect(content).to eq_ignoring_whitespace '<ol><li>Item <strong>One</strong></li><li>Item <em>Two</em></li></ol>'
+        end
+      end
+    end
+
+    describe 'definition lists' do
+      describe 'basic deflists without column headers' do
+        it 'deflist -> dl' do
+          content = helper.render_html_tags(value: [%(
+            <list type="deflist">
+              <defitem>
+                <label>AL</label>
+                <item>Alabama</item>
+              </defitem>
+              <defitem>
+                <label>AK</label>
+                <item>Alaska</item>
+              </defitem>
+              <defitem>
+                <label>AZ</label>
+                <item>Arizona</item>
+              </defitem>
+            </list>
+          )])
+          expect(content).to eq_ignoring_whitespace %(
+            <dl class="deflist">
+              <dt>AL</dt>
+              <dd>Alabama</dd>
+              <dt>AK</dt>
+              <dd>Alaska</dd>
+              <dt>AZ</dt>
+              <dd>Arizona</dd>
+            </dl>
+          )
+        end
+      end
+
+      describe 'deflists with column headers' do
+        it 'deflist -> table' do
+          content = helper.render_html_tags(value: [%(
+            <list type="deflist">
+              <listhead>
+                <head01>Abbreviation</head01>
+                <head02>Expansion</head02>
+              </listhead>
+              <defitem>
+                <label>ALS</label>
+                <item>Autograph Letter Signed</item>
+              </defitem>
+              <defitem>
+                <label>TLS</label>
+                <item>Typewritten Letter Signed</item>
+              </defitem>
+            </list>
+          )])
+          expect(content).to eq_ignoring_whitespace %(
+            <table class="table deflist">
+              <thead>
+                <tr>
+                  <th>Abbreviation</th>
+                  <th>Expansion</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>ALS</td>
+                  <td>Autograph Letter Signed</td>
+                </tr>
+                <tr>
+                  <td>TLS</td>
+                  <td>Typewritten Letter Signed</td>
+                </tr>
+              </tbody>
+            </table>
+          )
+        end
+      end
+    end
+
+    describe 'chronlists' do
+      describe 'basic chronlist without custom headers or eventgrps' do
+        it 'chronlist -> table w/default headers' do
+          content = helper.render_html_tags(value: [%(
+            <chronlist>
+              <head>Julia Stockton Rush</head>
+              <chronitem>
+                <date>1759</date>
+                <event>Born, at "Morven" family estate near Princeton, N.J.</event>
+              </chronitem>
+              <chronitem>
+                <date>1776</date>
+                <event>Married Benjamin Rush; the couple went on to have 13 children</event>
+              </chronitem>
+            </chronlist>
+          )])
+          expect(content).to eq_ignoring_whitespace %(
+          <table class="table chronlist">
+            <caption class="chronlist-head">Julia Stockton Rush</caption>
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Event</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="chronlist-item-date">1759</td>
+                <td class="chronlist-item-event">Born, at "Morven" family estate near Princeton, N.J.</td>
+              </tr>
+              <tr>
+                <td class="chronlist-item-date">1776</td>
+                <td class="chronlist-item-event">Married Benjamin Rush; the couple went on to have 13 children</td>
+              </tr>
+            </tbody>
+          </table>
+          )
+        end
+      end
+
+      describe 'chronlist with custom headers & multi events in eventgrps' do
+        it 'chronlist -> table w/custom headers' do
+          content = helper.render_html_tags(value: [%(
+            <chronlist>
+              <head>Benjamin Rush</head>
+              <listhead>
+                <head01>Specific Dates</head01>
+                <head02>Things That Happened</head02>
+              </listhead>
+              <chronitem>
+                <date>1769</date>
+                <eventgrp>
+                  <event>Began medical practice in Philadelphia</event>
+                  <event>Appointed Professor of Chemistry in College of Philadelphia's medical
+                      department</event>
+                </eventgrp>
+              </chronitem>
+              <chronitem>
+                <date>1776</date>
+                <eventgrp>
+                  <event>Took his seat in Second Continental Congress</event>
+                </eventgrp>
+              </chronitem>
+            </chronlist>
+          )])
+          expect(content).to eq_ignoring_whitespace %(
+          <table class="table chronlist">
+            <caption class="chronlist-head">Benjamin Rush</caption>
+            <thead>
+              <tr>
+                <th>Specific Dates</th>
+                <th>Things That Happened</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="chronlist-item-date">1769</td>
+                <td class="chronlist-item-event">
+                  <div>Began medical practice in Philadelphia</div>
+                  <div>Appointed Professor of Chemistry in College of Philadelphia's medical department</div>
+                </td>
+              </tr>
+              <tr>
+                <td class="chronlist-item-date">1776</td>
+                <td class="chronlist-item-event">
+                  <div>Took his seat in Second Continental Congress</div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -62,9 +62,9 @@ RSpec.describe 'Collection Page', type: :feature do
       end
     end
 
-    it 'multivalued notes are rendered as paragaphs' do
+    it 'html-formatted notes render with paragraphs intact' do
       within 'dd.blacklight-bioghist_ssm' do
-        expect(page).to have_css('p', count: 2)
+        expect(page).to have_css('p', count: 4)
         expect(page).to have_css('p', text: /^Alpha Omega Alpha Honor Medical Society was founded/)
         expect(page).to have_css('p', text: /^Root and his fellow medical students/)
       end
@@ -236,7 +236,7 @@ RSpec.describe 'Collection Page', type: :feature do
       it 'has citations' do
         click_link 'Access'
         expect(page).to have_css 'dt', text: 'PREFERRED CITATION:'
-        expect(page).to have_css 'dd', text: /Omega Alpha Archives\. 1894-1992/
+        expect(page).to have_css 'dd p', text: /Omega Alpha Archives\. 1894-1992/
       end
     end
 

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -263,7 +263,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'bioghist' do
-      expect(result['bioghist_ssm'].first).to match(/^Alpha Omega Alpha Honor Medical Society was founded/)
+      expect(result['bioghist_ssm'].first).to match(/Alpha Omega Alpha Honor Medical Society was founded/)
       expect(result['bioghist_teim'].second).to match(/Hippocratic oath/)
       expect(result['bioghist_heading_ssm'].first).to match(/^Historical Note/)
     end
@@ -273,7 +273,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'abstract' do
-      expect(condense_whitespace(result['abstract_ssm'].first)).to match(/Alpha Omega Alpha Honor Medical Society/)
+      expect(result['abstract_ssm'].first).to match(/Alpha Omega Alpha Honor Medical Society/)
     end
 
     it 'separatedmaterial' do
@@ -293,7 +293,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'arrangement' do
-      expect(result['arrangement_ssm'].first).to eq 'Arranged into seven series.'
+      expect(result['arrangement_ssm'].first).to match(/Arranged into seven series./)
     end
 
     it 'acqinfo' do
@@ -305,11 +305,11 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'custodhist' do
-      expect(result['custodhist_ssm'].first).to eq_ignoring_whitespace 'Maintained by Alpha Omega Alpha and the family of William Root.'
+      expect(result['custodhist_ssm'].first).to match(/Maintained by Alpha Omega Alpha and the family of William Root/)
     end
 
     it 'processinfo' do
-      expect(condense_whitespace(result['processinfo_ssm'].first)).to match(/^Processed in 2001\. Descended from astronomers\./)
+      expect(result['processinfo_ssm'].first).to match(/Processed in 2001\. Descended from astronomers\./)
     end
 
     describe 'component-level' do
@@ -370,9 +370,9 @@ describe 'EAD 2 traject indexing', type: :feature do
 
         it 'has own accessrestrict' do
           expect(component_with_own_accessrestrict['accessrestrict_ssm'])
-            .to eq ['Restricted until 2018.']
+            .to include(a_string_matching(/Restricted until 2018./))
           expect(component_with_own_accessrestrict['parent_access_restrict_ssm'])
-            .to eq ['No restrictions on access.']
+            .to include(a_string_matching(/No restrictions on access/))
         end
 
         it 'gets accessrestrict from parent component' do
@@ -405,9 +405,9 @@ describe 'EAD 2 traject indexing', type: :feature do
 
         it 'has own userestrict' do
           expect(component_with_own_userestrict['userestrict_ssm'])
-            .to eq ['Original photographs must be handled using gloves.']
+            .to include(a_string_matching(/Original photographs must be handled using gloves/))
           expect(component_with_own_userestrict['parent_access_terms_ssm'])
-            .to eq ['Original photographs must be handled using gloves.']
+            .to include(a_string_matching(/Original photographs must be handled using gloves./))
         end
 
         it 'gets userestrict from collection' do

--- a/spec/fixtures/ead/nlm/alphaomegaalpha.xml
+++ b/spec/fixtures/ead/nlm/alphaomegaalpha.xml
@@ -111,38 +111,165 @@
     </prefercite>
     <bioghist id="aspace_ff0f836406ce214cae38e1f7c798d76e">
       <head>Historical Note</head>
-      <p>Alpha Omega Alpha Honor Medical Society was founded in 1902 by William Webster Root and
-        five other medical students at the College of Physicians and Surgeons in Chicago. Root
-        viewed the society as a protest against "a condition which associated the name medical
-        student with rowdyism, boorishness, immorality, and low educational ideals." Of the
+      <p>
+        Alpha Omega Alpha Honor Medical Society was founded in 1902 by William Webster Root and
+        five other medical students at the <emph render="bold">College of Physicians and
+        Surgeons in Chicago</emph>. Root viewed the society as a protest against
+        <emph render="italic">a condition which associated the name medical student with rowdyism,
+        boorishness, immorality, and low educational ideals."</emph> Of the
         approximately 25,000 medical students in the United States at the turn of the century, no
-        more than 15 percent were college graduates. The only requirement in most schools was a high
+        more than <emph render="altrender" altrender="my-custom-class">15 percent</emph> were
+        college graduates. The only requirement in most schools was a high
         school diploma or its equivalent; the latter often meaning the ability to pay the fee. The
         schools themselves-there were about 150-were by and large of dubious quality. With a few
-        exceptions, notably the Johns Hopkins School of Medicine, founded in 1893, the medical
-        school curriculum consisted of a series of lectures, sometimes supplemented by
-        demonstrations at the bedside or in the laboratory, if such existed.</p>
-      <p> Root and his fellow medical students met to form a society that would foster honesty and
-        formulate higher ideals of scholastic achievement. Chartered in 1903 by the state of
+        exceptions, notably the Johns Hopkins School of Medicine<emph render="super">3</emph>, founded
+        in 1893, the medical school curriculum consisted of a series of lectures, sometimes supplemented by
+        demonstrations at the bedside or in the laboratory, if such existed.
+      </p>
+      <p>
+        Root and his fellow medical students met to form a society that would foster honesty and
+        formulate higher ideals of scholastic achievement.
+        <emph render="underline">Chartered in 1903</emph> by the state of
         Illinois, Alpha Omega Alpha's growth has paralleled the development of American medical
         education. Within a decade after the society was founded, chapters were established at
         seventeen medical schools. At present there are 124 active chapters in the United States and
         Canada. Today, when students and established physicians alike reject easy platitudes, the
         tenets of the society are more relevant than ever. As framed by Root, they are a modern
-        interpretation of the Hippocratic oath: "It is the duty of members to foster the scientific
-        and philosophical features of the medical profession, to look beyond self to the welfare of
-        the profession and of the public, to cultivate social mindedness, as well as individualistic
-        attitude toward responsibilities, to show respect for colleagues, especially for elders and
-        teachers, to foster research and in all ways to ennoble the profession of medicine and
-        advance it in public opinion. It is equally a duty to avoid that which is unworthy,
-        including the commercial spirit and all practices injurious to the welfare of patients, the
-        public, or the profession." [Excerpted from Alpha Omega Alpha website.]</p>
+        interpretation of the Hippocratic oath: <emph render="bolddoublequote">It is the duty of
+        members to foster the scientific and philosophical features of the medical profession</emph>,
+        to look beyond self to the welfare of the profession and of the public, to cultivate social
+        mindedness, as well as individualistic attitude toward responsibilities, to show respect for
+        colleagues, especially for elders and teachers, to foster research and in all ways to enoble
+        the profession of medicine and advance it in public opinion. <emph render="boldsinglequote">It
+        is equally a duty to avoid that which is unworthy, including the commercial spirit and all practices
+        injurious to the welfare of patients, the public, or the profession.</emph>
+        <emph render="smcaps">[Excerpted from Alpha Omega Alpha website.]</emph>
+      </p>
+      <p>Here is a chronlist with default table headers and no eventgrp elements.</p>
+      <chronlist>
+        <head>Julia Stockton Rush</head>
+        <chronitem>
+          <date>1759</date>
+          <event>Born, at "Morven" family estate near Princeton, N.J.</event>
+        </chronitem>
+        <chronitem>
+          <date>1776</date>
+          <event>Married Benjamin Rush; the couple went on to have 13 children</event>
+        </chronitem>
+        <chronitem>
+          <date>1848</date>
+          <event>Died at their county property, "Sydenham" (now 15th Street and Columbus Ave,
+                Philadelphia)</event>
+        </chronitem>
+      </chronlist>
+      <p>Here is a chronlist with custom table headers via listhead, and events wrapped in eventgrp.</p>
+      <chronlist>
+        <head>Benjamin Rush</head>
+        <listhead>
+          <head01>Dates</head01>
+          <head02>Things That Happened</head02>
+        </listhead>
+        <chronitem>
+          <date>1769</date>
+          <eventgrp>
+            <event>Began medical practice in Philadelphia</event>
+            <event>Appointed Professor of Chemistry in College of Philadelphia's medical
+                department</event>
+          </eventgrp>
+        </chronitem>
+        <chronitem>
+          <date>1776</date>
+          <eventgrp>
+            <event>Took his seat in Second Continental Congress</event>
+          </eventgrp>
+        </chronitem>
+        <chronitem>
+          <date>1776 August 2</date>
+          <eventgrp>
+            <event>Signed Declaration of Independence</event>
+          </eventgrp>
+        </chronitem>
+        <chronitem>
+          <date>1777 April</date>
+          <eventgrp>
+            <event>Commissioned Surgeon General of Middle Department of the Continental Army</event>
+          </eventgrp>
+        </chronitem>
+        <chronitem>
+          <date>1778</date>
+          <eventgrp>
+            <event>Resigned from the Army</event>
+            <event>Became lecturer at University of the State of Pennsylvania</event>
+          </eventgrp>
+        </chronitem>
+      </chronlist>
     </bioghist>
     <scopecontent id="aspace_00d4328c32ed5e54eac5c662aa45245f">
       <head>Collection Summary</head>
       <p>Correspondence, documents, records, photos and printed matter. Material relates to the
-        history, organization, membership, meetings and publications. A large portion of the
-        collection pertains to the different chapters of the Society.</p>
+          history, organization, membership, meetings and publications. A large portion of the
+          collection pertains to the different chapters of the Society.</p>
+      <p>Here is a simple list with a head.</p>
+      <list type="simple">
+        <head>Commission Members List</head>
+        <item>June E. Osborn, M.D., Chairman</item>
+        <item>David E. Rogers, M.D., Vice Chairman</item>
+        <item>The Honorable Diane Ahrens</item>
+        <item>K. Scott Allen</item>
+      </list>
+      <p>Here is an ordered list with a head.</p>
+      <list type="ordered">
+        <head>Track List</head>
+        <item>Title: How I Love the Old Black Cat, performer: Strawbridge, Mary, location:
+            Durham (N.C.)</item>
+        <item>Title: The Broken Heart, performer: Strawbridge, Mary | Robbins, Jewell,
+            location: Durham (N.C.)</item>
+        <item>Title: Farewell (You Are False), performer: Strawbridge, Mary, location:
+            Durham (N.C.)</item>
+      </list>
+      <p>Here is a list with no type specified, and render-attribute formatting within the items.</p>
+      <list>
+        <item>
+          <bibref><title render="italic">The Happy Marriage, and Other Poems</title> (Boston and
+              New York: Houghton Mifflin. 79 pp.)
+            </bibref>
+        </item>
+        <item>
+          <bibref><title render="italic">The Pot of Earth</title> (Boston and New York:
+              Houghton Mifflin. 44 pp.)
+            </bibref>
+        </item>
+      </list>
+      <p>Here is a definition list with column headings. Render it as a table.</p>
+      <list type="deflist">
+        <listhead>
+          <head01>Abbreviation</head01>
+          <head02>Expansion</head02>
+        </listhead>
+        <defitem>
+          <label>ALS</label>
+          <item>Autograph Letter Signed</item>
+        </defitem>
+        <defitem>
+          <label>TLS</label>
+          <item>Typewritten Letter Signed</item>
+        </defitem>
+      </list>
+      <p>Here is a traditional definition list with no column headings.</p>
+      <list type="deflist">
+        <defitem>
+          <label>AL</label>
+          <item>Alabama</item>
+        </defitem>
+        <defitem>
+          <label>AK</label>
+          <item>Alaska</item>
+        </defitem>
+        <defitem>
+          <label>AZ</label>
+          <item>Arizona</item>
+        </defitem>
+      </list>
     </scopecontent>
     <arrangement id="aspace_845bb9a95be0924c3c9b33ccdc676813">
       <head>Arrangement</head>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,7 +41,7 @@ end
 require 'rspec/expectations'
 
 def condense_whitespace(str)
-  str.gsub(/[\n\s]+/, ' ').strip
+  str.squish.strip.gsub(/>[\n\s]+</, '><')
 end
 
 def equal_modulo_whitespace(string1, string2)


### PR DESCRIPTION
### Summary of Changes

This is a rewrite of PR #888 with two major differences per discussion on that ticket: 1) Uses Ruby only for transformations (XSLT free); 2) Performs the transformation to HTML at render time rather than pre-indexing.

- Adds a `render_html_tags` helper method that transforms EAD XML tags stored in Solr fields into sanitized HTML
- Defines HTML transform rules for: `<list>`, `<deflist>`, `<chronlist>` and several render attributes e.g., `<emph render="bold" />`
- Configures all searchable note fields (`<abstract>`, `<scopecontent>`, `<bioghist>`, etc.) to index nodes as XML rather than text (`to_text: false`) and display with these formatting rules applied (on collection and component level).

### Screenshots
![al-render](https://user-images.githubusercontent.com/3933756/66536164-0a71fc80-eaea-11e9-84d7-43498f9069e8.png)
![al-lists](https://user-images.githubusercontent.com/3933756/66536168-0e9e1a00-eaea-11e9-8b7c-4124236fe742.png)
![al-deflists](https://user-images.githubusercontent.com/3933756/66536524-43f73780-eaeb-11e9-97d4-8823924cc2a6.png)
![al-chronlists](https://user-images.githubusercontent.com/3933756/66536186-18278200-eaea-11e9-8263-b1243c47ecdc.png)

