### PR TITLE
Update show page breadcrumb styling and metadata alignment

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -8,8 +8,13 @@
   background-color: transparent;
   margin-bottom: 0;
   padding: 0;
-  .breadcrumb-item + .breadcrumb-item::before {
-    content: '';
+
+  .breadcrumb-item + .breadcrumb-item {
+    padding-top: 2px;
+
+    &::before {
+      content: '';
+    }
   }
 }
 
@@ -20,7 +25,7 @@
   height: 100%;
   min-width: 200px;
   padding: $spacer;
-  
+
   :first-child {
     padding-top: 0;
   }
@@ -49,7 +54,13 @@
   }
 }
 
-.al-show-breadcrumb h1 { font-size: 1.5rem; }
+.al-show-breadcrumb h1 {
+  font-size: 1.5rem;
+
+  &.media .col {
+    padding-top: $spacer * .25;
+  }
+}
 
 .breadcrumb-item {
   flex: 1 0 100%;
@@ -61,11 +72,35 @@
   }
 }
 
+// Show page breadcrumbs
 @for $i from 1 to 14 {
-  .breadcrumb-item.breadcrumb-item-#{$i} {
-    padding-left: ($i - 1) * 10px !important;
+  .breadcrumb-item.breadcrumb-item-#{$i}.media {
+    padding-left: 0;
+
+    @media (max-width: 767px) {
+      &::before {
+        padding-right: 0;
+      }
+    }
+
+    @media (min-width: 768px) {
+      padding-left: ($i - 1) * 10px;
+	  }
   }
 }
+
+// Show page metadata.
+// Indent to match terminal show page breadcrumb.
+@for $i from 1 to 14 {
+  .al-metadata-section.breadcrumb-item-#{$i} {
+    padding-left: 0;
+
+    @media (min-width: 768px) {
+      padding-left: ($i * 10) + 10px;
+    }
+  }
+}
+
 
 // Collapse arrow indicators
 .al-toggle-view-all {

--- a/app/views/catalog/_show_upper_metadata_default.html.erb
+++ b/app/views/catalog/_show_upper_metadata_default.html.erb
@@ -1,6 +1,6 @@
 <% if blacklight_config.show.component_metadata_partials.present? %>
   <% parents = Arclight::Parents.from_solr_document(document).as_parents %>
-  <dl class="breadcrumb-item breadcrumb-item-<%= parents.length + 3 %>">
+  <dl class="al-metadata-section breadcrumb-item breadcrumb-item-<%= parents.length + 3 %>">
     <% blacklight_config.show.component_metadata_partials.each do |metadata| %>
       <% doc_presenter = show_presenter(document).with_field_group(metadata) %>
       <% generic_document_fields(metadata).each do |field_name, field| %>


### PR DESCRIPTION
This PR updates a few things involving the show page breadcrumbs and metadata section:

- Gives breadcrumbs a little better vertical separation
- Vertically aligns the terminal (H1) breadcrumb/component title a bit better with its associated icon
- Left-aligns the metadata section with the left-edge of the H1 for better visual connection between the title of the page and its metadata
- On mobile, eliminates the indentation of the breadcrumbs and metadata to make better use of the limited horizontal space

### Before
<img width="613" alt="Screen Shot 2019-10-08 at 12 30 48 PM" src="https://user-images.githubusercontent.com/101482/66426852-9dfedc80-e9c7-11e9-8c58-5994600d4b23.png">

### After
<img width="613" alt="Screen Shot 2019-10-08 at 12 31 24 PM" src="https://user-images.githubusercontent.com/101482/66426868-a6efae00-e9c7-11e9-9c42-955f72a17713.png">

### Before
<img width="393" alt="Screen Shot 2019-10-08 at 12 33 12 PM" src="https://user-images.githubusercontent.com/101482/66427003-fafa9280-e9c7-11e9-9148-c7a81ffd28eb.png">

### After
(The actions box still needs styling and spacing, but I want to focus on that separately.)

<img width="393" alt="Screen Shot 2019-10-08 at 12 34 17 PM" src="https://user-images.githubusercontent.com/101482/66427021-01890a00-e9c8-11e9-8a13-8e2da38094d9.png">







