### PR TITLE
Style subseries similar to series for links

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -44,6 +44,7 @@
 
   // Series level
   .blacklight-series .document-title-heading,
+  .blacklight-subseries .document-title-heading,
   .blacklight-file .document-title-heading,
   .blacklight-binder .document-title-heading,
   .blacklight-other .document-title-heading {


### PR DESCRIPTION
When applied to work in #965 

## Before
<img width="1275" alt="Screen Shot 2019-10-21 at 2 16 08 PM" src="https://user-images.githubusercontent.com/1656824/67239892-7e2ad800-f40d-11e9-9710-0612b7e8dba7.png">

## After
<img width="1190" alt="Screen Shot 2019-10-21 at 2 15 51 PM" src="https://user-images.githubusercontent.com/1656824/67239893-7ec36e80-f40d-11e9-994d-b8d1818d6261.png">

