### PR TITLE
Render the SearchBarComponent

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -29,7 +29,11 @@
   </div>
   <div class="navbar-search navbar">
     <div class="<%= container_classes %>">
-      <%= render_search_bar  %>
+    <%= render(blacklight_config.view_config(document_index_view_type).search_bar_component.new(
+              url: search_action_url,
+              advanced_search_url: search_action_url(action: 'advanced_search'),
+              params: search_state.params_for_search.except(:qt),
+              autocomplete_path: search_action_path(action: :suggest))) %>
     </div>
   </div>
 </header>


### PR DESCRIPTION
Avoid calling the deprecated `render_search_bar` method
Fixes #1056 