### PR TITLE
add link to home at top of show page breadcrumbs

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -18,6 +18,9 @@
   }
 }
 
+.breadcrumb-home-link {
+  margin-bottom: ($spacer / 4);
+}
 .al-show-actions-box {
   border: $default-border-styling;
   background-color: $gray-200;

--- a/app/views/shared/_show_breadcrumbs.html.erb
+++ b/app/views/shared/_show_breadcrumbs.html.erb
@@ -1,6 +1,9 @@
 <% parents = Arclight::Parents.from_solr_document(document).as_parents %>
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
+    <li class="breadcrumb-home-link">
+      <%= link_to t('arclight.routes.home'), root_path %>
+    </li>
     <li class="media breadcrumb-item  breadcrumb-item-1">
       <% if document.repository_config.present? %>
         <span class="media-body" aria-hidden="true"><%= blacklight_icon :repository, classes: 'al-repository-content-icon' %></span>

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -333,6 +333,7 @@ RSpec.describe 'Collection Page', type: :feature do
   describe 'breadcrumb' do
     it 'links repository and shows collection header 1 text' do
       within '.al-show-breadcrumb' do
+        expect(page).to have_css 'a', text: 'Home'
         expect(page).to have_css 'a', text: 'National Library of Medicine. History of Medicine Division'
         expect(page).to have_css 'span', text: 'Alpha Omega Alpha Archives, 1894-1992'
       end

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -223,10 +223,11 @@ RSpec.describe 'Component Page', type: :feature do
   describe 'breadcrumb' do
     it 'links home, collection, and parents' do
       within '.al-show-breadcrumb' do
+        expect(page).to have_css 'a', text: 'Home'
         expect(page).to have_css 'a', text: 'National Library of Medicine. History of Medicine Division'
         expect(page).to have_css 'a', text: 'Alpha Omega Alpha Archives, 1894-1992'
         expect(page).to have_css 'a', text: 'Series I: Administrative Records, 1902-1976, bulk 1975-1976'
-        expect(page).to have_css 'a', count: 3
+        expect(page).to have_css 'a', count: 4
       end
     end
   end


### PR DESCRIPTION
Closes #924 
### Issue
- Add a "Home" link before the stacked breadcrumb hierarchy on the show pages
- Home link would be left-aligned with the repository link's icon

### Demo
#### Collection show page:
<a href="https://cl.ly/3b16d583906e" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/3j3C3r1K0R3B343m2t0V/%5Ba2ec40295faff2c8c6c3ffba2f36db1b%5D_Screen+Shot+2019-10-09+at+3.12.05+PM.png" style="display: block;height: auto;width: 100%;"/></a>

#### Component show page:
<a href="https://cl.ly/108cd11064ef" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/0Q332d1i0h0g18273w3g/%5B478e1144c4ea39ce9ee871bbe43280e4%5D_Screen+Shot+2019-10-09+at+3.12.20+PM.png" style="display: block;height: auto;width: 100%;"/></a>
