### PR TITLE
Embed the contact + address HTML into the repositories.yml

### DIFF
--- a/app/views/arclight/repositories/_in_person_repository.html.erb
+++ b/app/views/arclight/repositories/_in_person_repository.html.erb
@@ -8,12 +8,6 @@
 </div>
 <div class='al-in-person-repository-location'>
   <address>
-    <% %i[building address1 address2 city_state_zip_country].each do |f| %>
-      <% if repository.public_send(f).present? %>
-        <div class='al-repository-contact-<%= f %>'>
-          <%= repository.public_send(f) %>
-        </div>
-      <% end %>
-    <% end %>
+    <%= repository.location %>
   </address>
 </div>

--- a/app/views/arclight/repositories/_repository.html.erb
+++ b/app/views/arclight/repositories/_repository.html.erb
@@ -13,30 +13,11 @@
           <div class='col-4 col-md-3 al-repository-contact'>
             <address>
               <div class="al-repository-street-address">
-                <% %i[building address1 address2 city_state_zip_country].each do |f| %>
-                  <% if repository.public_send(f).present? %>
-                    <div class='al-repository-street-address-<%= f %>'>
-                      <%= repository.public_send(f) %>
-                    </div>
-                  <% end %>
-                <% end %>
-             </div>
+                <%= repository.location %>
+              </div>
 
               <div class="al-repository-contact-info">
-                <% if repository.phone.present? %>
-                  <div class='al-repository-contact-info-phone'>
-                    <%= repository.phone %>
-                  </div>
-                <% end %>
-                <% if repository.contact_info.present? %>
-                  <div class='al-repository-contact-info-contact_info'>
-                    <% if repository.contact_info.include?('@') %>
-                      <%= mail_to repository.contact_info %>
-                    <% else %>
-                      <%= repository.contact_info %>
-                    <% end %>
-                  </div>
-                <% end %>
+                <%= repository.contact %>
               </div>
             </address>
           </div>

--- a/app/views/arclight/repositories/_repository_contact.html.erb
+++ b/app/views/arclight/repositories/_repository_contact.html.erb
@@ -1,9 +1,3 @@
 <div class='al-in-person-repository-contact'>
-  <% %i[phone contact_info].each do |f| %>
-    <% if repository.public_send(f).present? %>
-      <div class='al-repository-contact-<%= f %>'>
-        <%= repository.public_send(f) %>
-      </div>
-    <% end %>
-  <% end %>
+  <%= repository.contact %>
 </div>

--- a/lib/arclight/repository.rb
+++ b/lib/arclight/repository.rb
@@ -15,11 +15,12 @@ module Arclight
       super(**data, slug: slug)
     end
 
-    # @return [String] handles the formatting of "city, state zip, country"
-    def city_state_zip_country
-      state_zip = state
-      state_zip += " #{zip}" if zip
-      [city, state_zip, country].compact.join(', ')
+    def contact
+      contact_html&.html_safe
+    end
+
+    def location
+      location_html&.html_safe
     end
 
     # Why are we using self#respond_to? below?

--- a/lib/generators/arclight/templates/config/repositories.yml
+++ b/lib/generators/arclight/templates/config/repositories.yml
@@ -1,50 +1,43 @@
 nlm:
   name: 'National Library of Medicine. History of Medicine Division'
   description: 'NLM’s History of Medicine Division collects, preserves, makes available, and interprets for diverse audiences one of the world’s richest collections of historical material related to human health and disease.'
-  building: 'Building 38, Room 1E-21'
-  address1: '8600 Rockville Pike'
-  address2: ''
-  city: 'Bethesda'
-  state: 'MD'
-  zip: '20894'
-  country: 'USA'
-  phone: ''
-  contact_info: 'hmdref@nlm.nih.gov'
+  contact_html: |
+    <div class="al-repository-contact-info"><a href="mailto:hmdref@nlm.nih.gov">hmdref@nlm.nih.gov</a></div>
+  location_html: |
+    <div class="al-repository-street-address-building">Building 38, Room 1E-21</div>
+    <div class="al-repository-street-address-address1">8600 Rockville Pike</div>
+    <div class="al-repository-street-address-city_state_zip_country">Bethesda, MD 20894, USA</div>
   thumbnail_url: "https://collections.nlm.nih.gov/pageturnerserver/ajaxp?theurl=http://localhost:8080/fedora/get/nlm:nlmuid-101421040-img/THUMB"
   request_types:
     google_form:
       request_url: 'https://docs.google.com/a/stanford.edu/forms/d/e/1FAIpQLSeOamhY_IcFw4sPnz0ddwWWkrPaHbM5wp7JVbOLOL_mIusEyw/viewform'
       request_mappings: "document_url=entry.1980510262&collection_name=entry.619150170&collection_creator=entry.14428541&eadid=entry.996397105&containers=entry.1125277048&title=entry.862815208"
+
 sul-spec:
   name: 'Stanford University Libraries. Special Collections and University Archives'
   visit_note: 'Special Collections and University Archives materials are stored offsite and must be paged 36 hours in advance.'
   description: 'The Special Collections and University Archives Department of Stanford University Libraries is committed to acquiring, preserving, and providing access to primary source materials that support the research needs of the Stanford community and beyond. There are three distinct divisions in our department: Manuscripts, Rare Books and University Archives. We welcome all students, scholars and members of the general public to the Field Reading Room. Learn more about using and accessing our collections.'
-  building: 'Green Library'
-  address1: '557 Escondido Mall'
-  address2: ''
-  city: 'Stanford'
-  state: 'CA'
-  zip: '94305'
-  country: 'USA'
-  phone: '(650) 725-1022'
-  contact_info: 'specialcollections@stanford.edu'
+  contact_html: |
+    <div class="al-repository-contact-phone">(650) 725-1022</div>
+    <div class="al-repository-contact-info"><a href="mailto:specialcollections@stanford.edu">specialcollections@stanford.edu</a></div>
+  location_html: |
+    <div class="al-repository-street-address-building">Green Library</div>
+    <div class="al-repository-street-address-address1">557 Escondido Mall</div>
+    <div class="al-repository-street-address-city_state_zip_country">Stanford, CA 94305, USA</div>
   thumbnail_url: 'https://library.stanford.edu/sites/default/files/styles/150x150/public/collection/image/Collections-Super-Enlight.jpg'
   request_types:
     aeon_web_ead:
       request_url: 'https://sample.request.com'
       request_mappings: 'Action=10&Form=31&Value=ead_url'
+
 umich-bhl:
   name: 'University of Michigan. Bentley Historical Library'
   description: 'The Bentley Historical Library collects the materials for and promotes the study of the histories of two great, intertwined institutions, the State of Michigan and the University of Michigan. The Library is open without fee to the public, and we welcome researchers regardless of academic or professional affiliation.'
-  building: ''
-  address1: '1150 Beal Ave'
-  address2: ''
-  city: 'Ann Arbor'
-  state: 'MI'
-  zip: '48109-2113'
-  country: 'USA'
-  phone: ''
-  contact_info: 'bentley.ref@umich.edu'
+  contact_html: |
+    <div class="al-repository-contact-info"><a href="mailto:bentley.ref@umich.edu">bentley.ref@umich.edu</a></div>
+  location_html: |
+    <div class="al-repository-street-address-address1">1150 Beal Ave</div>
+    <div class="al-repository-street-address-city_state_zip_country">Ann Arbor, MI 48109-2113, USA</div>
   thumbnail_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Bhlexterior.jpg/150px-Bhlexterior.jpg'
   request_types:
     aeon_external_request_endpoint:

--- a/spec/controllers/concerns/arclight/field_config_helpers_spec.rb
+++ b/spec/controllers/concerns/arclight/field_config_helpers_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Arclight::FieldConfigHelpers do
     it 'renders the in_person_repository partial' do
       content = Capybara.string(helper.context_access_tab_repository(document: document_with_repository))
       expect(content).to have_css('.al-in-person-repository-name', text: 'My Repository')
-      expect(content).to have_css('address .al-repository-contact-building', text: 'My Building')
+      expect(content).to have_css('address .al-repository-street-address-building', text: 'My Building')
     end
   end
 

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe 'Collection Page', type: :feature do
         expect(page).to have_css 'dd', text: /materials are stored offsite and must be paged/
         expect(page).to have_css 'dt', text: 'LOCATION OF THIS COLLECTION:'
         expect(page).to have_css 'dd a', text: /Special Collections and University Archives/
-        expect(page).to have_css 'dd .al-repository-contact-building', text: 'Green Library'
+        expect(page).to have_css 'dd .al-repository-street-address-building', text: 'Green Library'
       end
     end
 

--- a/spec/fixtures/config/repositories.yml
+++ b/spec/fixtures/config/repositories.yml
@@ -2,15 +2,14 @@ sample:
   name: 'My Repository'
   visit_note: 'Containers are stored offsite and must be pages 2 to 3 days in advance'
   description: 'Lorem ipsum'
-  building: 'My Building'
-  address1: 'My Street Address'
-  address2: 'My Extra Address'
-  city: 'My City'
-  state: 'My State'
-  zip: '12345'
-  country: 'My Country'
-  phone: '123-456-7890'
-  contact_info: 'My Contact Info'
+  contact_html: |
+    <div class="al-repository-contact-phone">123-456-7890</div>
+    <div class="al-repository-contact-info">My Contact Info</div>
+  location_html: |
+    <div class="al-repository-street-address-building">My Building</div>
+    <div class="al-repository-street-address-address1">My Street Address</div>
+    <div class="al-repository-street-address-address2">My Extra Address</div>
+    <div class="al-repository-street-address-city_state_zip_country">My City, My State 12345, My Country</div>
   thumbnail_url: 'http://example.com/thumbnail_ABC.jpg'
   request_types:
       google_form:
@@ -25,15 +24,13 @@ sul-spec:
   name: 'Stanford University Libraries. Special Collections and University Archives'
   visit_note: 'Special Collections and University Archives materials are stored offsite and must be paged 36 hours in advance.'
   description: 'The Special Collections and University Archives Department of Stanford University Libraries is committed to acquiring, preserving, and providing access to primary source materials that support the research needs of the Stanford community and beyond. There are three distinct divisions in our department: Manuscripts, Rare Books and University Archives. We welcome all students, scholars and members of the general public to the Field Reading Room. Learn more about using and accessing our collections.'
-  building: 'Green Library'
-  address1: '557 Escondido Mall'
-  address2: ''
-  city: 'Stanford'
-  state: 'CA'
-  zip: '94305'
-  country: 'USA'
-  phone: '(650) 725-1022'
-  contact_info: 'specialcollections@stanford.edu'
+  contact_html: |
+    <div class="al-repository-contact-phone">(650) 725-1022</div>
+    <div class="al-repository-contact-info"><a href="mailto:specialcollections@stanford.edu">specialcollections@stanford.edu</a></div>
+  location_html: |
+    <div class="al-repository-street-address-building">Green Library</div>
+    <div class="al-repository-street-address-address1">557 Escondido Mall</div>
+    <div class="al-repository-street-address-city_state_zip_country">Stanford, CA 94305, USA</div>
   thumbnail_url: 'https://library.stanford.edu/sites/default/files/styles/150x150/public/collection/image/Collections-Super-Enlight.jpg'
   request_types:
     aeon_web_ead:
@@ -42,15 +39,12 @@ sul-spec:
 nlm:
   name: 'National Library of Medicine. History of Medicine Division'
   description: 'NLM’s History of Medicine Division collects, preserves, makes available, and interprets for diverse audiences one of the world’s richest collections of historical material related to human health and disease.'
-  building: 'Building 38, Room 1E-21'
-  address1: '8600 Rockville Pike'
-  address2: ''
-  city: 'Bethesda'
-  state: 'MD'
-  zip: '20894'
-  country: 'USA'
-  phone: ''
-  contact_info: 'hmdref@nlm.nih.gov'
+  contact_html: |
+    <div class="al-repository-contact-info"><a href="mailto:hmdref@nlm.nih.gov">hmdref@nlm.nih.gov</a></div>
+  location_html: |
+    <div class="al-repository-street-address-building">Building 38, Room 1E-21</div>
+    <div class="al-repository-street-address-address1">8600 Rockville Pike</div>
+    <div class="al-repository-street-address-city_state_zip_country">Bethesda, MD 20894, USA</div>
   thumbnail_url: "https://collections.nlm.nih.gov/pageturnerserver/ajaxp?theurl=http://localhost:8080/fedora/get/nlm:nlmuid-101421040-img/THUMB"
   request_types:
     google_form:
@@ -60,15 +54,11 @@ nlm:
 umich-bhl:
   name: 'University of Michigan. Bentley Historical Library'
   description: 'The Bentley Historical Library collects the materials for and promotes the study of the histories of two great, intertwined institutions, the State of Michigan and the University of Michigan. The Library is open without fee to the public, and we welcome researchers regardless of academic or professional affiliation.'
-  building: ''
-  address1: '1150 Beal Ave'
-  address2: ''
-  city: 'Ann Arbor'
-  state: 'MI'
-  zip: '48109-2113'
-  country: 'USA'
-  phone: ''
-  contact_info: 'bentley.ref@umich.edu'
+  contact_html: |
+    <div class="al-repository-contact-info"><a href="mailto:bentley.ref@umich.edu">bentley.ref@umich.edu</a></div>
+  location_html: |
+    <div class="al-repository-street-address-address1">1150 Beal Ave</div>
+    <div class="al-repository-street-address-city_state_zip_country">Ann Arbor, MI 48109-2113, USA</div>
   thumbnail_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Bhlexterior.jpg/150px-Bhlexterior.jpg'
   request_types:
       aeon_external_request_endpoint:

--- a/spec/lib/arclight/repository_spec.rb
+++ b/spec/lib/arclight/repository_spec.rb
@@ -52,44 +52,12 @@ RSpec.describe Arclight::Repository do
         expect(repo.description).to eq 'Lorem ipsum'
       end
 
-      it '#building' do
-        expect(repo.building).to eq 'My Building'
+      it '#location_html' do
+        expect(repo.location).to be_html_safe
       end
 
-      it '#address1' do
-        expect(repo.address1).to eq 'My Street Address'
-      end
-
-      it '#address2' do
-        expect(repo.address2).to eq 'My Extra Address'
-      end
-
-      it '#city' do
-        expect(repo.city).to eq 'My City'
-      end
-
-      it '#state' do
-        expect(repo.state).to eq 'My State'
-      end
-
-      it '#zip' do
-        expect(repo.zip).to eq '12345'
-      end
-
-      it '#country' do
-        expect(repo.country).to eq 'My Country'
-      end
-
-      it '#city_state_zip_country' do
-        expect(repo.city_state_zip_country).to eq 'My City, My State 12345, My Country'
-      end
-
-      it '#phone' do
-        expect(repo.phone).to eq '123-456-7890'
-      end
-
-      it '#contact_info' do
-        expect(repo.contact_info).to eq 'My Contact Info'
+      it '#contact' do
+        expect(repo.contact).to be_html_safe
       end
 
       it '#thumbnail_url' do
@@ -125,15 +93,6 @@ RSpec.describe Arclight::Repository do
 
     it 'in a YAML file' do
       expect(repo.slug).to eq 'nlm'
-    end
-  end
-
-  context 'when missing data' do
-    let(:repo) { described_class.find_by(slug: 'sample') }
-
-    it 'handles missing a country' do
-      repo.country = nil
-      expect(repo.city_state_zip_country).to eq 'My City, My State 12345'
     end
   end
 

--- a/spec/views/repositories/index.html.erb_spec.rb
+++ b/spec/views/repositories/index.html.erb_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'arclight/repositories/index', type: :view do
     end
 
     it 'has the correct contact information' do
-      expect(rendered).to have_css('.al-repository-contact-info-contact_info a @href', count: 3, text: /mailto:/)
+      expect(rendered).to have_css('.al-repository-contact-contact_info a @href', count: 3, text: /mailto:/)
     end
 
     it 'handles a missing building' do
@@ -53,7 +53,7 @@ RSpec.describe 'arclight/repositories/index', type: :view do
     end
 
     it 'handles a missing phone' do
-      expect(rendered).to have_css('.al-repository-contact-info-phone', count: 2)
+      expect(rendered).to have_css('.al-repository-contact-phone', count: 2)
     end
 
     context 'collection counts' do
@@ -102,13 +102,13 @@ RSpec.describe 'arclight/repositories/index', type: :view do
     it 'handles a missing email' do
       test_data.first.contact_info = nil
       render
-      expect(rendered).to have_css('.al-repository-contact-info-contact_info a @href', count: 3, text: /mailto:/)
+      expect(rendered).to have_css('.al-repository-contact-info a @href', count: 3, text: /mailto:/)
     end
 
     it 'handles a malformed email' do
       test_data.first.contact_info = 'not-an-email-address'
       render
-      expect(rendered).to have_css('.al-repository-contact-info-contact_info a @href', count: 3, text: /mailto:/)
+      expect(rendered).to have_css('.al-repository-contact-info a @href', count: 3, text: /mailto:/)
     end
   end
 end


### PR DESCRIPTION
I don't see anywhere we make this data actionable, so maybe it's easier to just let implementations write HTML?