### PR TITLE
Prevent actions box download labels from wrapping

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -44,6 +44,7 @@
 
   &-downloads {
     padding-top: $spacer * .25;
+    white-space: nowrap;
 
     &-container {
       margin-top: $spacer * .5;


### PR DESCRIPTION
In certain cases (no or short collection id and no request button), the actions box is sized fairly narrow and if there are download links present their labels might be wrapped, even though there is no reason for the actions box to be so narrow that there isn't room to keep the download link labels on a single line:

<img width="283" alt="Screen Shot 2019-10-25 at 5 37 29 PM" src="https://user-images.githubusercontent.com/101482/67611449-9e7cce80-f74e-11e9-836c-190e79cf2d5b.png">

This PR just ensures the download link labels don't wrap and keeps the box looking cleaner:

<img width="248" alt="Screen Shot 2019-10-25 at 5 36 27 PM" src="https://user-images.githubusercontent.com/101482/67611480-b05e7180-f74e-11e9-834b-b8636ad019be.png">

