### PR TITLE
Bugfix for context nav when using Blacklight 7.13.0+ -- configures pa…

### DIFF
--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -96,6 +96,9 @@ class CatalogController < ApplicationController
     config.add_facet_field 'places_ssim', label: 'Places', show: false
     config.add_facet_field 'access_subjects_ssim', label: 'Subject', limit: 10
     config.add_facet_field 'component_level_isim', show: false
+
+    # Note that parent_ssim is an array of all ancestor nodes, including the parent
+    # parent_ssi is just the immediate parent; it's used in queries for context nav
     config.add_facet_field 'parent_ssim', show: false
     config.add_facet_field 'parent_ssi', show: false
 

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -97,6 +97,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'access_subjects_ssim', label: 'Subject', limit: 10
     config.add_facet_field 'component_level_isim', show: false
     config.add_facet_field 'parent_ssim', show: false
+    config.add_facet_field 'parent_ssi', show: false
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request


### PR DESCRIPTION
…rent_ssi as a hidden facet. Closes #1032.

A followup to https://github.com/projectblacklight/arclight/commit/fd22c860869bcb323bda1efbf9b1d2889ec9f623 -- because `parent_ssi` is used as filter in the URL params for finding child components, it has to be explicitly configured as a facet field for Blacklight versions >= `7.13.0`