### PR TITLE
Remove title attribute (toolitip) from scope note display

### DIFF
--- a/app/views/arclight/repositories/show.html.erb
+++ b/app/views/arclight/repositories/show.html.erb
@@ -21,7 +21,7 @@
         <div class='row'>
           <div class='col-md-10 col-lg-9'>
             <h3 class="h5"><%= link_to document.normalized_title, solr_document_path(document.id) %></h3>
-            <%= content_tag('div', class: 'al-document-abstract-or-scope', title: document.abstract_or_scope) do %>
+            <%= content_tag('div', class: 'al-document-abstract-or-scope') do %>
               <%= content_tag('div', 'data-arclight-truncate' => true) do %>
                 <%= document.abstract_or_scope %>
               <% end %>

--- a/app/views/catalog/_index_online_contents_default.html.erb
+++ b/app/views/catalog/_index_online_contents_default.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag('div', class: 'al-document-abstract-or-scope', title: document.abstract_or_scope) do %>
+<%= content_tag('div', class: 'al-document-abstract-or-scope') do %>
   <%= content_tag(:h4, I18n.t('arclight.hierarchy.scope_and_contents'), class: 'al-hierarchy-sub-heading') %>
   <%= content_tag('div', 'data-arclight-truncate' => true) do %>
     <%= document.abstract_or_scope %>


### PR DESCRIPTION
Closes #930.

- Removes `title` attribute in two remaining places we seem to use it. I can't do a before and after of the online contents case because I can't find an example where we currently show the scope note in that tab. But it seems safe to remove from there.

### Before
<img width="962" alt="Screen Shot 2019-10-11 at 11 48 18 AM" src="https://user-images.githubusercontent.com/101482/66676878-4fe31680-ec1d-11e9-94c6-2250d8a4bbcd.png">

### After 
Can't really prove it is gone with a screenshot. But if you checkout this branch and hover over a scope note on this page (http://localhost:3000/repositories/sul-spec) your should not see a tooltip appear.

