### PR TITLE
Remove grouped by collection toggle for bookmarks

### DIFF
--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -3,6 +3,6 @@
   <div>
     <%= render partial: "paginate_compact", object: @response if show_pagination? %>
   </div>
-  <%= render partial: 'group_toggle' %>
+  <%= render partial: 'group_toggle' unless current_page?(controller: 'bookmarks')  %>
   <%= render_results_collection_tools wrapping_class: "search-widgets float-md-right" %>
 </div>


### PR DESCRIPTION
A quick, but not ideal fix that closes #942 (see discussion in issue). 

This PR remove the "Group by collection" toggle from the Bookmarks list until we can implement a version of that feature for bookmarks. 