### PR TITLE
Bugfix for context nav where a click on an ancestor node's Expand button was omitting its preceding sibling. Fixes #1005.

### DIFF
--- a/app/assets/javascripts/arclight/context_navigation.js
+++ b/app/assets/javascripts/arclight/context_navigation.js
@@ -67,25 +67,6 @@ class ExpandButton {
 }
 
 /**
- * Modeling <button> Elements which hide or retrieve <li> elements for sibling
- *   documents nested within the <li> elements of the <ul> tree
- * @class
- */
-class NestedExpandButton extends ExpandButton {
-  /**
-   * This retrieves the <li> elements which are hidden/rendered in response to
-   *   clicking the <button> element
-   * @param {jQuery} $li - the <button> element
-   * @return {jQuery} - a jQuery object containing the targeted <li>
-   */
-  findSiblings() {
-    const highlighted = this.$el.siblings('.al-hierarchy-highlight');
-    const $siblings = highlighted.prevAll('.al-collection-context');
-    return $siblings.slice(0, -1);
-  }
-}
-
-/**
  * Models the placeholder display elements for content loading from AJAX
  *   requests
  * @class
@@ -280,28 +261,6 @@ class ContextNavigation {
       contextNavigation.getData();
     });
   }
-
-
-  /**
-   * Update the ancestors for <li> elements
-   * @param {jQuery} $li - the <li> element for the current, highlighted
-   *   Document in the <ul> context list of collections, components, and
-   *   containers
-   */
-  /* eslint-disable class-methods-use-this */
-  updateListSiblings($li) {
-    const prevSiblings = $li.prevAll('.al-collection-context');
-    if (prevSiblings.length > 1) {
-      const hiddenNextSiblings = prevSiblings.slice(0, -1);
-      hiddenNextSiblings.toggleClass('collapsed');
-
-      const button = new NestedExpandButton();
-
-      const lastHiddenNextSibling = hiddenNextSiblings[hiddenNextSiblings.length - 1];
-      button.$el.insertAfter(lastHiddenNextSibling);
-    }
-  }
-  /* eslint-enable class-methods-use-this */
 
   /**
    * This updates the elements in the View DOM using an AJAX response containing

--- a/app/assets/javascripts/arclight/context_navigation.js
+++ b/app/assets/javascripts/arclight/context_navigation.js
@@ -11,6 +11,10 @@ class NavigationDocument {
     this.el.find('li.al-collection-context').addClass('al-hierarchy-highlight');
   }
 
+  makeCollapsible() {
+    this.el.find('li.al-collection-context').addClass('collapsible');
+  }
+
   collapse() {
     this.el.find('li.al-collection-context').addClass('collapsed');
   }
@@ -32,9 +36,9 @@ class ExpandButton {
    * @param {jQuery} $li - the <button> element
    * @return {jQuery} - a jQuery object containing the targeted <li>
    */
-  findSiblings() {
-    const $siblings = this.$el.parent().children('li');
-    return $siblings.slice(0, -1);
+  findCollapsibleSiblings() {
+    const $siblings = this.$el.parent().children('li.collapsible');
+    return $siblings;
   }
 
   /**
@@ -44,7 +48,7 @@ class ExpandButton {
    *   <button> element
    */
   handleClick() {
-    const $targeted = this.findSiblings();
+    const $targeted = this.findCollapsibleSiblings();
 
     $targeted.toggleClass('collapsed');
     this.$el.toggleClass('collapsed');
@@ -179,6 +183,7 @@ class ContextNavigation {
     if (prevSiblingDocs.length > 1 && originalDocumentIndex > 0) {
       const hiddenPrevSiblingDocs = prevSiblingDocs.slice(0, -1);
       hiddenPrevSiblingDocs.forEach(siblingDoc => {
+        siblingDoc.makeCollapsible();
         siblingDoc.collapse();
       });
 
@@ -226,6 +231,7 @@ class ContextNavigation {
     let renderedBeforeDocs;
     if (beforeDocs.length > 1) {
       beforeDocs.forEach(function (parentDoc) {
+        parentDoc.makeCollapsible();
         parentDoc.collapse();
       });
       renderedBeforeDocs = beforeDocs.map(newDoc => newDoc.render()).join('');

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -207,6 +207,13 @@ RSpec.describe 'Component Page', type: :feature do
           expect(page).to have_css '.document-title-heading', text: 'Miscellaneous 1999'
         end
       end
+
+      it 'includes ancestor\'s preceding sibling when clicking ancestor\'s Expand button' do
+        within '#collection-context' do
+          find('#aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671-collapsible-hierarchy .prev-siblings button').click
+          expect(page).to have_css '.document-title-heading', text: 'Officers and directors - lists, 1961, n.d.'
+        end
+      end
     end
 
     context 'when on a component with an eadid with . normalized to -' do


### PR DESCRIPTION
This bug was caused by the Expand button's click handler not fully accounting for the difference between:
1. The current component level's collapse logic (all preceding siblings are collapsed _except for the preceding one_)
2. The current component's ancestor level's collapse logic (all preceding siblings are collapsed)

...as outlined in #673 & #812 

These changes add a `collapsible` class to any components that _should_ get collapsed/expanded in the current context, then makes the Expand/Collapse buttons (regardless of nesting level) only toggle those.

Before:
![arclight-context-before](https://user-images.githubusercontent.com/3933756/90052514-3d0af980-dca7-11ea-8539-db6c72de3836.gif)

After:
![arclight-context-after](https://user-images.githubusercontent.com/3933756/90052526-41cfad80-dca7-11ea-8896-915978ce28fb.gif)

