### PR TITLE
Adjust default border color and associated variable

### DIFF
--- a/app/assets/stylesheets/arclight/variables.scss
+++ b/app/assets/stylesheets/arclight/variables.scss
@@ -1,6 +1,6 @@
 // Colors
 $background-highlight: #ffffaa;
-$default-border-color: $gray-400;
+$default-border-color: $border-color;
 
 // Spacing
 $result-item-body-padding: 12px;


### PR DESCRIPTION
Super simple PR. I just realized the default border color we were using is one shade off the default border color used by Bootstrap. For consistency and easy of adopter theming, it probably makes sense to just use the default Bootstrap color. Also, in the process of updating that I realized Bootstrap has a `$border-color` variable, so I switched from specifying an explicit color to using the Bootstrap variable.

End result is the borders, such as between result items, are just a tad lighter than they currently are, but still work fine and are now consistent with the border below search results controls (which comes from the Bootstrap `$border-color` variable via Blacklight):

<img width="893" alt="Screen Shot 2019-10-14 at 9 40 17 AM" src="https://user-images.githubusercontent.com/101482/66768128-b5761380-ee66-11e9-92fc-707941458a03.png">

