### PR TITLE
Use setup-ruby@v1 action

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@0a29871fe2b0200a17a4497bae54fe5df0d973aa # v1.115.3
+      uses: ruby/setup-ruby@v1 
       with:
         bundler-cache: true
         ruby-version: ${{ matrix.ruby }}
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install Ruby and gems
-        uses: ruby/setup-ruby@0a29871fe2b0200a17a4497bae54fe5df0d973aa # v1.115.3
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: 3.1


### PR DESCRIPTION
we're pointed at a commit hash, which is a little weird and which the docs seem to discourage. I think it was autogenerated that way.