### PR TITLE
Update package.json so we can publish sass source files to NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,19 @@ Then visit http://localhost:3000. It will also start a Solr instance on port 898
 
 You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-### Release a new version of the gem
+### Releasing
 
-To release a new version:
+#### To release a new gem:
 
 1. Update the version number in `lib/arclight/version.rb`
 2. Run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, build the gem file (e.g., `gem build arclight.gemspec`) and push the `.gem` file to [rubygems.org](https://rubygems.org) (e.g., `gem push arclight-x.y.z.gem`).
+
+#### To release the frontend sources:
+
+When any of the javascript components or SASS sources in the gem are changed, this package should be published to NPM with the following steps:
+1. [Install npm](https://www.npmjs.com/get-npm)
+2. Bump the version number in `package.json`
+3. run `npm publish` to push the javascript package to https://npmjs.org/package/arclight
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "arclight",
-  "description": "",
-  "main": "index.js",
+  "version": "1.0.0-pre.1",
+  "description": "The frontend for arclight",
+  "main": "app/assets/javascript/arclight/arclight.js",
+  "files": [
+    "app/assets"
+  ],
   "devDependencies": {
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^11.1.3",


### PR DESCRIPTION
Because we're using cssbuilding-rails in NTA, we didn't have a path to the SASS source files in the arclight engine. This PR allows us to access a path in node_modules. We essentially copied blacklight's approach.