### PR TITLE
Decrease font size of breadcrumbs in grouped result views

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -65,6 +65,10 @@ article.document {
 }
 
 .al-grouped-results {
+  .breadcrumb-links {
+    font-size: $font-size-sm;
+  }
+
   .al-document-abstract-or-scope {
     margin-bottom: 0;
     margin-top: $spacer * .75;


### PR DESCRIPTION
I noticed that the font size of the breadcrumbs in both grouped search result views was larger than for the non-grouped views. This PR adds styling so the grouped result views use the smaller font styling for breadcrumbs.

### Before
<img width="869" alt="Screen Shot 2019-10-25 at 5 07 27 PM" src="https://user-images.githubusercontent.com/101482/67610851-3fb55600-f74a-11e9-8ed1-42f41b553f8b.png">


### After

<img width="869" alt="Screen Shot 2019-10-25 at 5 07 53 PM" src="https://user-images.githubusercontent.com/101482/67610847-3af0a200-f74a-11e9-939d-ffc3ca958c59.png">
