### PR TITLE
Simplify our indexing of acqinfo to a single field

### DIFF
--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -172,9 +172,6 @@ to_field 'access_terms_ssm', extract_xpath('/ead/archdesc/userestrict/*[local-na
 
 to_field 'acqinfo_ssim', extract_xpath('/ead/archdesc/acqinfo/*[local-name()!="head"]')
 to_field 'acqinfo_ssim', extract_xpath('/ead/archdesc/descgrp/acqinfo/*[local-name()!="head"]')
-to_field 'acqinfo_ssm' do |_record, accumulator, context|
-  accumulator.concat(context.output_hash.fetch('acqinfo_ssim', []))
-end
 
 to_field 'access_subjects_ssim', extract_xpath('/ead/archdesc/controlaccess', to_text: false) do |_record, accumulator|
   accumulator.map! do |element|
@@ -459,9 +456,6 @@ compose 'components', ->(record, accumulator, _context) { accumulator.concat rec
   to_field 'acqinfo_ssim', extract_xpath('/ead/archdesc/descgrp/acqinfo/*[local-name()!="head"]')
   to_field 'acqinfo_ssim', extract_xpath('./acqinfo/*[local-name()!="head"]')
   to_field 'acqinfo_ssim', extract_xpath('./descgrp/acqinfo/*[local-name()!="head"]')
-  to_field 'acqinfo_ssm' do |_record, accumulator, context|
-    accumulator.concat(context.output_hash.fetch('acqinfo_ssim', []))
-  end
 
   to_field 'language_ssm', extract_xpath('./did/langmaterial')
   to_field 'containers_ssim' do |record, accumulator|

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -261,7 +261,7 @@ class CatalogController < ApplicationController
     # Collection Show Page - Background Section
     config.add_background_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :render_html_tags
     config.add_background_field 'bioghist_ssm', label: 'Biographical / Historical', helper_method: :render_html_tags
-    config.add_background_field 'acqinfo_ssm', label: 'Acquisition information', helper_method: :render_html_tags
+    config.add_background_field 'acqinfo_ssim', label: 'Acquisition information', helper_method: :render_html_tags
     config.add_background_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :render_html_tags
     config.add_background_field 'custodhist_ssm', label: 'Custodial history', helper_method: :render_html_tags
     config.add_background_field 'processinfo_ssm', label: 'Processing information', helper_method: :render_html_tags
@@ -312,7 +312,7 @@ class CatalogController < ApplicationController
     config.add_component_field 'abstract_ssm', label: 'Abstract', helper_method: :render_html_tags
     config.add_component_field 'extent_ssm', label: 'Extent'
     config.add_component_field 'scopecontent_ssm', label: 'Scope and Content', helper_method: :render_html_tags
-    config.add_component_field 'acqinfo_ssm', label: 'Acquisition information', helper_method: :render_html_tags
+    config.add_component_field 'acqinfo_ssim', label: 'Acquisition information', helper_method: :render_html_tags
     config.add_component_field 'appraisal_ssm', label: 'Appraisal information', helper_method: :render_html_tags
     config.add_component_field 'custodhist_ssm', label: 'Custodial history', helper_method: :render_html_tags
     config.add_component_field 'processinfo_ssm', label: 'Processing information', helper_method: :render_html_tags

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -297,7 +297,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'acqinfo' do
-      expect(result['acqinfo_ssm'].first).to eq 'Donated by Alpha Omega Alpha.'
+      expect(result['acqinfo_ssim'].first).to eq 'Donated by Alpha Omega Alpha.'
     end
 
     it 'appraisal' do
@@ -595,8 +595,8 @@ describe 'EAD 2 traject indexing', type: :feature do
         'Donated by Alpha Omega Alpha.'
       )
 
-      expect(first_component).to include 'acqinfo_ssm'
-      expect(first_component['acqinfo_ssm']).to contain_exactly(
+      expect(first_component).to include 'acqinfo_ssim'
+      expect(first_component['acqinfo_ssim']).to contain_exactly(
         'Donated by Alpha Omega Alpha.'
       )
     end
@@ -616,8 +616,8 @@ describe 'EAD 2 traject indexing', type: :feature do
           ["Gift, John L. Parascandola, PHS Historian's Office, 3/1/1994, Acc. #812. Gift, Donald Goldman, Acc. #2005-21."]
         )
 
-        expect(first_component).to include 'acqinfo_ssm'
-        expect(first_component['acqinfo_ssm']).to equal_array_ignoring_whitespace(
+        expect(first_component).to include 'acqinfo_ssim'
+        expect(first_component['acqinfo_ssim']).to equal_array_ignoring_whitespace(
           ["Gift, John L. Parascandola, PHS Historian's Office, 3/1/1994, Acc. #812. Gift, Donald Goldman, Acc. #2005-21."]
         )
       end

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe ArclightHelper, type: :helper do
     end
 
     context 'when the configured fields have content' do
-      let(:document) { SolrDocument.new('acqinfo_ssm': ['Data']) }
+      let(:document) { SolrDocument.new('acqinfo_ssim': ['Data']) }
 
       it 'is true' do
         expect(helper.fields_have_content?(document, :background_field)).to eq true


### PR DESCRIPTION
This simplifies our indexing to a single field and only shows acqinfo at
the level in which it is available in the EAD.

Discussed some in #784

Previously "Acquisition info" for the collection was shown on every component page. In discussion with @jvine it was indicated that we should only show this on the level in which it was expressed in the ead.