### PR TITLE
Update styling of show page actions box

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -25,18 +25,15 @@
   background-color: $gray-200;
   font-size: $font-size-sm;
   height: 100%;
-  min-width: 200px;
-  padding: $spacer;
+  margin-bottom: $spacer * 2;
+  padding: ($spacer * .5) $spacer ($spacer * .75);
 
-  :first-child {
-    padding-top: 0;
-  }
-  :last-child {
-    padding-bottom: 0;
+  @media (max-width: 767px) {
+    margin-top: $spacer;
   }
 
-  > div {
-    padding: ($spacer / 3) 0;
+  .al-collection-id {
+    margin-bottom: $spacer * .75;
   }
 
   &-options {
@@ -45,9 +42,16 @@
   }
 
   &-downloads {
+    padding-top: $spacer * .25;
+
+    &-container {
+      margin-top: $spacer * .5;
+    }
+
     &-file {
       &.blacklight-icons {
-        width: 1.24rem;
+        margin-right: $spacer * .5;
+
         svg {
           fill: $secondary;
         }

--- a/app/views/arclight/_requests.html.erb
+++ b/app/views/arclight/_requests.html.erb
@@ -1,5 +1,5 @@
 <% if item_requestable?('', { document: document }) %>
-  <div class='mr-2 al-show-actions-box-request'>
+  <div class='mr-4 al-show-actions-box-request flex-md-fill'>
     <% document.repository_config.available_request_types.each do |request_type| %>
       <%= render partial: "arclight/requests/#{request_type}", locals: { document: document } %>
     <% end %>

--- a/app/views/catalog/_document_downloads.html.erb
+++ b/app/views/catalog/_document_downloads.html.erb
@@ -1,12 +1,12 @@
 <% if document_downloads.files.present? %>
-  <div class=" al-show-actions-box-downloads">
+  <div class=" al-show-actions-box-downloads-container">
     <% document_downloads.files.each do |file| %>
-      <div class="py-1 al-show-actions-box-downloads-file">
+      <div class="al-show-actions-box-downloads media">
         <%= blacklight_icon(file.type, classes: "al-show-actions-box-downloads-file") %>
         <% if file.size %>
-          <%= link_to(t("arclight.views.show.download_with_size.#{file.type}", size: file.size), file.href) %>
+          <%= link_to(t("arclight.views.show.download_with_size.#{file.type}", size: file.size), file.href, class: "media-body") %>
         <% else %>
-          <%= link_to(t("arclight.views.show.download.#{file.type}"), file.href) %>
+          <%= link_to(t("arclight.views.show.download.#{file.type}"), file.href, class: "media-body") %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/catalog/_show_actions_box_default.html.erb
+++ b/app/views/catalog/_show_actions_box_default.html.erb
@@ -1,7 +1,7 @@
-<div class='al-show-actions-box d-flex flex-column'>
-  <div class=" d-flex flex-wrap">
+<div class='al-show-actions-box'>
+  <div class="al-actions-box-container">
     <% if document.unitid || document.containers.present? %>
-      <div class='al-collection-id mr-2'>
+      <div class='al-collection-id'>
         <% if document.unitid %>
           <%= t(:'arclight.views.show.collection_id', id: document.unitid) %>
         <% end %>
@@ -15,15 +15,13 @@
         <% end %>
       </div>
     <% end %>
-    <div class='al-show-actions-box-options mt-md-3'>
+    <div class='al-show-actions-box-options d-flex'>
       <%= render partial: 'arclight/requests', locals: { document: document } %>
-      <div class='mr-auto al-show-actions-box-bookmarks'>
+      <div class='al-show-actions-box-bookmarks flex-md-fill'>
         <%= render partial: 'catalog/bookmark_control', locals: { document: document } %>
       </div>
     </div>
   </div>
 
-  <div>
-    <%= render document.downloads %>
-  </div>
+  <%= render document.downloads %>
 </div>

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -347,8 +347,10 @@ RSpec.describe 'Collection Page', type: :feature do
     let(:doc_id) { 'a0011-xmlaspace_ref6_lx4' }
 
     it 'renders links to the files for download' do
-      expect(page).to have_css('.al-show-actions-box-downloads-file', text: 'Download finding aid (1.23MB)')
-      expect(page).to have_css('.al-show-actions-box-downloads-file', text: 'Download EAD (123456)')
+      within '.al-show-actions-box-downloads-container' do
+        expect(page).to have_css('a', text: 'Download finding aid (1.23MB)')
+        expect(page).to have_css('a', text: 'Download EAD (123456)')
+      end
     end
   end
 

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -242,8 +242,10 @@ RSpec.describe 'Component Page', type: :feature do
     let(:doc_id) { 'a0011-xmlaspace_ref6_lx4' }
 
     it 'renders links to the files for download' do
-      expect(page).to have_css('.al-show-actions-box-downloads-file', text: 'Download finding aid (1.23MB)')
-      expect(page).to have_css('.al-show-actions-box-downloads-file', text: 'Download EAD (123456)')
+      within '.al-show-actions-box-downloads-container' do
+        expect(page).to have_css('a', text: 'Download finding aid (1.23MB)')
+        expect(page).to have_css('a', text: 'Download EAD (123456)')
+      end
     end
   end
 end


### PR DESCRIPTION
This PR improves several styling issues with the show page actions box:

- Add bottom margin to separate the actions box from the tabbed content area or metadata section
- Adds top margin on mobile to separate the actions box from the page title
- Removes various redundant or unnecessary CSS classes and HTML elements (I don't think any removal affected any tests but we'll see and I'll fix if necessary)
- Adjust CSS so that the box width is no wider than necessary to hold content, whatever combination of elements are present in the box
- Spaces the Request button and Bookmark checkbox a bit different on mobile versus desktop
- Fine-tunes spacing of elements within the box so things look more or less consistent whatever combination of elements are present in the box

A few examples:

### Before
<img width="534" alt="Screen Shot 2019-10-09 at 8 50 38 AM" src="https://user-images.githubusercontent.com/101482/66609792-c83ece80-eb6e-11e9-828e-583e6188a54a.png">

---

<img width="353" alt="Screen Shot 2019-10-10 at 8 57 40 AM" src="https://user-images.githubusercontent.com/101482/66609823-d856ae00-eb6e-11e9-8a06-cddd104f9b9b.png">


### After
<img width="312" alt="Screen Shot 2019-10-10 at 3 02 36 PM" src="https://user-images.githubusercontent.com/101482/66610004-4f8c4200-eb6f-11e9-9acf-d7befcf4a3c4.png">

---

<img width="394" alt="Screen Shot 2019-10-10 at 3 02 57 PM" src="https://user-images.githubusercontent.com/101482/66610024-574be680-eb6f-11e9-8e5a-c4f7f47f0435.png">

---

<img width="394" alt="Screen Shot 2019-10-10 at 3 03 27 PM" src="https://user-images.githubusercontent.com/101482/66610039-603cb800-eb6f-11e9-99af-501672c3124f.png">

---

<img width="394" alt="Screen Shot 2019-10-10 at 3 03 37 PM" src="https://user-images.githubusercontent.com/101482/66610052-6763c600-eb6f-11e9-824c-6d676910ca0a.png">

---

<img width="603" alt="Screen Shot 2019-10-10 at 3 04 19 PM" src="https://user-images.githubusercontent.com/101482/66610070-6f236a80-eb6f-11e9-82f4-929eb8bfb1d0.png">
