### PR TITLE
Require Arclight rather than import

### DIFF
--- a/lib/generators/arclight/install_generator.rb
+++ b/lib/generators/arclight/install_generator.rb
@@ -105,7 +105,7 @@ module Arclight
         "\n  import $ from \"jquery\"\n  " \
           "window.$ = $ // required by arclight\n  " \
           "window.jQuery = $ // required by arclight/responsive_truncator.js\n  " \
-          'import("arclight")'
+          'require "arclight"'
       end
     end
   end


### PR DESCRIPTION
If we import it, it is possible that the Blacklight.onLoad event happens before the code is loaded onto the page.