### PR TITLE
Implements a generic client side approach to collection context

### DIFF
--- a/app/assets/javascripts/arclight/context_navigation.js
+++ b/app/assets/javascripts/arclight/context_navigation.js
@@ -220,6 +220,13 @@ class ContextNavigation {
     //
     // Otherwise, retrieve the parent...
     let newDocIndex = newDocs.findIndex(doc => doc.id === this.targetId);
+
+    if (newDocIndex === -1) {
+      const renderedDocs = newDocs.map(newDoc => newDoc.render()).join('');
+      this.ul.append(renderedDocs);
+      this.el.html(this.ul);
+      return;
+    }
     // Update the docs before the item
     // Retrieves the documents up to and including the "new document"
     const beforeDocs = newDocs.slice(0, newDocIndex);

--- a/app/assets/javascripts/arclight/context_navigation.js
+++ b/app/assets/javascripts/arclight/context_navigation.js
@@ -131,19 +131,22 @@ class ContextNavigation {
     return `${this.originalParents[0]}${this.originalParents[this.data.arclight.level]}`;
   }
 
+  get requestParent() {
+    return this.originalParents[this.data.arclight.level - 1] || this.data.arclight.originalDocument.replace(this.originalParents[0], '');
+  }
+
   getData() {
     const that = this;
     // Add a placeholder so flashes of text are not as significant
     const placeholder = new Placeholder();
     this.el.after(placeholder.$el);
-
     $.ajax({
       url: this.data.arclight.path,
       data: {
         'f[component_level_isim][]': this.data.arclight.level,
         'f[has_online_content_ssim][]': this.data.arclight.access,
         'f[collection_sim][]': this.data.arclight.name,
-        'f[parent_ssi][]': this.data.arclight.parent,
+        'f[parent_ssi][]': this.requestParent,
         search_field: this.data.arclight.search_field,
         original_parents: this.data.arclight.originalParents,
         original_document: this.originalDocument,

--- a/app/assets/stylesheets/arclight/modules/context_navigation.scss
+++ b/app/assets/stylesheets/arclight/modules/context_navigation.scss
@@ -4,8 +4,14 @@ ul.parent {
 
 li.al-collection-context  {
   flex-grow: 1;
+  margin-right: 0;
+  margin-left: 0;
   padding-left: 15px;
   max-width: 100%;
+
+  .al-collection-context-collapsible {
+    width: 100%;
+  }
 
   .documentHeader {
     flex-grow: 1;

--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -120,6 +120,18 @@
   content: image-url('blacklight/plus.svg');
 }
 
+// Collapse arrow indicators
+.al-toggle-view-children {
+  &:not(.collapsed) {
+    & {
+      content: image-url('blacklight/minus.svg');
+    }
+  }
+
+  content: image-url('blacklight/plus.svg');
+}
+
+
 a.al-toggle-view-all{
   vertical-align: text-bottom;
 }

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -267,7 +267,13 @@ module ArclightHelper
   end
 
   def show_expanded?(document)
-    !original_document?(document)
+    !original_document?(document) && within_original_tree?(document)
+  end
+
+  def within_original_tree?(document)
+    params['original_parents'].map do |parent|
+      Arclight::Parent.new(id: parent, eadid: document.parent_ids.first, level: nil, label: nil).global_id
+    end.include?(document.id)
   end
 
   def original_document?(document)

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -266,37 +266,28 @@ module ArclightHelper
     send(:"render_document_#{config_field}_label", document, field: field)
   end
 
-  ##
-  # Reduces a document's parent_ids to a set of nested ul/li that resembels
-  # the collection / component / subcomponent structure
-  def nested_component_lists(document)
-    document.parent_ids.reverse.reduce(''.html_safe) do |acc, parent_id|
-      content_tag(
-        :ul,
-        class: %w[parent collection-context],
-        data: { 'data-collapse': I18n.t('arclight.views.show.collapse'), 'data-expand': I18n.t('arclight.views.show.expand') }
-      ) do
-        content_tag(:li, id: parent_id) do
-          safe_join(
-            [context_navigator_content(document, parent_id), acc]
-          )
-        end
-      end
-    end
+  def show_expanded?(document)
+    !original_document?(document)
   end
 
-  def context_navigator_content(document, parent_id)
+  def original_document?(document)
+    document.id == params['original_document']
+  end
+
+  def generic_context_navigation(document, original_parents: document.parent_ids, component_level: 1)
     content_tag(
-      :div, '',
-      class: "context-navigator al-hierarchy-level-#{document.component_level} documents-hierarchy",
+      :div,
+      '',
+      class: 'context-navigator',
       data: {
+        collapse: I18n.t('arclight.views.show.collapse'),
+        expand: I18n.t('arclight.views.show.expand'),
         arclight: {
-          level: document.parent_ids.index(parent_id) + 1,
+          level: component_level,
           path: search_catalog_path(hierarchy_context: 'component'),
           name: document.collection_name,
-          parent: parent_id,
           originalDocument: document.id,
-          originalParents: document.parent_ids
+          originalParents: original_parents
         }
       }
     )

--- a/app/views/catalog/_component_context.html.erb
+++ b/app/views/catalog/_component_context.html.erb
@@ -1,5 +1,5 @@
 <h2 class="sr-only"><%= t 'arclight.views.show.context' %></h2>
 <!-- Section below will be moved into its own partial later -->
 <%= content_tag(:div, id: t("arclight.views.show.sections.collection_context_field").parameterize) do %>
-  <%= nested_component_lists(@document) %>
+  <%= generic_context_navigation(@document) %>
 <% end %>

--- a/app/views/catalog/_index_collection_context_default.html.erb
+++ b/app/views/catalog/_index_collection_context_default.html.erb
@@ -37,10 +37,11 @@
       </div>
     </div>
   </div>
-  <%= content_tag(:div, id: "#{document.id}-collapsible-hierarchy",
-    class: "collapse al-hierarchy-level-#{document.component_level} #{'show' if show_expanded?(document)}",
-  ) do %>
-    <% if document.number_of_children > 0 %>
+  <% if document.number_of_children > 0 %>
+    <%= content_tag(:div, id: "#{document.id}-collapsible-hierarchy",
+      class: "collapse al-collection-context-collapsible al-hierarchy-level-#{document.component_level} #{'show' if show_expanded?(document)}",
+      data: { resolved: false }
+    ) do %>
       <%= generic_context_navigation(document, component_level: document.component_level + 1, original_parents: params[:original_parents]) %>
     <% end %>
   <% end %>

--- a/app/views/catalog/_index_collection_context_default.html.erb
+++ b/app/views/catalog/_index_collection_context_default.html.erb
@@ -6,6 +6,18 @@
     </div>
     <div class="col col-no-left-padding d-flex flex-wrap">
       <div class="index_title document-title-heading my-w-75 w-md-100 order-0">
+        <% if document.children? %>
+            <%= link_to(
+              blacklight_icon(:plus),
+              "##{document.id}-collapsible-hierarchy",
+              class: "al-toggle-view-children #{!show_expanded?(document) ? 'collapsed' : ''}",
+              'aria-label': t('arclight.hierarchy.view_all'),
+                data: {
+                  toggle: 'collapse'
+                }
+              )
+            %>
+        <% end %>
       
         <% counter = document_counter_with_offset(document_counter) %>
         <%= link_to_document document, document_show_link_field(document), counter: counter %>
@@ -25,4 +37,11 @@
       </div>
     </div>
   </div>
+  <%= content_tag(:div, id: "#{document.id}-collapsible-hierarchy",
+    class: "collapse al-hierarchy-level-#{document.component_level} #{'show' if show_expanded?(document)}",
+  ) do %>
+    <% if document.number_of_children > 0 %>
+      <%= generic_context_navigation(document, component_level: document.component_level + 1, original_parents: params[:original_parents]) %>
+    <% end %>
+  <% end %>
 </li>

--- a/spec/features/collection_context_spec.rb
+++ b/spec/features/collection_context_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Collection context', type: :feature, js: true do
+  let(:doc_id) { 'aoa271aspace_6ea193f778e553ca9ea0d00a3e5a1891' }
+
+  before do
+    visit solr_document_path(id: doc_id)
+  end
+
+  describe 'highly nested item' do
+    it 'highlights the correct context item' do
+      expect(page).to have_css '.al-hierarchy-highlight', text: 'Initial Phase'
+    end
+
+    it 'siblings are not expanded' do
+      expect(page).to have_css '.al-toggle-view-children.collapsed[href="#aoa271aspace_b70574c7229e6f237f780579cc04595d-collapsible-hierarchy"]'
+    end
+
+    it 'direct ancestors are expanded' do
+      expect(page).to have_css '#aoa271aspace_f934f1add34289f28bd0feb478e68275-collapsible-hierarchy.show', visible: true
+      expect(page).to have_css '#aoa271aspace_238a0567431f36f49acea49ef576d408-collapsible-hierarchy.show', visible: true
+      expect(page).to have_css '#aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671-collapsible-hierarchy.show', visible: true
+    end
+
+    it 'siblings above are hidden' do
+      expect(page).to have_css '#aoa271aspace_843e8f9f22bac69872d0802d6fffbb04', visible: false
+    end
+  end
+end


### PR DESCRIPTION
This PR implements a new approach to collection context. It follows similar patterns from before, but with a more fully designed consideration. It also aims to reuse existing pieces of JavaScript functionality, while also only sending of single requests. The goal, provide a performant way to build out the the collection context tree.

![Screen Shot 2019-10-16 at 5 11 31 PM](https://user-images.githubusercontent.com/1656824/66965951-bf4f7080-f038-11e9-8f74-005bf223290a.png)


Some of the styling, and the approach and location of UI work is based off of @estelendur work in #955 

Todos: 
 - [x] for things not yet requested, request them on the +/- interaction
 - [ ] ~~parent_ssm's isn't that great since the components do not include the actual id (we can spin this off)~~

![OMG](https://user-images.githubusercontent.com/1656824/67044729-27aa5a80-f0ea-11e9-824b-d91fdd9cb159.gif)
