### PR TITLE
Update styling of (non-show page) breadcrumb links

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -72,6 +72,7 @@ article.document {
   }
   .al-grouped-repository {
     font-size: $font-size-sm;
+    margin-bottom: $spacer * .75;
   }
   .al-grouped-title-bar {
     background-color: $gray-200;
@@ -178,7 +179,15 @@ article.document {
 }
 
 .breadcrumb-links a {
+  border-bottom: 1px dashed $gray-600;
   color: $body-color;
+
+  &:hover,
+  &:active {
+    border-color: inherit;
+    border-bottom-style: solid;
+    text-decoration: none;
+  }
 }
 
 .breadcrumb-links .col {

--- a/app/views/catalog/_group_header_compact_default.html.erb
+++ b/app/views/catalog/_group_header_compact_default.html.erb
@@ -2,7 +2,7 @@
   <div class='row'>
     <div class='col-md-12'>
       <% if document.repository_config.present? %>
-        <div class='al-grouped-repository'>
+        <div class='al-grouped-repository breadcrumb-links'>
           <%= link_to(document.repository_config.name, arclight_engine.repository_path(document.repository_config.slug)) %>
         </div>
       <% end %>

--- a/app/views/catalog/_group_header_default.html.erb
+++ b/app/views/catalog/_group_header_default.html.erb
@@ -2,7 +2,7 @@
   <div class='row'>
     <div class='col-md-12'>
       <% if document.repository_config.present? %>
-        <div class='al-grouped-repository'>
+        <div class='al-grouped-repository breadcrumb-links'>
           <%= link_to(document.repository_config.name, arclight_engine.repository_path(document.repository_config.slug)) %>
         </div>
       <% end %>


### PR DESCRIPTION
This PR adds a dashed bottom border to breadcrumb links that are in the various search results views. This styling should make it more clear that these are links, without having to make the link text blue (which we are trying to avoid because there can be a ton of breadcrumb links on a page and if they are all blue the page could be overwhelming visually busy).

This doesn't affect the breadcrumb links that are stacked and indented at top of show pages. Those links are blue and assumed to be obvious links from their context/placement, even without color.

I'm not going to close #488 with this PR, although that ticket is about improving link styling, because it specifically references a page with the tree navigation. We can revisit that ticket after the tree navigation is completed and decide what additional link styling might need to be done there.

### Examples
(Hover behavior is the same as it currently is.)

<img width="893" alt="Screen Shot 2019-10-11 at 3 17 25 PM" src="https://user-images.githubusercontent.com/101482/66688195-6b104f00-ec3a-11e9-828d-ac041ea25874.png">

---

<img width="893" alt="Screen Shot 2019-10-11 at 3 17 58 PM" src="https://user-images.githubusercontent.com/101482/66688206-72cff380-ec3a-11e9-9e1a-bbea2a5d0ee7.png">


