### PR TITLE
remove extra subheading on collection context tab

### DIFF
--- a/app/views/catalog/_component_context.html.erb
+++ b/app/views/catalog/_component_context.html.erb
@@ -1,8 +1,5 @@
 <h2 class="sr-only"><%= t 'arclight.views.show.context' %></h2>
 <!-- Section below will be moved into its own partial later -->
 <%= content_tag(:div, id: t("arclight.views.show.sections.collection_context_field").parameterize) do %>
-  <h3 class='al-show-sub-heading'>
-    <%= t("arclight.views.show.sections.collection_context_field") %>
-  </h3>
   <%= nested_component_lists(@document) %>
 <% end %>


### PR DESCRIPTION
Closes #926 

### Issue
The "Collection context" tab has a redundant h3 heading. There is a SR-only h2 that reiterates the tab label
- removed h3 heading for collection context

### Demo
<a href="https://cl.ly/5ef9997338cd" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/0y1G1u030e2A1h0x3o2P/%5Ba03cf226fca8dbbe3cd6f8b2ae5b74f6%5D_Screen+Shot+2019-10-08+at+1.56.02+PM.png" style="display: block;height: auto;width: 100%;"/></a>