### PR TITLE
Stop using Capybara in a deprecated way

### DIFF
--- a/spec/features/grouped_results_spec.rb
+++ b/spec/features/grouped_results_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe 'Grouped search results', type: :feature do
   it 'displays breadcrumbs only for component parents' do
     visit search_catalog_path q: 'alpha omega', group: 'true'
     within first('.breadcrumb-links') do
-      expect(page).not_to have_link(/Alpha/)
+      expect(page).to have_link 'National Library of Medicine. History of Medicine Division'
+      expect(page).to have_css 'a', count: 1 # Only one link is in the .breadcrumb-links
     end
     expect(page).to have_css '.breadcrumb-links a', text: /Series/
   end

--- a/spec/features/grouped_results_spec.rb
+++ b/spec/features/grouped_results_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Grouped search results', type: :feature do
     visit search_catalog_path q: 'alpha omega', group: 'true'
     within first('.breadcrumb-links') do
       expect(page).to have_link 'National Library of Medicine. History of Medicine Division'
-      expect(page).to have_css 'a', count: 1 # Only one link is in the .breadcrumb-links
+      expect(page).to have_link count: 1 # Only one link is in the .breadcrumb-links
     end
     expect(page).to have_css '.breadcrumb-links a', text: /Series/
   end


### PR DESCRIPTION
The have_link with a regex is deprecated.  Instead of having a negative assertion, switch this to two positive assertions


Fixes #1083