### PR TITLE
Refactor breadcrumb methods to share some common behavior

### DIFF
--- a/app/models/arclight/parents.rb
+++ b/app/models/arclight/parents.rb
@@ -21,7 +21,7 @@ module Arclight
     ##
     # @return [Array[Arclight::Parent]]
     def as_parents
-      ids.map.with_index { |_id, idx| Arclight::Parent.new(id: ids[idx], label: labels[idx], eadid: eadid, level: levels[idx]) }
+      ids.map.with_index { |id, idx| Arclight::Parent.new(id: id, label: labels[idx], eadid: eadid, level: levels[idx]) }
     end
 
     ##


### PR DESCRIPTION
I think it's probably a good idea to deprecate `regular_compact_breadcrumbs` and `component_top_level_parent_to_links`, but I'm not sure I fully appreciate the nuance yet.