### PR TITLE
Update styling of several result item elements

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -124,7 +124,7 @@
 // Scope content
 .al-document-abstract-or-scope {
   font-size: 0.85rem;
-  line-height: 1.25;
+  line-height: 1.5;
   max-width: 45em;
   margin-bottom: $spacer;
 }

--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -66,6 +66,8 @@ article.document {
 
 .al-grouped-results {
   .al-document-abstract-or-scope {
+    margin-bottom: 0;
+    margin-top: $spacer * .75;
     max-width: 45em;
   }
   .al-grouped-repository {

--- a/app/assets/stylesheets/arclight/variables.scss
+++ b/app/assets/stylesheets/arclight/variables.scss
@@ -15,7 +15,7 @@ $default-border-styling: 1px solid $default-border-color;
   color: $dark;
   font-size: $font-size-sm;
   line-height: 1.2;
-  margin: ($spacer * .5) 0 0;
+  margin: 0;
   padding: ($spacer * .25) ($spacer * .5);
   text-align: left;
   white-space: normal;

--- a/app/views/catalog/_arclight_index_compact_default.html.erb
+++ b/app/views/catalog/_arclight_index_compact_default.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div class='breadcrumb-links media'>
       <span class="media-body" aria-hidden="true"><%= blacklight_icon :repository, classes: 'al-repository-content-icon' %></span>
-    <span class="col ml-3 pl-0" ><%= regular_compact_breadcrumbs(document) %></span>
+    <span class="col ml-2 pl-0" ><%= regular_compact_breadcrumbs(document) %></span>
     </div>
   </div>
 </div>

--- a/app/views/catalog/_index_breadcrumb_default.html.erb
+++ b/app/views/catalog/_index_breadcrumb_default.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class='breadcrumb-links media'>
   	<span class="media-body ml-3" aria-hidden="true"><%= blacklight_icon :repository, classes: 'al-repository-content-icon' %></span>
-    <span class="col ml-3 pl-0" ><%= parents_to_links(document) %></span>
+    <span class="col ml-2 pl-0" ><%= parents_to_links(document) %></span>
   </div>
 </div>


### PR DESCRIPTION
Minor tweaks to:

A - Fix issue where an extent badge that fits in the first line of a result item title adds unwanted top margin to the title
B - Increase line-height of scope note (this will affect the contents tree scope note as well, but that's intended)
C - Decrease by `.5rem` the space between the repository icon and the repository text

### Before
<img width="870" alt="Screen Shot 2019-10-08 at 5 12 34 PM" src="https://user-images.githubusercontent.com/101482/66442623-6193a680-e9f0-11e9-99a1-4ec6401754fd.png">

### After
<img width="870" alt="Screen Shot 2019-10-08 at 5 19 06 PM" src="https://user-images.githubusercontent.com/101482/66442722-c5b66a80-e9f0-11e9-919d-7ba7735d9fb5.png">
