### PR TITLE
Stop using deprecated method document_show_link_field

### DIFF
--- a/app/views/catalog/_arclight_index_compact_default.html.erb
+++ b/app/views/catalog/_arclight_index_compact_default.html.erb
@@ -5,7 +5,7 @@
   <div class="col col-no-left-padding col-no-right-padding">
     <div class="d-flex justify-content-between">
       <h3 class="col col-no-left-padding">
-        <%= link_to_document document, document_show_link_field(document), counter: document_counter %>
+        <%= link_to_document document, counter: document_counter %>
       </h3>
       <%= render_index_doc_actions document %>
     </div>

--- a/app/views/catalog/_arclight_index_default.html.erb
+++ b/app/views/catalog/_arclight_index_default.html.erb
@@ -7,7 +7,7 @@
   <div class="col col-no-left-padding d-flex flex-wrap">
     <div class="documentHeader my-w-75 w-md-100 order-0" data-document-id="<%= document.id %>">
       <h3 class="index_title document-title-heading">
-        <%= link_to_document document, document_show_link_field(document), counter: counter %>
+        <%= link_to_document document, counter: counter %>
         <%= content_tag('span', class: 'al-document-extent badge') do %>
           <%= document.extent %>
         <% end if document.extent %>

--- a/app/views/catalog/_arclight_index_group_document_compact_default.html.erb
+++ b/app/views/catalog/_arclight_index_group_document_compact_default.html.erb
@@ -6,7 +6,7 @@
     </div>
     <div class="col col-no-left-padding">
       <h4>
-        <%= link_to_document document, document_show_link_field(document), counter: document_counter %>
+        <%= link_to_document document, counter: document_counter %>
       </h4>
       <div class='breadcrumb-links media'>
         <% unless breadcrumbs.nil? %>

--- a/app/views/catalog/_arclight_index_group_document_default.html.erb
+++ b/app/views/catalog/_arclight_index_group_document_default.html.erb
@@ -6,7 +6,7 @@
     </div>
     <div class="col col-no-left-padding">
       <h4>
-        <%= link_to_document document, document_show_link_field(document), counter: document_counter %>
+        <%= link_to_document document, counter: document_counter %>
       </h4>
       <div class='breadcrumb-links media'>
         <% unless breadcrumbs.nil? %>

--- a/app/views/catalog/_group_header_compact_default.html.erb
+++ b/app/views/catalog/_group_header_compact_default.html.erb
@@ -6,7 +6,7 @@
           <%= link_to(document.repository_config.name, arclight_engine.repository_path(document.repository_config.slug)) %>
         </div>
       <% end %>
-      <h3><%= link_to_document document, document_show_link_field(document) %></h3>
+      <h3><%= link_to_document document %></h3>
       <%= content_tag('span', class: 'al-document-extent badge') do %>
         <%= document.extent %>
       <% end if document.extent %>

--- a/app/views/catalog/_group_header_default.html.erb
+++ b/app/views/catalog/_group_header_default.html.erb
@@ -6,7 +6,7 @@
           <%= link_to(document.repository_config.name, arclight_engine.repository_path(document.repository_config.slug)) %>
         </div>
       <% end %>
-      <h3><%= link_to_document document, document_show_link_field(document) %></h3>
+      <h3><%= link_to_document document %></h3>
       <%= content_tag('span', class: 'al-document-extent badge') do %>
         <%= document.extent %>
       <% end if document.extent %>

--- a/app/views/catalog/_index_collection_context_default.html.erb
+++ b/app/views/catalog/_index_collection_context_default.html.erb
@@ -21,7 +21,7 @@
     <div class="col col-no-left-padding d-flex flex-wrap">
       <div class="index_title document-title-heading my-w-75 w-md-100 order-0">
         <% counter = document_counter_with_offset(document_counter) %>
-        <%= link_to_document document, document_show_link_field(document), counter: counter %>
+        <%= link_to_document document, counter: counter %>
         <% if document.children? %>
           <span class="badge badge-pill badge-secondary al-number-of-children-badge"><%= document.number_of_children %><span class="sr-only"><%= t(:'arclight.views.index.number_of_components', count: document.number_of_children) %></span></span>
         <% end %>

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -2,6 +2,6 @@
 <div class="documentHeader col" data-document-id="<%= document.id %>">
   <h3 class="index_title document-title-heading">
     <% counter = document_counter_with_offset(document_counter) %>
-    <%= link_to_document document, document_show_link_field(document), counter: counter %>
+    <%= link_to_document document, counter: counter %>
   </h3>
 </div>


### PR DESCRIPTION
Part of https://github.com/projectblacklight/arclight/issues/1056