### PR TITLE
Avoid deprecation warning about filtering parameters.

### DIFF
--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -232,6 +232,9 @@ class CatalogController < ApplicationController
       }
     end
 
+    # These are the parameters passed through in search_state.params_for_search
+    config.search_state_fields += %i[id group hierarchy_context original_document original_parents]
+
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc


### PR DESCRIPTION
This explicitly provides a list of permitted parameters

Part of #1056