### PR TITLE
Remove unnecessary javascript from install generator

### DIFF
--- a/lib/generators/arclight/install_generator.rb
+++ b/lib/generators/arclight/install_generator.rb
@@ -111,9 +111,8 @@ module Arclight
 
     def import_arclight_javascript
       inject_into_file 'app/javascript/application.js', after: 'import "blacklight"' do
-        "\n  import $ from \"jquery\"\n  " \
-          "window.$ = $ // required by arclight\n  " \
-          "window.jQuery = $ // required by arclight/responsive_truncator.js\n  " \
+        "\nimport $ from \"jquery\"\n" \
+          "window.$ = $ // required by arclight\n" \
           'import "arclight"'
       end
     end


### PR DESCRIPTION
we no longer need to define window.jQuery as responsiveTruncator is gone