### PR TITLE
adjust width of containers to fix indenting styles

### DIFF
--- a/app/assets/stylesheets/arclight/modules/context_navigation.scss
+++ b/app/assets/stylesheets/arclight/modules/context_navigation.scss
@@ -10,7 +10,8 @@ li.al-collection-context  {
   .documentHeader {
     flex-grow: 1;
     margin-bottom: $spacer;
-    font-size: 1.25rem
+    font-size: 1.25rem;
+    width: 100%;
   }
 
   .col.col-no-left-padding.d-flex.flex-wrap {

--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -137,6 +137,7 @@
 
   ul {
     list-style: none;
+    flex-grow: 1;
   }
 
   .documents-hierarchy,


### PR DESCRIPTION
part of #925 
### Issue
there is a wrapping issue with the collection context tab on nested components

### Fix
adjusted the width of the collection context ul and the document header row

### Discussion
This may not be a complete fix as there is some JS refactoring that is going to take place. Also, the fixtures loaded don't have deeply nested items (that I could find) so there may still be some issues that will appear on the demo site.

Also, this may not fix the look of nested components when the +/- collapse is in place.

@jrgriffiniii was assigned to this ticket but it wasn't moved to the in progress column so this may overlap with his work. If so, we can close this PR.

### Demo
Before:
<a href="https://cl.ly/cb46b687c76d" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/182u24363J3X3l3x2y2d/Screen%20Shot%202019-10-08%20at%205.26.41%20PM.png" style="display: block;height: auto;width: 100%;"/></a>

After:
<a href="https://cl.ly/d4eef00ccbfc" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/2G2r321e3T1Y302i3g2P/Screen%20Shot%202019-10-08%20at%205.26.00%20PM.png" style="display: block;height: auto;width: 100%;"/></a>
