### PR TITLE
Drop Rails 6.0.x support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,8 +14,6 @@ jobs:
         rails_version: [6.1.7, 7.0.4]
         ruby: [2.7, '3.0']
         include:
-          - rails_version: 6.0.6
-            ruby: 2.7
           - rails_version: 7.0.4
             ruby: 3.1
     env:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Rails engine supporting discovery of archival materials, based on [Blacklight]
 ## Requirements
 
 * [Ruby](https://www.ruby-lang.org/en/) 2.7 or later
-* [Rails](http://rubyonrails.org) 6.0 or later
+* [Rails](http://rubyonrails.org) 6.1 or later
 * Solr 8.1 or later
 
 ## Installation


### PR DESCRIPTION
This will enable us to support Blacklight 8.0, which does not support Rails 6.0

See https://github.com/projectblacklight/blacklight/pull/2750

Ref #1048 