### PR TITLE
Do not show scope label on context nav

### DIFF
--- a/app/views/catalog/_index_collection_context_default.html.erb
+++ b/app/views/catalog/_index_collection_context_default.html.erb
@@ -33,7 +33,11 @@
 
       <div class="order-2">
         <div class="row">
-          <%= render partial: 'arclight_abstract_or_scope', locals: { document: document } %>
+          <%= content_tag('div', class: 'al-document-abstract-or-scope mb-0') do %>
+            <%= content_tag('div', data: { 'arclight-truncate': true, 'truncate-more': I18n.t('arclight.truncation.view_more'), 'truncate-less': I18n.t('arclight.truncation.view_less') } ) do %>
+              <%= document.abstract_or_scope %>
+            <% end %>
+          <% end if document.abstract_or_scope %>
         </div>
       </div>
     </div>

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe 'Collection Page', type: :feature do
           within '#aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671 ' do
             expect(page).to have_css(
               '.al-document-abstract-or-scope',
-              text: /^scope note:.*Administrative records include/im
+              text: /Administrative records include/
             )
           end
         end


### PR DESCRIPTION
Per @jvine 

## Before
<img width="1217" alt="Screen Shot 2019-10-22 at 5 19 45 PM" src="https://user-images.githubusercontent.com/1656824/67342720-35981b00-f4f0-11e9-8de4-105fe1552443.png">

## After
<img width="1206" alt="Screen Shot 2019-10-22 at 5 19 34 PM" src="https://user-images.githubusercontent.com/1656824/67342721-35981b00-f4f0-11e9-923f-9790cc5d82ce.png">
