### PR TITLE
Avoid a deprecated blacklight method render_opensearch_response_metadata

### DIFF
--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,7 +1,7 @@
 <% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params), :application_name => application_name) %>
 
 <% content_for(:head) do %>
-  <%= render_opensearch_response_metadata %>
+  <%= render "catalog/opensearch_response_metadata", response: @response %>
   <%= rss_feed_link_tag %>
   <%= atom_feed_link_tag %>
 <% end %>


### PR DESCRIPTION
Part of #1056 