### PR TITLE
Clean up styling of collection context fixes #961

### DIFF
--- a/app/assets/javascripts/arclight/context_navigation.js
+++ b/app/assets/javascripts/arclight/context_navigation.js
@@ -125,7 +125,7 @@ class ContextNavigation {
     this.eadid = this.data.arclight.eadid;
     this.originalParents = originalParents || this.data.arclight.originalParents;
     this.originalDocument = originalDocument || this.data.arclight.originalDocument;
-    this.ul = $('<ul></ul>');
+    this.ul = $('<ul class="al-context-nav-parent"></ul>');
   }
 
   // Gets the targetId to select, based off of parents and current level

--- a/app/assets/stylesheets/arclight/modules/context_navigation.scss
+++ b/app/assets/stylesheets/arclight/modules/context_navigation.scss
@@ -1,4 +1,4 @@
-ul.parent {
+ul.al-context-nav-parent {
   padding-left: 20px;
 }
 
@@ -16,8 +16,11 @@ li.al-collection-context  {
   .documentHeader {
     flex-grow: 1;
     margin-bottom: $spacer;
-    font-size: 1.25rem;
     width: 100%;
+  }
+
+  .document-title-heading {
+    font-size: 1.25rem;
   }
 
   .col.col-no-left-padding.d-flex.flex-wrap {
@@ -52,7 +55,7 @@ li.al-collection-context  {
       padding: 10px;
     }
   }
-  ul.parent {
+  ul.al-context-nav-parent {
     padding-left: 40px;
   }
 }

--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -147,27 +147,23 @@
     }
   }
 
-  // Top-level context
-  .al-hierarchy-level-0 .document-title-heading {
-    // background-color: red;
-    font-size: $h5-font-size;
+  .document-title-heading {
     font-weight: 400;
-    margin-bottom: ($spacer / 2);
-
     > a {
       color: $gray-900;
     }
+  }
+
+  // Top-level context
+  .al-hierarchy-level-0 .document-title-heading {
+    font-size: $h5-font-size;
+    margin-bottom: ($spacer / 2);
   }
 
   // All subsequent levels
   @for $i from 1 through 12 {
     .al-hierarchy-level-#{$i} .document-title-heading {
       font-size: $h6-font-size;
-      font-weight: 400;
-
-      > a {
-        color: $gray-900;
-      }
     }
   }
 

--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -108,19 +108,7 @@
   }
 }
 
-
-// Collapse arrow indicators
-.al-toggle-view-all {
-  &[aria-expanded="true"] {
-    & {
-      content: image-url('blacklight/minus.svg');
-    }
-  }
-
-  content: image-url('blacklight/plus.svg');
-}
-
-// Collapse arrow indicators
+// Collapse +/- indicators
 .al-toggle-view-children {
   &:not(.collapsed) {
     & {
@@ -131,9 +119,8 @@
   content: image-url('blacklight/plus.svg');
 }
 
-
-a.al-toggle-view-all{
-  vertical-align: text-bottom;
+.al-toggle-children-container {
+  margin-left: -1.5rem;
 }
 
 .bookmark-toggle .toggle-bookmark {

--- a/app/views/catalog/_index_collection_context_default.html.erb
+++ b/app/views/catalog/_index_collection_context_default.html.erb
@@ -1,24 +1,25 @@
 <li id="<%= document.id %>" class="al-collection-context row d-flex align-items-start">
   <div class="documentHeader row" data-document-id="<%= document.id %>">
     <% requestable = item_requestable?('', { document: document }) %>
+    <% if document.children? %>
+      <div class="al-toggle-children-container">
+        <%= link_to(
+          blacklight_icon(:plus),
+          "##{document.id}-collapsible-hierarchy",
+          class: "al-toggle-view-children #{!show_expanded?(document) ? 'collapsed' : ''}",
+          'aria-label': t('arclight.hierarchy.view_all'),
+            data: {
+              toggle: 'collapse'
+            }
+          )
+        %>
+      </div>
+    <% end %>
     <div class="col-auto">
       <%= render partial: 'arclight_document_header_icon', locals: { document: document }  %>
     </div>
     <div class="col col-no-left-padding d-flex flex-wrap">
       <div class="index_title document-title-heading my-w-75 w-md-100 order-0">
-        <% if document.children? %>
-            <%= link_to(
-              blacklight_icon(:plus),
-              "##{document.id}-collapsible-hierarchy",
-              class: "al-toggle-view-children #{!show_expanded?(document) ? 'collapsed' : ''}",
-              'aria-label': t('arclight.hierarchy.view_all'),
-                data: {
-                  toggle: 'collapse'
-                }
-              )
-            %>
-        <% end %>
-      
         <% counter = document_counter_with_offset(document_counter) %>
         <%= link_to_document document, document_show_link_field(document), counter: counter %>
         <% if document.children? %>


### PR DESCRIPTION
Tightens up general styling of collection context view. Also moves +/- outside of icon.

## Before
![Screen Shot 2019-10-22 at 6 40 31 AM](https://user-images.githubusercontent.com/1656824/67286697-1620d400-f497-11e9-9d97-9b9db37defa8.png)

## After
![Screen Shot 2019-10-22 at 6 41 18 AM](https://user-images.githubusercontent.com/1656824/67286696-1620d400-f497-11e9-8ea4-46105c468ff2.png)
