### PR TITLE
Bugfix: context navigation fetches correct child components when clic…

### DIFF
--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -197,6 +197,17 @@ RSpec.describe 'Component Page', type: :feature do
         end
       end
     end
+
+    context 'when on a deeply nested component' do
+      let(:doc_id) { 'aoa271aspace_6ea193f778e553ca9ea0d00a3e5a1891' }
+
+      it 'enables expanding nodes outside of own ancestor tree' do
+        within '#collection-context' do
+          find('#aoa271aspace_01daa89087641f7fc9dbd7a10d3f2da9 .al-toggle-view-children').click
+          expect(page).to have_css '.document-title-heading', text: 'Miscellaneous 1999'
+        end
+      end
+    end
   end
 
   describe 'access tab', js: true do

--- a/spec/features/search_breadcrumb_spec.rb
+++ b/spec/features/search_breadcrumb_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe 'Search Breadcrumb', type: :feature do
         expect(page).to have_content 'Search results'
       end
     end
-  end
-  context 'on regular search results' do
+
     it do
       visit search_catalog_path f: { level_sim: ['Collection'] }, search_field: 'all_fields'
       within '.al-search-breadcrumb' do

--- a/spec/presenters/arclight/index_presenter_spec.rb
+++ b/spec/presenters/arclight/index_presenter_spec.rb
@@ -17,10 +17,6 @@ describe Arclight::IndexPresenter, type: :presenter do
   end
 
   before do
-    expect(view_context).to receive_messages(
-      controller: instance_double('Controller', params: {}, session: {}),
-      default_document_index_view_type: 'index'
-    )
     config.index.title_field = :normalized_title_ssm
   end
 


### PR DESCRIPTION
…king +/- on a node outside of the originally loaded component's ancestry. Fixes #982.