### PR TITLE
Use suggest_index_catalog_path explicitly for the search form's …

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -21,7 +21,11 @@
       <% end %>
 
       <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
-      <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q rounded-0 form-control", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
+      <%
+        # Use "autocomplete_path: suggest_index_catalog_path" explicitly so that the RepositoriesController gets the appropriate
+        # autocomplete path w/o having to have the search form action be local to the controller (by including Blacklight::Catalog)
+      %>
+      <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q rounded-0 form-control", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: suggest_index_catalog_path }  %>
 
       <span class="input-group-append">
         <button type="submit" class="btn btn-primary search-btn" id="search">


### PR DESCRIPTION
…autocomplete_path

Closes #1025 

FWIW, this autocomplete will be the autocomplete that spans across the entire index (like it does everywhere else) since filtering autocomplete results based on any current context isn't possible (as far as I understand) 