### PR TITLE
Move fields_have_content? to the presenter

### DIFF
--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -157,12 +157,6 @@ module ArclightHelper
     'active' if on_repositories_index?
   end
 
-  def fields_have_content?(document, field_accessor)
-    generic_document_fields(field_accessor).any? do |_, field|
-      generic_should_render_field?(field_accessor, document, field)
-    end
-  end
-
   # If we have a facet on the repository, then return the Repository object for it
   #
   # @return [Repository]

--- a/app/presenters/arclight/show_presenter.rb
+++ b/app/presenters/arclight/show_presenter.rb
@@ -12,7 +12,25 @@ module Arclight
       self
     end
 
+    def fields_have_content?(field_accessor)
+      generic_document_fields(field_accessor).any? do |_, field|
+        generic_should_render_field?(field_accessor, field)
+      end
+    end
+
+    ##
+    # Calls the method for a configured field
+    def generic_should_render_field?(config_field, field)
+      view_context.public_send(:"should_render_#{config_field}?", document, field)
+    end
+
     private
+
+    ##
+    # Calls the method for a configured field
+    def generic_document_fields(config_field)
+      view_context.public_send(:"document_#{config_field}s")
+    end
 
     def field_group
       @field_group || 'show_field'

--- a/app/views/catalog/_collection_context.html.erb
+++ b/app/views/catalog/_collection_context.html.erb
@@ -1,13 +1,14 @@
+<%# locals: (presenter:) -%>
 <div class="row">
   <div class="col-md-3 order-md-2">
-    <%= render partial: 'collection_context_nav' %>
+    <%= render 'collection_context_nav', presenter: presenter %>
   </div>
 
   <div class="col-md-9 order-md-1">
     <h2 class="sr-only"><%= t 'arclight.views.show.context' %></h2>
     <% unless blacklight_config.show.metadata_partials.nil? %>
       <% blacklight_config.show.metadata_partials.each do |metadata| %>
-        <% next unless fields_have_content?(@document, metadata) %>
+        <% next unless presenter.fields_have_content?(metadata) %>
         <%= render partial: 'custom_metadata', locals: { document: @document, field_accessor: metadata } %>
       <% end %>
     <% end %>

--- a/app/views/catalog/_collection_context_nav.html.erb
+++ b/app/views/catalog/_collection_context_nav.html.erb
@@ -1,10 +1,12 @@
+<%# locals: (presenter:) -%>
+
 <nav class='al-sidebar-navigation-context al-sticky-sidebar'
      id="collection-context-sidebar"
      aria-label='<%= t('arclight.views.show.context_nav.title') %>'>
   <ul class='nav nav-pills flex-sm-row flex-md-column text-sm-left text-md-right'>
     <% unless blacklight_config.show.metadata_partials.nil? %>
       <% blacklight_config.show.metadata_partials.each do |item| %>
-        <% next unless fields_have_content?(@document, item) %>
+        <% next unless presenter.fields_have_content?(item) %>
         <li class='nav-item'>
           <%= link_to t("arclight.views.show.sections.#{item}"), "##{t("arclight.views.show.sections.#{item}").parameterize}", class: 'nav-link' %>
         </li>

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -1,4 +1,5 @@
 <% parents = Arclight::Parents.from_solr_document(document).as_parents %>
+<% presenter = document_presenter(document) %>
 <div class='row'>
   <div class='col-md-12'>
     <% if document.digital_objects.present? %>
@@ -41,7 +42,7 @@
 
     <div class='tab-content'>
       <div class='tab-pane active' id='context' role='tabpanel'>
-        <%= render 'collection_context' %>
+        <%= render 'collection_context', presenter: presenter %>
       </div>
       <div class='tab-pane' id='contents' role='tabpanel'>
         <%= render 'collection_contents' %>
@@ -54,7 +55,7 @@
       <div class='tab-pane' id='access' role='tabpanel'>
         <h2 class="sr-only"><%= t 'arclight.views.show.access' %></h2>
         <% unless blacklight_config.show.context_access_tab_items.nil? %>
-          <% items = blacklight_config.show.context_access_tab_items.select { |i|  fields_have_content?(@document, i) }  %>
+          <% items = blacklight_config.show.context_access_tab_items.select { |i| presenter.fields_have_content?(i) }  %>
           <% items.each_with_index do |item, index| %>
             <%= render partial: 'access_contents', locals: { document: @document, field_accessor: item, card_index: index} %>
           <% end %>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -57,7 +57,8 @@
           <div class='tab-pane' id='access' role='tabpanel'>
             <h2 class="sr-only"><%= t 'arclight.views.show.access' %></h2>
             <% unless blacklight_config.show.component_access_tab_items.nil? %>
-              <% items = blacklight_config.show.component_access_tab_items.select { |i|  fields_have_content?(@document, i) }  %>
+              <% presenter = document_presenter(document) %>
+              <% items = blacklight_config.show.component_access_tab_items.select { |i| presenter.fields_have_content?(i) }  %>
               <% items.each_with_index do |item, index| %>
                 <%= render partial: 'access_contents', locals: { document: @document, field_accessor: item, card_index: index} %>
               <% end %>

--- a/app/views/shared/_context_sidebar.html.erb
+++ b/app/views/shared/_context_sidebar.html.erb
@@ -1,6 +1,6 @@
 <% unless blacklight_config.show.context_access_tab_items.nil? %>
   <div id="accordion" role="tablist" aria-multiselectable="true">
-    <% items = blacklight_config.show.context_access_tab_items.select { |i|  fields_have_content?(@document, i) }  %>
+    <% items = blacklight_config.show.context_access_tab_items.select { |i| presenter.fields_have_content?(i) }  %>
     <% items.each_with_index do |item, index| %>
       <%= render partial: 'context_card', locals: { document: @document, field_accessor: item, card_index: index} %>
     <% end %>

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -155,31 +155,6 @@ RSpec.describe ArclightHelper, type: :helper do
     end
   end
 
-  describe '#fields_have_content?' do
-    before do
-      expect(helper).to receive_messages(
-        blacklight_config: CatalogController.blacklight_config,
-        blacklight_configuration_context: Blacklight::Configuration::Context.new(helper)
-      )
-    end
-
-    context 'when the configured fields have content' do
-      let(:document) { SolrDocument.new(acqinfo_ssim: ['Data']) }
-
-      it 'is true' do
-        expect(helper.fields_have_content?(document, :background_field)).to be true
-      end
-    end
-
-    context 'when the configured fields have no content' do
-      let(:document) { SolrDocument.new }
-
-      it 'is true' do
-        expect(helper.fields_have_content?(document, :background_field)).to be false
-      end
-    end
-  end
-
   describe '#parents_to_links' do
     let(:document) do
       SolrDocument.new(

--- a/spec/presenters/arclight/show_presenter_spec.rb
+++ b/spec/presenters/arclight/show_presenter_spec.rb
@@ -42,4 +42,29 @@ describe Arclight::ShowPresenter, type: :presenter do
       expect(presenter.send(:field_config, 'some_field')).to be_a Blacklight::Configuration::NullField
     end
   end
+
+  describe '#fields_have_content?' do
+    before do
+      allow(view_context).to receive_messages(
+        should_render_field?: true,
+        document_background_fields: CatalogController.blacklight_config.background_fields
+      )
+    end
+
+    context 'when the configured fields have content' do
+      let(:document) { SolrDocument.new(acqinfo_ssim: ['Data']) }
+
+      it 'is true' do
+        expect(presenter.fields_have_content?(:background_field)).to be true
+      end
+    end
+
+    context 'when the configured fields have no content' do
+      let(:document) { SolrDocument.new }
+
+      it 'is true' do
+        expect(presenter.fields_have_content?(:background_field)).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
The presenter is a more idiomatic blacklight way to represent what is being displayed about a document. It allows us to get rid of helpers, which can be overly complex as they have no encapsulation