### PR TITLE
Use the SearchBarComponent to override less upstream stuff

### DIFF
--- a/app/assets/stylesheets/arclight/modules/mastheads.scss
+++ b/app/assets/stylesheets/arclight/modules/mastheads.scss
@@ -49,6 +49,8 @@
 }
 
 .within-collection-dropdown {
+  flex-basis: calc(20ch + 2rem);
+  flex-basis: max-content;
   min-width: 0;
 
   @include media-breakpoint-up(sm) {

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,38 +1,11 @@
-<%
-# Overridden from Blacklight to add a drop down that allows the user to choose to search w/i the collection or all collections
-%>
-<%= form_tag search_action_url, method: :get, class: 'search-query-form pr-0', role: 'search' do %>
-  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8).merge(f: (search_state.params_for_search[:f] || {}).except(:collection_sim))) %>
-  <div class="d-md-flex">
+<%= render((blacklight_config&.view_config(document_index_view_type)&.search_bar_component || Blacklight::SearchBarComponent).new(
+      url: search_action_url,
+      advanced_search_url: search_action_url(action: 'advanced_search'),
+      params: search_state.params_for_search.except(:qt).merge(f: (search_state.params_for_search[:f] || {}).except(:collection_sim)),
+      presenter: presenter,
+      autocomplete_path: search_action_path(action: :suggest))) do |c| %>
+
+  <% c.prepend do %>
     <%= render 'catalog/within_collection_dropdown' %>
-
-    <% if search_fields.length > 1 %>
-      <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
-    <% end %>
-    <div class="input-group flex-nowrap">
-      <% if search_fields.length > 1 %>
-          <%= select_tag(:search_field,
-                         options_for_select(search_fields, h(params[:search_field])),
-                         title: t('blacklight.search.form.search_field.title'),
-                         id: "search_field",
-                         class: "custom-select search-field") %>
-      <% elsif search_fields.length == 1 %>
-        <%= hidden_field_tag :search_field, search_fields.first.last %>
-      <% end %>
-
-      <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
-      <%
-        # Use "autocomplete_path: suggest_index_catalog_path" explicitly so that the RepositoriesController gets the appropriate
-        # autocomplete path w/o having to have the search form action be local to the controller (by including Blacklight::Catalog)
-      %>
-      <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q rounded-0 form-control", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: suggest_index_catalog_path }  %>
-
-      <span class="input-group-append">
-        <button type="submit" class="btn btn-primary search-btn" id="search">
-          <span class="submit-search-text d-none d-lg-inline"><%= t('blacklight.search.form.submit') %></span>
-          <%= blacklight_icon :search, aria_hidden: true %>
-        </button>
-      </span>
-    </div>
-  </div>
+  <% end %>
 <% end %>

--- a/arclight.gemspec
+++ b/arclight.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'blacklight', '~> 7.2'
+  spec.add_dependency 'blacklight', '~> 7.14'
   spec.add_dependency 'blacklight_range_limit', '>= 7.1', '< 9'
   spec.add_dependency 'rails', '>= 6', '< 7.1'
   spec.add_dependency 'rexml'


### PR DESCRIPTION
This is the first refactor to the search form; I suspect we'll want to just extract a `Arclight::SearchBarComponent` and configure it, but that'll may need some more due diligence.