### PR TITLE
Remove unused markup in compact.svg Fixes #938

### DIFF
--- a/app/assets/images/blacklight/compact.svg
+++ b/app/assets/images/blacklight/compact.svg
@@ -1,1 +1,1 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><defs><style>.cls-1{fill:none;}</style></defs><title>compact</title><path class="cls-1" d="M0,0H24V24H0Z"/><path d="M3,15H21V13H3Zm0,4H21V17H3Zm0-8H21V9H3ZM3,5V7H21V5Z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M3,15H21V13H3Zm0,4H21V17H3Zm0-8H21V9H3ZM3,5V7H21V5Z"/></svg>


### PR DESCRIPTION
No visual changes

<img width="386" alt="Screen Shot 2019-10-18 at 3 22 11 PM" src="https://user-images.githubusercontent.com/1656824/67129183-18dfa880-f1bb-11e9-9e62-048fc3a6fca3.png">
