### PR TITLE
Update styling of Contents and Online Content tabs

### DIFF
--- a/app/assets/stylesheets/arclight/modules/context_navigation.scss
+++ b/app/assets/stylesheets/arclight/modules/context_navigation.scss
@@ -1,5 +1,10 @@
+#contents > .context-navigator,
+#collection-context > .context-navigator {
+  padding-left: $spacer;
+}
+
 ul.al-context-nav-parent {
-  padding-left: 20px;
+  padding-left: 0px;
 }
 
 li.al-collection-context  {

--- a/app/assets/stylesheets/arclight/modules/context_navigation.scss
+++ b/app/assets/stylesheets/arclight/modules/context_navigation.scss
@@ -17,6 +17,11 @@ li.al-collection-context  {
     padding-top: $spacer * .25;
   }
 
+  .al-number-of-children-badge {
+    font-size: 12px;
+    vertical-align: middle;
+  }
+
   .documentHeader {
     flex-grow: 1;
     margin-bottom: $spacer;

--- a/app/assets/stylesheets/arclight/modules/context_navigation.scss
+++ b/app/assets/stylesheets/arclight/modules/context_navigation.scss
@@ -13,6 +13,10 @@ li.al-collection-context  {
     width: 100%;
   }
 
+  .blacklight-icons {
+    padding-top: $spacer * .25;
+  }
+
   .documentHeader {
     flex-grow: 1;
     margin-bottom: $spacer;

--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -145,13 +145,6 @@
     }
   }
 
-  .document-title-heading {
-    font-weight: 400;
-    > a {
-      color: $gray-900;
-    }
-  }
-
   // Top-level context
   .al-hierarchy-level-0 .document-title-heading {
     font-size: $h5-font-size;

--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -20,16 +20,10 @@
     font-size: $font-size-sm;
   }
 
-  // Component title + children badge
-  .documentHeader {
-    border-bottom: $border-width dashed $gray-400;
-    margin-bottom: ($spacer / 2);
-  }
-
   // Headings and text
   .al-document-abstract-or-scope {
     font-size: 0.85rem;
-    line-height: 1.25;
+    line-height: 1.5;
     max-width: 45em;
   }
 
@@ -49,10 +43,6 @@
     font-size: $h5-font-size;
     font-weight: 400;
     margin-bottom: ($spacer / 2);
-
-    > a {
-      color: $gray-900;
-    }
   }
 
   .blacklight-series,

--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -99,7 +99,7 @@
   }
 }
 
-.al-hierarchy-highlight {
+.al-hierarchy-highlight > .documentHeader {
   background: $mark-bg;
 }
 

--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -1,4 +1,5 @@
-.documents-list {
+.documents-list,
+.documents-online_contents {
   margin-bottom: $spacer;
 
   // Result item header
@@ -39,6 +40,7 @@
     }
 
     .al-document-abstract-or-scope {
+      margin-bottom: $spacer * .5;
       max-width: 45em;
     }
   }


### PR DESCRIPTION
This PR includes a bunch of styling updates aimed at making the Contents and Online Contents tabbed content more visually consistent:

- We currently highlight the entire current item in the contents tree, which means the highlight can be very large (vertically) if the item contains children and the item is expanded. This PR makes it so only the current item is highlighted, and not its children.
- The number of children badge is made a fixed font-size, which is not ideal, but better than the default behavior that bases its font size on the item title font size, which doesn't look so good in the tree context where the item title font size can be pretty big and vary by level.
- Reduced the indent of the tree hierarchy levels by `20px` so we gain some horizontal space and things feel a bit tighter.
- Updated styling that was assigning some tree and online contents item titles to use a gray font color, even though the titles are links. All item titles are now given the default link color.
- The Online Content tab items had a lot of styling issues, but they are now styled based on the search results styling, which improves most of the problems (there is one excess vertical space issue that is still bothering me, which applies to both search results and this panel, but resolving it seems complicated so I'm saving for later).

### Before - Contents tab
More left indent than we need; large/differing badge size, unnecessarily inclusive item highlight.

<img width="768" alt="Screen Shot 2019-10-25 at 4 34 37 PM" src="https://user-images.githubusercontent.com/101482/67610097-691fb300-f745-11e9-95b1-de0c66114d89.png">


### After - Contents tab

<img width="768" alt="Screen Shot 2019-10-25 at 4 35 57 PM" src="https://user-images.githubusercontent.com/101482/67610118-8b193580-f745-11e9-8c4c-65081da0855e.png">


### Before - Online contents tab
Inconsistent link colors; unnecessary dotted border; no vertical spacing between items, etc.

<img width="833" alt="Screen Shot 2019-10-25 at 4 36 42 PM" src="https://user-images.githubusercontent.com/101482/67610156-c3207880-f745-11e9-8056-ef55d310b4c0.png">

### After - Online contents tab

<img width="833" alt="Screen Shot 2019-10-25 at 4 38 23 PM" src="https://user-images.githubusercontent.com/101482/67610181-e3503780-f745-11e9-9aca-9d1bbe475545.png">
