### PR TITLE
Add a SolrDocument#parents accessor

### DIFF
--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -80,7 +80,7 @@ module ArclightHelper
   ##
   # @param [SolrDocument]
   def document_parents(document)
-    Arclight::Parents.from_solr_document(document).as_parents
+    document.parents
   end
 
   def repository_collections_path(repository)

--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -14,6 +14,10 @@ module Arclight
       @repository_config ||= Arclight::Repository.find_by(name: repository)
     end
 
+    def parents
+      @parents ||= Arclight::Parents.from_solr_document(self).as_parents
+    end
+
     def parent_ids
       fetch('parent_ssim', [])
     end

--- a/app/views/arclight/viewers/_oembed.html.erb
+++ b/app/views/arclight/viewers/_oembed.html.erb
@@ -1,7 +1,6 @@
-<% parents = Arclight::Parents.from_solr_document(viewer.document).as_parents %>
 <% viewer.resources.each do |resource| %>
   <%= content_tag(:div, viewer.attributes_for(resource)) do %>
-    <div class="al-digital-object media breadcrumb-item breadcrumb-item-<%= parents.length + 6 %>"> 
+    <div class="al-digital-object media breadcrumb-item breadcrumb-item-<%= viewer.document.parents.length + 6 %>">
       <%= link_to(resource.label, resource.href) %>
     </div>
   <% end %>

--- a/app/views/catalog/_show_collection.html.erb
+++ b/app/views/catalog/_show_collection.html.erb
@@ -1,16 +1,15 @@
-<% parents = Arclight::Parents.from_solr_document(document).as_parents %>
 <% presenter = document_presenter(document) %>
 <div class='row'>
   <div class='col-md-12'>
     <% if document.digital_objects.present? %>
-      <%= content_tag :p, class: "media breadcrumb-item breadcrumb-item-#{parents.length + 3}" do %>
+      <%= content_tag :p, class: "media breadcrumb-item breadcrumb-item-#{document.parents.length + 3}" do %>
         <span class="media-body al-online-content-icon" aria-hidden="true"><%= blacklight_icon :online %></span>
         <span class="col text-muted">
           <%= t('arclight.views.show.online_content_upper') %>
         </span>
         <%= render_document_partial(document, 'arclight_viewer') %>
       <% end %>
-    <% end %>    
+    <% end %>
     <div class='row'>
       <div class='col-lg-12'>
         <ul class='nav nav-tabs nav-fill' role='tablist' aria-label='<%= t('arclight.views.show.tablist_nav') %>'>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -1,8 +1,7 @@
-<% parents = Arclight::Parents.from_solr_document(document).as_parents %>
 <div class='row'>
   <div class='col-md-12'>
     <% if document.digital_objects.present? %>
-      <%= content_tag :p, class: "media breadcrumb-item breadcrumb-item-#{parents.length + 3}" do %>
+      <%= content_tag :p, class: "media breadcrumb-item breadcrumb-item-#{document.parents.length + 3}" do %>
         <span class="media-body al-online-content-icon" aria-hidden="true"><%= blacklight_icon :online %></span>
         <span class="col text-muted">
           <%= t('arclight.views.show.online_content_upper') %>

--- a/app/views/catalog/_show_upper_metadata_default.html.erb
+++ b/app/views/catalog/_show_upper_metadata_default.html.erb
@@ -1,6 +1,5 @@
 <% if blacklight_config.show.component_metadata_partials.present? %>
-  <% parents = Arclight::Parents.from_solr_document(document).as_parents %>
-  <dl class="al-metadata-section breadcrumb-item breadcrumb-item-<%= parents.length + 3 %>">
+  <dl class="al-metadata-section breadcrumb-item breadcrumb-item-<%= document.parents.length + 3 %>">
     <% blacklight_config.show.component_metadata_partials.each do |metadata| %>
       <% doc_presenter = document_presenter(document).with_field_group(metadata) %>
       <% generic_document_fields(metadata).each do |field_name, field| %>

--- a/app/views/shared/_show_breadcrumbs.html.erb
+++ b/app/views/shared/_show_breadcrumbs.html.erb
@@ -1,4 +1,3 @@
-<% parents = Arclight::Parents.from_solr_document(document).as_parents %>
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
     <li class="breadcrumb-home-link">
@@ -12,15 +11,15 @@
           <span class="media-body" aria-hidden="true"><%= blacklight_icon :repository, classes: 'al-repository-content-icon' %></span><span class="col"><%= t('arclight.show_breadcrumb_label') %></span>
       <% end %>
     </li>
-    <% parents.each_with_index.map do |parent, index| %>
+    <% document.parents.each_with_index.map do |parent, index| %>
       <%= content_tag :li, class: "breadcrumb-item breadcrumb-item-#{index + 1} media" do %>
         <span class="media-body" aria-hidden="true"><%= blacklight_icon document_or_parent_icon(parent) %></span>
         <span class="col"><%= link_to parent.label, solr_document_path(parent.global_id) %></span>
-      <% end %> 
+      <% end %>
     <% end %>
   </ol>
 
-  <%= content_tag :h1, class: "breadcrumb-item breadcrumb-item-#{parents.length + 2} media" do %>
+  <%= content_tag :h1, class: "breadcrumb-item breadcrumb-item-#{document.parents.length + 2} media" do %>
     <span class="media-body" aria-hidden="true"><%= blacklight_icon document_or_parent_icon(document) %></span>
     <span class="col"><%= document.normalized_title %></span>
   <% end %>


### PR DESCRIPTION
I'm not exactly sure what the `breadcrumb-item-*` classes are or how the math works out, but an accessor seems nicer until we can figure that out🤷 