### PR TITLE
Adds :original_parents param to search_state_fields as an array

### DIFF
--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -233,7 +233,8 @@ class CatalogController < ApplicationController
     end
 
     # These are the parameters passed through in search_state.params_for_search
-    config.search_state_fields += %i[id group hierarchy_context original_document original_parents]
+    config.search_state_fields += %i[id group hierarchy_context original_document]
+    config.search_state_fields << { original_parents: [] }
 
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and


### PR DESCRIPTION
It looks like `:original_parents` param is an array so it was still triggering the `Unpermitted parameter` deprecation warning despite being included in `search_state_fields`.