### PR TITLE
Update result item view styling for consistency

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -1,5 +1,5 @@
 .documents-list {
-
+  margin-bottom: $spacer;
 
   // Result item header
   .al-document-title-bar {
@@ -12,19 +12,26 @@
 
   // Result item body
   article.document {
-    border-bottom: 0;
-    margin-bottom: $spacer * 2;
-    padding: 0 $result-item-body-padding;
+    border-bottom: $default-border-styling;
+    margin-top: 0;
+    padding: $spacer 0;
+
+    &:first-child {
+      padding-top: 0;
+    }
 
     .document-title-heading {
       font-size: $h5-font-size;
       .al-document-extent {
         background-color: $gray-200;
         border: $default-border-styling;
+        border-radius: 10px;
         font-size: $font-size-sm;
+        line-height: 1.2;
         margin-bottom: 0.25rem;
         padding: 2px $result-item-body-padding;
-        border-radius: 10px;
+        text-align: left;
+        white-space: normal;
       }
     }
 
@@ -82,7 +89,7 @@ article.document {
     }
   }
   .grouped-documents {
-    margin: $result-item-body-padding;
+    margin: $result-item-body-padding 0;
     h4 {
       font-size: $h5-font-size;
     }
@@ -125,7 +132,7 @@ article.document {
     padding: $spacer 0;
 
     &:first-child {
-      border-top: $default-border-styling;
+      padding-top: 0;
     }
   }
 }

--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -23,15 +23,7 @@
     .document-title-heading {
       font-size: $h5-font-size;
       .al-document-extent {
-        background-color: $gray-200;
-        border: $default-border-styling;
-        border-radius: 10px;
-        font-size: $font-size-sm;
-        line-height: 1.2;
-        margin-bottom: 0.25rem;
-        padding: 2px $result-item-body-padding;
-        text-align: left;
-        white-space: normal;
+        @include extent-badge;
       }
     }
 
@@ -93,6 +85,28 @@ article.document {
     h4 {
       font-size: $h5-font-size;
     }
+
+    .al-grouped-more {
+      border-bottom: $default-border-styling;
+      padding: ($spacer * .5) 0;
+    }
+
+    .document {
+      border-bottom: $default-border-styling;
+      margin-top: 0;
+      padding: $spacer 0;
+
+      &:last-child {
+        border-bottom: 0;
+      }
+    }
+  }
+
+  .al-document-extent {
+    @include extent-badge;
+    background-color: $gray-100;
+    border-color: $gray-400;
+    color: $gray-700;
   }
 }
 

--- a/app/assets/stylesheets/arclight/variables.scss
+++ b/app/assets/stylesheets/arclight/variables.scss
@@ -7,3 +7,16 @@ $result-item-body-padding: 12px;
 
 // Mixins
 $default-border-styling: 1px solid $default-border-color;
+
+@mixin extent-badge {
+  background-color: $gray-200;
+  border: $default-border-styling;
+  border-radius: $border-radius-lg;
+  color: $dark;
+  font-size: $font-size-sm;
+  line-height: 1.2;
+  margin: ($spacer * .5) 0 0;
+  padding: ($spacer * .25) ($spacer * .5);
+  text-align: left;
+  white-space: normal;
+}

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -197,8 +197,7 @@ module ArclightHelper
     safe_join(
       documents.each_with_index.map do |document, i|
         render_document_partial(document, :arclight_index_group_document, document_counter: i)
-      end,
-      raw('<hr>')
+      end
     )
   end
 

--- a/app/views/catalog/_arclight_index_default.html.erb
+++ b/app/views/catalog/_arclight_index_default.html.erb
@@ -8,7 +8,7 @@
     <div class="documentHeader my-w-75 w-md-100 order-0" data-document-id="<%= document.id %>">
       <h3 class="index_title document-title-heading">
         <%= link_to_document document, document_show_link_field(document), counter: counter %>
-        <%= content_tag('span', class: 'al-document-extent badge badge-light') do %>
+        <%= content_tag('span', class: 'al-document-extent badge') do %>
           <%= document.extent %>
         <% end if document.extent %>
       </h3>

--- a/app/views/catalog/_group.html.erb
+++ b/app/views/catalog/_group.html.erb
@@ -15,7 +15,6 @@
           <%= t('arclight.views.index.group_results_count', count: g.total) %>
         <% end %>
       </div>
-      <hr>
       <%= render_grouped_documents(g.docs) %>
     </div>
   <% end %>

--- a/app/views/catalog/_group_header_compact_default.html.erb
+++ b/app/views/catalog/_group_header_compact_default.html.erb
@@ -7,7 +7,7 @@
         </div>
       <% end %>
       <h3><%= link_to_document document, document_show_link_field(document) %></h3>
-      <%= content_tag('span', class: 'badge badge-light') do %>
+      <%= content_tag('span', class: 'al-document-extent badge') do %>
         <%= document.extent %>
       <% end if document.extent %>
     </div>

--- a/app/views/catalog/_group_header_default.html.erb
+++ b/app/views/catalog/_group_header_default.html.erb
@@ -7,7 +7,7 @@
         </div>
       <% end %>
       <h3><%= link_to_document document, document_show_link_field(document) %></h3>
-      <%= content_tag('span', class: 'badge badge-light') do %>
+      <%= content_tag('span', class: 'al-document-extent badge') do %>
         <%= document.extent %>
       <% end if document.extent %>
       <%= content_tag('div', class: 'al-document-abstract-or-scope') do %>


### PR DESCRIPTION
We have four varieties of result pages and a fair amount of inconsistency amongst them. This PR makes a handful of things more consistent:

- All result items are fully left aligned with content area
- All result items have borders to separate
- The extent badge is styled similarly
- Extraneous top border in list view, compact removed
- Use of `<hr>`s for borders replaced with `border-bottom` so implementers can more easily target styling of all result item borders

The visible differences aren't dramatic but the visual and code consistency will make future styling easier. (There is a bit more visual styling I still plan to do around some details but didn't want to try to do too much at once.)

Some examples:

### Before: List view 
- Items not full left-aligned
- No item border separator

<img width="848" alt="Screen Shot 2019-10-07 at 3 47 43 PM" src="https://user-images.githubusercontent.com/101482/66354912-325f3580-e91b-11e9-8356-d2015666057e.png">

### After: List view 

<img width="848" alt="Screen Shot 2019-10-07 at 3 47 56 PM" src="https://user-images.githubusercontent.com/101482/66354956-5458b800-e91b-11e9-929b-17aad39f0a3c.png">

### Before: List view, compact
- Extraneous top border

<img width="848" alt="Screen Shot 2019-10-07 at 3 48 56 PM" src="https://user-images.githubusercontent.com/101482/66354996-781bfe00-e91b-11e9-9f0f-89b2a31ba77a.png">
 
### After: List view, compact

<img width="848" alt="Screen Shot 2019-10-07 at 3 49 02 PM" src="https://user-images.githubusercontent.com/101482/66355013-836f2980-e91b-11e9-8f15-27ae6d4f5b9b.png">

### Before: Grouped view
- Items not full left-aligned
- Item separator using `<hr>` 

<img width="848" alt="Screen Shot 2019-10-07 at 3 50 32 PM" src="https://user-images.githubusercontent.com/101482/66355028-91bd4580-e91b-11e9-9d63-396804a35359.png">

### After: Grouped view
<img width="848" alt="Screen Shot 2019-10-07 at 3 50 46 PM" src="https://user-images.githubusercontent.com/101482/66355364-e365d000-e91b-11e9-8ef4-3ea4b9d4f9ca.png">

