### PR TITLE
Allow assets to work when using importmap-rails

### DIFF
--- a/app/assets/javascripts/arclight/collection_navigation.js
+++ b/app/assets/javascripts/arclight/collection_navigation.js
@@ -1,7 +1,5 @@
-(function (global) {
-  var CollectionNavigation;
 
-  CollectionNavigation = {
+  const CollectionNavigation = {
     init: function (el, page = 1) {
       var $el = $(el);
       var data = $el.data();
@@ -71,30 +69,27 @@
     }
   };
 
-  global.CollectionNavigation = CollectionNavigation;
-}(this));
+  Blacklight.onLoad(function () {
+    'use strict';
 
-Blacklight.onLoad(function () {
-  'use strict';
+    $('.al-contents').each(function (i, element) {
+      CollectionNavigation.init(element); // eslint-disable-line no-undef
+    });
 
-  $('.al-contents').each(function (i, element) {
-    CollectionNavigation.init(element); // eslint-disable-line no-undef
-  });
+    $('.al-contents').on('navigation.contains.elements', function (e) {
+      var toEnable = $('[data-hierarchy-enable-me]');
+      var srOnly = $('h2[data-sr-enable-me]');
+      toEnable.removeClass('disabled');
+      toEnable.text(srOnly.data('hasContents'));
+      srOnly.text(srOnly.data('hasContents'));
 
-  $('.al-contents').on('navigation.contains.elements', function (e) {
-    var toEnable = $('[data-hierarchy-enable-me]');
-    var srOnly = $('h2[data-sr-enable-me]');
-    toEnable.removeClass('disabled');
-    toEnable.text(srOnly.data('hasContents'));
-    srOnly.text(srOnly.data('hasContents'));
-
-    $(e.target).find('.collapse').on('show.bs.collapse', function (ee) {
-      var $newTarget = $(ee.target);
-      $newTarget.find('.al-contents').each(function (i, element) {
-        CollectionNavigation.init(element); // eslint-disable-line no-undef
+      $(e.target).find('.collapse').on('show.bs.collapse', function (ee) {
+        var $newTarget = $(ee.target);
+        $newTarget.find('.al-contents').each(function (i, element) {
+          CollectionNavigation.init(element); // eslint-disable-line no-undef
         // Turn off additional ajax requests on show
-        $newTarget.off('show.bs.collapse');
+          $newTarget.off('show.bs.collapse');
+        });
       });
     });
   });
-});

--- a/lib/arclight/engine.rb
+++ b/lib/arclight/engine.rb
@@ -35,5 +35,9 @@ module Arclight
         ActiveSupport.on_load(:action_view) { include ArclightHelper }
       end
     end
+
+    initializer 'arclight.assets', before: 'assets' do |app|
+      app.config.assets.precompile << 'arclight/arclight.js'
+    end
   end
 end


### PR DESCRIPTION
Importmap-rails is the default JavaScript pipeline for Rails 7, so we should support it.