### PR TITLE
Fixes #909 by using collection context approach

### DIFF
--- a/app/assets/javascripts/arclight/context_navigation.js
+++ b/app/assets/javascripts/arclight/context_navigation.js
@@ -122,6 +122,7 @@ class ContextNavigation {
     this.el = $(el);
     this.data = this.el.data();
     this.parentLi = this.el.parent();
+    this.eadid = this.data.arclight.eadid;
     this.originalParents = originalParents || this.data.arclight.originalParents;
     this.originalDocument = originalDocument || this.data.arclight.originalDocument;
     this.ul = $('<ul></ul>');
@@ -129,11 +130,14 @@ class ContextNavigation {
 
   // Gets the targetId to select, based off of parents and current level
   get targetId() {
-    return `${this.originalParents[0]}${this.originalParents[this.data.arclight.level]}`;
+    return `${this.eadid}${this.originalParents[this.data.arclight.level]}`;
   }
 
   get requestParent() {
-    return this.originalParents[this.data.arclight.level - 1] || this.data.arclight.originalDocument.replace(this.originalParents[0], '');
+    if (this.originalParents && this.originalParents[this.data.arclight.level - 1]) {
+      return this.originalParents[this.data.arclight.level - 1];
+    }
+    return this.data.arclight.originalDocument.replace(this.eadid, '');
   }
 
   getData() {
@@ -327,8 +331,18 @@ class ContextNavigation {
     }
     this.el.parent().data('resolved', true);
     this.addListenersForPlusMinus();
-    this.truncateItems();
+    this.enablebuttons();
     Blacklight.doBookmarkToggleBehavior();
+    this.el.trigger('navigation.contains.elements');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  enablebuttons() {
+    var toEnable = $('[data-hierarchy-enable-me]');
+    var srOnly = $('h2[data-sr-enable-me]');
+    toEnable.removeClass('disabled');
+    toEnable.text(srOnly.data('hasContents'));
+    srOnly.text(srOnly.data('hasContents'));
   }
 
   addListenersForPlusMinus() {
@@ -344,15 +358,6 @@ class ContextNavigation {
           contextNavigation.getData();
         });
       }
-    });
-  }
-
-  truncateItems() {
-    this.el.find('[data-arclight-truncate="true"]').each(function (_, el) {
-      $(el).responsiveTruncate({
-        more: el.dataset.truncateMore,
-        less: el.dataset.truncateLess
-      });
     });
   }
 }

--- a/app/assets/javascripts/arclight/truncator.js.erb
+++ b/app/assets/javascripts/arclight/truncator.js.erb
@@ -10,13 +10,19 @@ Blacklight.onLoad(function () {
   });
 
   // When elements get loaded from hierarchy
-  $('.al-contents').on('navigation.contains.elements', function () {
+  $('.al-contents, .context-navigator').on('navigation.contains.elements', function (e) {
     $('a[data-toggle="tab"]').on('shown.bs.tab', function () {
       $('[data-arclight-truncate="true"]').each(function (_, el) {
         $(el).responsiveTruncate({
           more: "<%= I18n.t 'arclight.truncation.view_more' %>",
           less: "<%= I18n.t 'arclight.truncation.view_less' %>"
         });
+      });
+    });
+    $(e.target).find('[data-arclight-truncate="true"]').each(function (_, el) {
+      $(el).responsiveTruncate({
+        more: "<%= I18n.t 'arclight.truncation.view_more' %>",
+        less: "<%= I18n.t 'arclight.truncation.view_less' %>"
       });
     });
   });

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -271,7 +271,7 @@ module ArclightHelper
   end
 
   def within_original_tree?(document)
-    params['original_parents'].map do |parent|
+    Array.wrap(params['original_parents']).map do |parent|
       Arclight::Parent.new(id: parent, eadid: document.parent_ids.first, level: nil, label: nil).global_id
     end.include?(document.id)
   end
@@ -293,7 +293,8 @@ module ArclightHelper
           path: search_catalog_path(hierarchy_context: 'component'),
           name: document.collection_name,
           originalDocument: document.id,
-          originalParents: original_parents
+          originalParents: original_parents,
+          eadid: document.eadid
         }
       }
     )

--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -30,7 +30,7 @@ module Arclight
     end
 
     def eadid
-      fetch('ead_ssi', nil)
+      fetch('ead_ssi', nil)&.strip
     end
 
     def unitid

--- a/app/views/catalog/_collection_contents.html.erb
+++ b/app/views/catalog/_collection_contents.html.erb
@@ -1,12 +1,4 @@
 <% document ||= @document %>
 
 <h2 class="sr-only" data-sr-enable-me='true' data-has-contents=<%= t 'arclight.views.show.has_content' %>></h2>
-<%= content_tag(
-  :div, '',
-  class: 'al-contents',
-  data: {
-    arclight: {
-      hierarchy: true, level: 1, path: search_catalog_path, name: document.collection_name
-    }
-  }
-) %>
+<%= generic_context_navigation(document) %>

--- a/spec/features/aeon_web_ead_request_spec.rb
+++ b/spec/features/aeon_web_ead_request_spec.rb
@@ -8,12 +8,13 @@ describe 'Aeon Web EAD Request', type: :feature, js: true do
       visit solr_document_path 'm0198-xml'
       click_link 'Contents'
 
-      within '.document-position-0' do
-        expect(page).to have_css(
-          'a[href*="https://sample.request.com?Action=10&Form=31&Value=http%3A%2F%2Fexample.com%2FM0198.xml',
-          text: 'Request'
-        )
+      within '#m0198-xmlaspace_ref11_d0s' do
+        click_link 'Pages 1-78'
       end
+      expect(page).to have_css(
+        'a[href*="https://sample.request.com?Action=10&Form=31&Value=http%3A%2F%2Fexample.com%2FM0198.xml',
+        text: 'Request'
+      )
     end
   end
 end

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe 'Collection Page', type: :feature do
 
       it 'component metadata' do
         within '#contents' do
-          within '.document-position-0 ' do
+          within '#aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671 ' do
             expect(page).to have_css(
               '.al-document-abstract-or-scope',
               text: /^scope note:.*Administrative records include/im
@@ -294,16 +294,16 @@ RSpec.describe 'Collection Page', type: :feature do
 
       it 'sub components are viewable and expandable' do
         within '#contents' do
-          within '.document-position-0' do
+          within '#aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671' do
             click_link 'View'
-            within '.blacklight-other.document-position-3' do
-              expect(page).to have_css '.document-title-containers', text: /Box 1, Folder 4\-5/
+            within '#aoa271aspace_dc2aaf83625280ae2e193beb3f4aea78.al-collection-context' do
+              expect(page).to have_css '.al-document-container', text: /Box 1, Folder 4\-5/
             end
             expect(page).to have_css 'a', text: 'Reports'
-            within '.blacklight-subseries.document-position-21' do
+            within '#aoa271aspace_238a0567431f36f49acea49ef576d408' do
               click_link 'View'
               expect(page).to have_css 'a', text: 'Expansion Plan'
-              within '.blacklight-subseries.document-position-0' do
+              within '#aoa271aspace_f934f1add34289f28bd0feb478e68275' do
                 click_link 'View'
                 expect(page).to have_css 'a', text: 'Initial Phase'
                 expect(page).to have_css 'a', text: 'Phase II: Expansion'
@@ -314,7 +314,7 @@ RSpec.describe 'Collection Page', type: :feature do
       end
 
       it 'includes the number of direct children of the component' do
-        within '.document-position-0' do
+        within '#aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671' do
           expect(page).to have_css(
             '.al-number-of-children-badge',
             text: /25/

--- a/spec/features/many_component_ead_spec.rb
+++ b/spec/features/many_component_ead_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Many component EAD', type: :feature do
     it 'includes all components' do
       click_link 'Contents'
       within '#contents' do
-        expect(page).to have_css '.blacklight-file', count: 202
+        expect(page).to have_css 'li.al-collection-context', count: 202
       end
     end
 
@@ -16,8 +16,8 @@ RSpec.describe 'Many component EAD', type: :feature do
       click_link 'Contents'
       within '#contents' do
         click_link 'View'
-        within '#aspace_327a75c226d44aa1a769edb4d2f13c6e-collapsible-hierarchy' do
-          expect(page).to have_css '.blacklight-item', count: 202
+        within '#lc0100aspace_327a75c226d44aa1a769edb4d2f13c6e-collapsible-hierarchy' do
+          expect(page).to have_css 'li.al-collection-context', count: 202
         end
       end
     end


### PR DESCRIPTION
A follow up to #957 (should be reviewed first).

This fixes #909 by enhancing work in #957 and giving us the same semantic structure and view in the Collection Contents tab also.

![contents](https://user-images.githubusercontent.com/1656824/67106427-d6e93f00-f187-11e9-9661-d5e741557bbd.gif)
