### PR TITLE
Restore bottom margin on breadcrumb nav container

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -1,6 +1,7 @@
 .al-search-breadcrumb,
 .al-show-breadcrumb {
   font-size: $font-size-sm;
+  margin-bottom: $spacer;
 }
 
 .al-show-breadcrumb .breadcrumb {


### PR DESCRIPTION
PR #922 removed the bottom margin on the breadcrumb container but we do need it for proper vertical spacing between the breadcrumb container and elements that can follow it (see screenshots below). If it needs to be removed for something to do with the online content (topic of PR #922) then we can look at removing it in a more targeted way.

### Before

<img width="433" alt="Screen Shot 2019-10-10 at 5 02 56 PM" src="https://user-images.githubusercontent.com/101482/66615265-d3025f00-eb80-11e9-9fe5-09ab4ae80543.png">

---

<img width="345" alt="Screen Shot 2019-10-10 at 5 04 14 PM" src="https://user-images.githubusercontent.com/101482/66615274-da296d00-eb80-11e9-9cea-750aef2dd261.png">

### After
<img width="345" alt="Screen Shot 2019-10-10 at 5 05 31 PM" src="https://user-images.githubusercontent.com/101482/66615299-f88f6880-eb80-11e9-9169-55a7865b8ab0.png">

---

<img width="345" alt="Screen Shot 2019-10-10 at 5 04 47 PM" src="https://user-images.githubusercontent.com/101482/66615307-ffb67680-eb80-11e9-958d-bb4fc21470ad.png">
