### PR TITLE
[WIP] updates gemspec to support rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ sudo: false
 language: ruby
 notifications:
   email: false
-rvm:
-  - 2.5.5
-  - 2.6.3
+matrix:
+  include:
+    - rvm: 2.6.5
+    - rvm: 2.6.5
+      env: "RAILS_VERSION=5.2.3"
+    - rvm: 2.5.7
+      env: "RAILS_VERSION=5.2.3"
 jdk:
   - openjdk11
 

--- a/arclight.gemspec
+++ b/arclight.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'blacklight', '~> 7.2'
   spec.add_dependency 'blacklight_range_limit', '~> 7.1'
-  spec.add_dependency 'rails', '~> 5.0'
+  spec.add_dependency 'rails', '>= 5.1', '< 7'
   spec.add_dependency 'sprockets-bumble_d'
   spec.add_dependency 'traject', '~> 3.0'
   spec.add_dependency 'traject_plus', '~> 1.2'


### PR DESCRIPTION
Makes arclight gemspec match the [blacklight one](https://github.com/projectblacklight/blacklight/blob/master/blacklight.gemspec#L28).
Also updates the travis test matrix to include the latest 2.5 and 2.6 versions of Ruby.
Closes #954 