### PR TITLE
Index EAD components hierarchically

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -76,7 +76,7 @@ RSpec/MultipleMemoizedHelpers:
 # Offense count: 19
 # Configuration parameters: AllowedGroups.
 RSpec/NestedGroups:
-  Max: 4
+  Max: 5
 
 # Offense count: 7
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/lib/arclight/normalized_id.rb
+++ b/lib/arclight/normalized_id.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'arclight/exceptions'
+
 module Arclight
   ##
   # A simple utility class to normalize identifiers

--- a/lib/arclight/normalized_title.rb
+++ b/lib/arclight/normalized_title.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'arclight/exceptions'
+
 module Arclight
   ##
   # A utility class to normalize titles, typically by joining

--- a/lib/arclight/traject/ead2_component_config.rb
+++ b/lib/arclight/traject/ead2_component_config.rb
@@ -1,0 +1,311 @@
+# frozen_string_literal: true
+
+require 'logger'
+require 'traject'
+require 'traject/nokogiri_reader'
+require 'traject_plus'
+require 'traject_plus/macros'
+require 'arclight/level_label'
+require 'arclight/normalized_date'
+require 'arclight/normalized_title'
+require 'active_model/conversion' ## Needed for Arclight::Repository
+require 'active_support/core_ext/array/wrap'
+require 'arclight/digital_object'
+require 'arclight/year_range'
+require 'arclight/missing_id_strategy'
+require 'arclight/traject/nokogiri_namespaceless_reader'
+
+# rubocop:disable Style/MixinUsage
+extend TrajectPlus::Macros
+# rubocop:enable Style/MixinUsage
+
+settings do
+  # provide 'root' # the root EAD collection indexing context
+  # provide 'parent' # the immediate parent component (or collection) indexing context
+  # provide 'counter' # a global component counter to provide a global sort order for nested components
+  provide 'reader_class_name', 'Arclight::Traject::NokogiriNamespacelessReader'
+  provide 'logger', Logger.new($stderr)
+end
+
+NAME_ELEMENTS = %w[corpname famname name persname].freeze
+
+SEARCHABLE_NOTES_FIELDS = %w[
+  accessrestrict
+  accruals
+  altformavail
+  appraisal
+  arrangement
+  bibliography
+  bioghist
+  custodhist
+  fileplan
+  note
+  odd
+  originalsloc
+  otherfindaid
+  phystech
+  prefercite
+  processinfo
+  relatedmaterial
+  scopecontent
+  separatedmaterial
+  userestrict
+].freeze
+
+DID_SEARCHABLE_NOTES_FIELDS = %w[
+  abstract
+  materialspec
+  physloc
+].freeze
+
+to_field 'ref_ssi' do |record, accumulator, _context|
+  accumulator << if record.attribute('id').blank?
+                   strategy = Arclight::MissingIdStrategy.selected
+                   hexdigest = strategy.new(record).to_hexdigest
+                   parent_id = settings[:parent].output_hash['id'].first
+                   root_id = settings[:root].output_hash['id'].first
+                   logger.warn('MISSING ID WARNING') do
+                     [
+                       "A component in #{parent_id} did not have an ID so one was minted using the #{strategy} strategy.",
+                       "The ID of this document will be #{root_id}#{hexdigest}."
+                     ].join(' ')
+                   end
+                   record['id'] = hexdigest
+                   hexdigest
+                 else
+                   record.attribute('id')&.value&.strip&.gsub('.', '-')
+                 end
+end
+to_field 'ref_ssm' do |_record, accumulator, context|
+  accumulator.concat context.output_hash['ref_ssi']
+end
+
+to_field 'id' do |_record, accumulator, context|
+  accumulator << [
+    settings[:root].output_hash['id'],
+    context.output_hash['ref_ssi']
+  ].join
+end
+
+to_field 'ead_ssi' do |_record, accumulator, _context|
+  accumulator << settings[:root].output_hash['ead_ssi'].first
+end
+
+to_field 'title_filing_si', extract_xpath('./did/unittitle'), first_only
+to_field 'title_ssm', extract_xpath('./did/unittitle')
+to_field 'title_teim', extract_xpath('./did/unittitle')
+
+to_field 'unitdate_bulk_ssim', extract_xpath('./did/unitdate[@type="bulk"]')
+to_field 'unitdate_inclusive_ssm', extract_xpath('./did/unitdate[@type="inclusive"]')
+to_field 'unitdate_other_ssim', extract_xpath('./did/unitdate[not(@type)]')
+
+to_field 'normalized_title_ssm' do |_record, accumulator, context|
+  dates = Arclight::NormalizedDate.new(
+    context.output_hash['unitdate_inclusive_ssm'],
+    context.output_hash['unitdate_bulk_ssim'],
+    context.output_hash['unitdate_other_ssim']
+  ).to_s
+  title = context.output_hash['title_ssm']&.first
+  accumulator << Arclight::NormalizedTitle.new(title, dates).to_s
+end
+
+to_field 'normalized_date_ssm' do |_record, accumulator, context|
+  accumulator << Arclight::NormalizedDate.new(
+    context.output_hash['unitdate_inclusive_ssm'],
+    context.output_hash['unitdate_bulk_ssim'],
+    context.output_hash['unitdate_other_ssim']
+  ).to_s
+end
+
+to_field 'component_level_isim' do |_record, accumulator|
+  level = 1
+  parent = settings[:parent]
+
+  while parent != settings[:root]
+    level += 1
+    parent = parent.settings[:parent]
+  end
+
+  accumulator << level
+end
+
+to_field 'parent_ssim' do |_record, accumulator, _context|
+  accumulator.concat(settings[:parent].output_hash['parent_ssim'] || [])
+  accumulator.concat settings[:parent].output_hash['ref_ssi'] || settings[:parent].output_hash['id']
+end
+
+to_field 'parent_ssi' do |_record, accumulator, _context|
+  accumulator.concat settings[:parent].output_hash['ref_ssi'] || settings[:parent].output_hash['id']
+end
+
+to_field 'parent_unittitles_ssm' do |_rec, accumulator, _context|
+  accumulator.concat(settings[:parent].output_hash['parent_unittitles_ssm'] || [])
+  accumulator.concat settings[:parent].output_hash['normalized_title_ssm']
+end
+
+to_field 'parent_unittitles_teim' do |_record, accumulator, context|
+  accumulator.concat context.output_hash['parent_unittitles_ssm']
+end
+
+to_field 'parent_levels_ssm' do |_record, accumulator, _context|
+  ## Top level document
+  accumulator.concat settings[:parent].output_hash['parent_levels_ssm'] || []
+  accumulator.concat settings[:parent].output_hash['level_ssm']
+end
+
+to_field 'unitid_ssm', extract_xpath('./did/unitid')
+to_field 'collection_unitid_ssm' do |_record, accumulator, _context|
+  accumulator.concat Array.wrap(settings[:root].output_hash['unitid_ssm'])
+end
+to_field 'repository_ssm' do |_record, accumulator, _context|
+  accumulator << settings[:root].clipboard[:repository]
+end
+to_field 'repository_sim' do |_record, accumulator, _context|
+  accumulator << settings[:root].clipboard[:repository]
+end
+to_field 'collection_ssm' do |_record, accumulator, _context|
+  accumulator.concat settings[:root].output_hash['normalized_title_ssm']
+end
+to_field 'collection_sim' do |_record, accumulator, _context|
+  accumulator.concat settings[:root].output_hash['normalized_title_ssm']
+end
+to_field 'collection_ssi' do |_record, accumulator, _context|
+  accumulator.concat settings[:root].output_hash['normalized_title_ssm']
+end
+
+to_field 'extent_ssm', extract_xpath('./did/physdesc/extent')
+to_field 'extent_teim', extract_xpath('./did/physdesc/extent')
+
+to_field 'creator_ssm', extract_xpath('./did/origination')
+to_field 'creator_ssim', extract_xpath('./did/origination')
+to_field 'creators_ssim', extract_xpath('./did/origination')
+to_field 'creator_sort' do |record, accumulator|
+  accumulator << record.xpath('./did/origination').map(&:text).join(', ')
+end
+to_field 'collection_creator_ssm' do |_record, accumulator, _context|
+  accumulator.concat Array.wrap(settings[:root].output_hash['creator_ssm'])
+end
+to_field 'has_online_content_ssim', extract_xpath('.//dao') do |_record, accumulator|
+  accumulator.replace([accumulator.any?])
+end
+to_field 'child_component_count_isim' do |record, accumulator|
+  accumulator << record.xpath('c|c01|c02|c03|c04|c05|c06|c07|c08|c09|c10|c11|c12').count
+end
+
+to_field 'ref_ssm' do |record, accumulator|
+  accumulator << record.attribute('id')
+end
+
+to_field 'level_ssm' do |record, accumulator|
+  level = record.attribute('level')&.value
+  other_level = record.attribute('otherlevel')&.value
+  accumulator << Arclight::LevelLabel.new(level, other_level).to_s
+end
+
+to_field 'level_sim' do |_record, accumulator, context|
+  next unless context.output_hash['level_ssm']
+
+  accumulator.concat context.output_hash['level_ssm']&.map(&:capitalize)
+end
+
+to_field 'sort_ii' do |_record, accumulator, _context|
+  accumulator.replace([settings[:counter].increment])
+end
+
+# Get the <accessrestrict> from the closest ancestor that has one (includes top-level)
+to_field 'parent_access_restrict_ssm' do |record, accumulator|
+  accumulator.concat Array
+    .wrap(record.xpath('(./ancestor::*/accessrestrict)[last()]/*[local-name()!="head"]')
+    .map(&:text))
+end
+
+# Get the <userestrict> from self OR the closest ancestor that has one (includes top-level)
+to_field 'parent_access_terms_ssm' do |record, accumulator|
+  accumulator.concat Array
+    .wrap(record.xpath('(./ancestor-or-self::*/userestrict)[last()]/*[local-name()!="head"]')
+    .map(&:text))
+end
+
+to_field 'digital_objects_ssm', extract_xpath('./dao|./did/dao', to_text: false) do |_record, accumulator|
+  accumulator.map! do |dao|
+    label = dao.attributes['title']&.value ||
+            dao.xpath('daodesc/p')&.text
+    href = (dao.attributes['href'] || dao.attributes['xlink:href'])&.value
+    Arclight::DigitalObject.new(label: label, href: href).to_json
+  end
+end
+
+to_field 'date_range_sim', extract_xpath('./did/unitdate/@normal', to_text: false) do |_record, accumulator|
+  range = Arclight::YearRange.new
+  next range.years if accumulator.blank?
+
+  ranges = accumulator.map(&:to_s)
+  range << range.parse_ranges(ranges)
+  accumulator.replace range.years
+end
+
+NAME_ELEMENTS.map do |selector|
+  to_field 'names_ssim', extract_xpath("./controlaccess/#{selector}")
+  to_field "#{selector}_ssm", extract_xpath(".//#{selector}")
+end
+
+to_field 'geogname_sim', extract_xpath('./controlaccess/geogname')
+to_field 'geogname_ssm', extract_xpath('./controlaccess/geogname')
+to_field 'places_ssim', extract_xpath('./controlaccess/geogname')
+
+to_field 'access_subjects_ssim', extract_xpath('./controlaccess', to_text: false) do |_record, accumulator|
+  accumulator.map! do |element|
+    %w[subject function occupation genreform].map do |selector|
+      element.xpath(".//#{selector}").map(&:text)
+    end
+  end.flatten!
+end
+
+to_field 'access_subjects_ssm' do |_record, accumulator, context|
+  accumulator.concat(context.output_hash.fetch('access_subjects_ssim', []))
+end
+
+to_field 'acqinfo_ssim', extract_xpath('/ead/archdesc/acqinfo/*[local-name()!="head"]')
+to_field 'acqinfo_ssim', extract_xpath('/ead/archdesc/descgrp/acqinfo/*[local-name()!="head"]')
+to_field 'acqinfo_ssim', extract_xpath('./acqinfo/*[local-name()!="head"]')
+to_field 'acqinfo_ssim', extract_xpath('./descgrp/acqinfo/*[local-name()!="head"]')
+
+to_field 'language_ssm', extract_xpath('./did/langmaterial')
+to_field 'containers_ssim' do |record, accumulator|
+  record.xpath('./did/container').each do |node|
+    accumulator << [node.attribute('type'), node.text].join(' ').strip
+  end
+end
+
+SEARCHABLE_NOTES_FIELDS.map do |selector|
+  to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']", to_text: false)
+  to_field "#{selector}_heading_ssm", extract_xpath("./#{selector}/head")
+  to_field "#{selector}_teim", extract_xpath("./#{selector}/*[local-name()!='head']")
+end
+DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
+  to_field "#{selector}_ssm", extract_xpath("./did/#{selector}", to_text: false)
+end
+to_field 'did_note_ssm', extract_xpath('./did/note')
+
+# =============================
+# Each component child document
+# <c> <c01> <c12>
+# =============================
+
+to_field 'components' do |record, accumulator, context|
+  child_components = record.xpath('c|c01|c02|c03|c04|c05|c06|c07|c08|c09|c10|c11|c12')
+  component_indexer = Traject::Indexer::NokogiriIndexer.new.tap do |i|
+    i.load_config_file(__FILE__)
+  end
+
+  component_indexer.settings do
+    provide :parent, context
+    provide :root, context.settings[:root]
+    provide :counter, context.settings[:counter]
+  end
+
+  child_components.each do |child_component|
+    output = component_indexer.map_record(child_component)
+    accumulator << output if output.keys.any?
+  end
+end

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -5,7 +5,6 @@ require 'traject'
 require 'traject/nokogiri_reader'
 require 'traject_plus'
 require 'traject_plus/macros'
-require 'arclight/exceptions'
 require 'arclight/level_label'
 require 'arclight/normalized_date'
 require 'arclight/normalized_title'
@@ -14,7 +13,6 @@ require 'active_support/core_ext/array/wrap'
 require 'arclight/digital_object'
 require 'arclight/year_range'
 require 'arclight/repository'
-require 'arclight/missing_id_strategy'
 require 'arclight/traject/nokogiri_namespaceless_reader'
 
 # rubocop:disable Style/MixinUsage
@@ -241,255 +239,31 @@ to_field 'descrules_ssm', extract_xpath('/ead/eadheader/profiledesc/descrules')
 # <c> <c01> <c12>
 # =============================
 
-compose 'components', ->(record, accumulator, _context) { accumulator.concat record.xpath('//*[is_component(.)]', NokogiriXpathExtensions.new) } do
-  to_field 'ref_ssi' do |record, accumulator, context|
-    accumulator << if record.attribute('id').blank?
-                     strategy = Arclight::MissingIdStrategy.selected
-                     hexdigest = strategy.new(record).to_hexdigest
-                     parent_id = context.clipboard[:parent].output_hash['id'].first
-                     logger.warn('MISSING ID WARNING') do
-                       [
-                         "A component in #{parent_id} did not have an ID so one was minted using the #{strategy} strategy.",
-                         "The ID of this document will be #{parent_id}#{hexdigest}."
-                       ].join(' ')
-                     end
-                     record['id'] = hexdigest
-                     hexdigest
-                   else
-                     record.attribute('id')&.value&.strip&.gsub('.', '-')
-                   end
-  end
-  to_field 'ref_ssm' do |_record, accumulator, context|
-    accumulator.concat context.output_hash['ref_ssi']
+to_field 'components' do |record, accumulator, context|
+  child_components = record.xpath("/ead/archdesc/dsc/c|#{('/ead/archdesc/dsc/c01'..'/ead/archdesc/dsc/c12').to_a.join('|')}")
+  next unless child_components.any?
+
+  config_file_path = File.join(__dir__, 'ead2_component_config.rb')
+  component_indexer = Traject::Indexer::NokogiriIndexer.new.tap do |i|
+    i.load_config_file(config_file_path)
   end
 
-  to_field 'id' do |_record, accumulator, context|
-    accumulator << [
-      context.clipboard[:parent].output_hash['id'],
-      context.output_hash['ref_ssi']
-    ].join
-  end
-
-  to_field 'ead_ssi' do |_record, accumulator, context|
-    accumulator << context.clipboard[:parent].output_hash['ead_ssi'].first
-  end
-
-  to_field 'title_filing_si', extract_xpath('./did/unittitle'), first_only
-  to_field 'title_ssm', extract_xpath('./did/unittitle')
-  to_field 'title_teim', extract_xpath('./did/unittitle')
-
-  to_field 'unitdate_bulk_ssim', extract_xpath('./did/unitdate[@type="bulk"]')
-  to_field 'unitdate_inclusive_ssm', extract_xpath('./did/unitdate[@type="inclusive"]')
-  to_field 'unitdate_other_ssim', extract_xpath('./did/unitdate[not(@type)]')
-
-  to_field 'normalized_title_ssm' do |_record, accumulator, context|
-    dates = Arclight::NormalizedDate.new(
-      context.output_hash['unitdate_inclusive_ssm'],
-      context.output_hash['unitdate_bulk_ssim'],
-      context.output_hash['unitdate_other_ssim']
-    ).to_s
-    title = context.output_hash['title_ssm']&.first
-    accumulator << Arclight::NormalizedTitle.new(title, dates).to_s
-  end
-
-  to_field 'normalized_date_ssm' do |_record, accumulator, context|
-    accumulator << Arclight::NormalizedDate.new(
-      context.output_hash['unitdate_inclusive_ssm'],
-      context.output_hash['unitdate_bulk_ssim'],
-      context.output_hash['unitdate_other_ssim']
-    ).to_s
-  end
-
-  to_field 'component_level_isim' do |record, accumulator|
-    accumulator << (1 + NokogiriXpathExtensions.new.is_component(record.ancestors).count)
-  end
-
-  to_field 'parent_ssim' do |record, accumulator, context|
-    accumulator << context.clipboard[:parent].output_hash['id'].first
-    accumulator.concat(NokogiriXpathExtensions.new.is_component(record.ancestors).reverse.map { |n| n.attribute('id')&.value })
-  end
-
-  to_field 'parent_ssi' do |_record, accumulator, context|
-    accumulator << context.output_hash['parent_ssim'].last
-  end
-
-  to_field 'parent_unittitles_ssm' do |_rec, accumulator, context|
-    # top level document
-    accumulator.concat context.clipboard[:parent].output_hash['normalized_title_ssm']
-    parent_ssim = context.output_hash['parent_ssim']
-    components = context.clipboard[:parent].output_hash['components']
-
-    # other components
-    if parent_ssim && components
-      ancestors = parent_ssim.drop(1).map { |x| [x] }
-      accumulator.concat(components.select { |c| ancestors.include? c['ref_ssi'] }.flat_map { |c| c['normalized_title_ssm'] })
+  counter = Class.new do
+    def increment
+      @counter ||= -1
+      @counter += 1
     end
+  end.new
+
+  component_indexer.settings do
+    provide :parent, context
+    provide :root, context
+    provide :counter, counter
+    provide :logger, context.settings[:logger]
   end
 
-  to_field 'parent_unittitles_teim' do |_record, accumulator, context|
-    accumulator.concat context.output_hash['parent_unittitles_ssm']
+  child_components.each do |child_component|
+    output = component_indexer.map_record(child_component)
+    accumulator << output if output.keys.any?
   end
-
-  to_field 'parent_levels_ssm' do |_record, accumulator, context|
-    ## Top level document
-    accumulator.concat context.clipboard[:parent].output_hash['level_ssm']
-    ## Other components
-    context.output_hash['parent_ssim']&.drop(1)&.each do |id|
-      accumulator.concat Array
-        .wrap(context.clipboard[:parent].output_hash['components'])
-        .select { |c| c['ref_ssi'] == [id] }.map { |c| c['level_ssm'] }.flatten
-    end
-  end
-
-  to_field 'unitid_ssm', extract_xpath('./did/unitid')
-  to_field 'collection_unitid_ssm' do |_record, accumulator, context|
-    accumulator.concat Array.wrap(context.clipboard[:parent].output_hash['unitid_ssm'])
-  end
-  to_field 'repository_ssm' do |_record, accumulator, context|
-    accumulator << context.clipboard[:parent].clipboard[:repository]
-  end
-  to_field 'repository_sim' do |_record, accumulator, context|
-    accumulator << context.clipboard[:parent].clipboard[:repository]
-  end
-  to_field 'collection_ssm' do |_record, accumulator, context|
-    accumulator.concat context.clipboard[:parent].output_hash['normalized_title_ssm']
-  end
-  to_field 'collection_sim' do |_record, accumulator, context|
-    accumulator.concat context.clipboard[:parent].output_hash['normalized_title_ssm']
-  end
-  to_field 'collection_ssi' do |_record, accumulator, context|
-    accumulator.concat context.clipboard[:parent].output_hash['normalized_title_ssm']
-  end
-
-  to_field 'extent_ssm', extract_xpath('./did/physdesc/extent')
-  to_field 'extent_teim', extract_xpath('./did/physdesc/extent')
-
-  to_field 'creator_ssm', extract_xpath('./did/origination')
-  to_field 'creator_ssim', extract_xpath('./did/origination')
-  to_field 'creators_ssim', extract_xpath('./did/origination')
-  to_field 'creator_sort' do |record, accumulator|
-    accumulator << record.xpath('./did/origination').map(&:text).join(', ')
-  end
-  to_field 'collection_creator_ssm' do |_record, accumulator, context|
-    accumulator.concat Array.wrap(context.clipboard[:parent].output_hash['creator_ssm'])
-  end
-  to_field 'has_online_content_ssim', extract_xpath('.//dao') do |_record, accumulator|
-    accumulator.replace([accumulator.any?])
-  end
-  to_field 'child_component_count_isim' do |record, accumulator|
-    accumulator << NokogiriXpathExtensions.new.is_component(record.children).count
-  end
-
-  to_field 'ref_ssm' do |record, accumulator|
-    accumulator << record.attribute('id')
-  end
-
-  to_field 'level_ssm' do |record, accumulator|
-    level = record.attribute('level')&.value
-    other_level = record.attribute('otherlevel')&.value
-    accumulator << Arclight::LevelLabel.new(level, other_level).to_s
-  end
-
-  to_field 'level_sim' do |_record, accumulator, context|
-    next unless context.output_hash['level_ssm']
-
-    accumulator.concat context.output_hash['level_ssm']&.map(&:capitalize)
-  end
-
-  to_field 'sort_ii' do |_record, accumulator, context|
-    accumulator.replace([context.position])
-  end
-
-  # Get the <accessrestrict> from the closest ancestor that has one (includes top-level)
-  to_field 'parent_access_restrict_ssm' do |record, accumulator|
-    accumulator.concat Array
-      .wrap(record.xpath('(./ancestor::*/accessrestrict)[last()]/*[local-name()!="head"]')
-      .map(&:text))
-  end
-
-  # Get the <userestrict> from self OR the closest ancestor that has one (includes top-level)
-  to_field 'parent_access_terms_ssm' do |record, accumulator|
-    accumulator.concat Array
-      .wrap(record.xpath('(./ancestor-or-self::*/userestrict)[last()]/*[local-name()!="head"]')
-      .map(&:text))
-  end
-
-  to_field 'digital_objects_ssm', extract_xpath('./dao|./did/dao', to_text: false) do |_record, accumulator|
-    accumulator.map! do |dao|
-      label = dao.attributes['title']&.value ||
-              dao.xpath('daodesc/p')&.text
-      href = (dao.attributes['href'] || dao.attributes['xlink:href'])&.value
-      Arclight::DigitalObject.new(label: label, href: href).to_json
-    end
-  end
-
-  to_field 'date_range_sim', extract_xpath('./did/unitdate/@normal', to_text: false) do |_record, accumulator|
-    range = Arclight::YearRange.new
-    next range.years if accumulator.blank?
-
-    ranges = accumulator.map(&:to_s)
-    range << range.parse_ranges(ranges)
-    accumulator.replace range.years
-  end
-
-  NAME_ELEMENTS.map do |selector|
-    to_field 'names_ssim', extract_xpath("./controlaccess/#{selector}")
-    to_field "#{selector}_ssm", extract_xpath(".//#{selector}")
-  end
-
-  to_field 'geogname_sim', extract_xpath('./controlaccess/geogname')
-  to_field 'geogname_ssm', extract_xpath('./controlaccess/geogname')
-  to_field 'places_ssim', extract_xpath('./controlaccess/geogname')
-
-  to_field 'access_subjects_ssim', extract_xpath('./controlaccess', to_text: false) do |_record, accumulator|
-    accumulator.map! do |element|
-      %w[subject function occupation genreform].map do |selector|
-        element.xpath(".//#{selector}").map(&:text)
-      end
-    end.flatten!
-  end
-
-  to_field 'access_subjects_ssm' do |_record, accumulator, context|
-    accumulator.concat(context.output_hash.fetch('access_subjects_ssim', []))
-  end
-
-  to_field 'acqinfo_ssim', extract_xpath('/ead/archdesc/acqinfo/*[local-name()!="head"]')
-  to_field 'acqinfo_ssim', extract_xpath('/ead/archdesc/descgrp/acqinfo/*[local-name()!="head"]')
-  to_field 'acqinfo_ssim', extract_xpath('./acqinfo/*[local-name()!="head"]')
-  to_field 'acqinfo_ssim', extract_xpath('./descgrp/acqinfo/*[local-name()!="head"]')
-
-  to_field 'language_ssm', extract_xpath('./did/langmaterial')
-  to_field 'containers_ssim' do |record, accumulator|
-    record.xpath('./did/container').each do |node|
-      accumulator << [node.attribute('type'), node.text].join(' ').strip
-    end
-  end
-
-  SEARCHABLE_NOTES_FIELDS.map do |selector|
-    to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']", to_text: false)
-    to_field "#{selector}_heading_ssm", extract_xpath("./#{selector}/head")
-    to_field "#{selector}_teim", extract_xpath("./#{selector}/*[local-name()!='head']")
-  end
-  DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
-    to_field "#{selector}_ssm", extract_xpath("./did/#{selector}", to_text: false)
-  end
-  to_field 'did_note_ssm', extract_xpath('./did/note')
-end
-
-each_record do |_record, context|
-  context.output_hash['components'] &&= context.output_hash['components'].select { |c| c.keys.any? }
-end
-
-##
-# Used for evaluating xpath components to find
-class NokogiriXpathExtensions
-  # rubocop:disable Naming/PredicateName, Style/FormatString
-  def is_component(node_set)
-    node_set.find_all do |node|
-      component_elements = (1..12).map { |i| "c#{'%02d' % i}" }
-      component_elements.push 'c'
-      component_elements.include? node.name
-    end
-  end
-  # rubocop:enable Naming/PredicateName, Style/FormatString
 end

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -12,6 +12,9 @@ describe 'EAD 2 traject indexing', type: :feature do
       i.load_config_file(Arclight::Engine.root.join('lib/arclight/traject/ead2_config.rb'))
     end
   end
+  let(:all_components) do
+    components(result) - [result]
+  end
   let(:fixture_path) do
     Arclight::Engine.root.join('spec', 'fixtures', 'ead', 'sul-spec', 'a0011.xml')
   end
@@ -26,6 +29,12 @@ describe 'EAD 2 traject indexing', type: :feature do
   end
   let(:record) do
     records.first
+  end
+
+  def components(result)
+    [result] + result.fetch('components', []).flat_map do |component|
+      components(component)
+    end
   end
 
   before do
@@ -114,7 +123,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     describe 'components' do
-      let(:first_component) { result['components'].first }
+      let(:first_component) { all_components.first }
 
       it 'ref' do
         %w[ref_ssm ref_ssi].each do |field|
@@ -153,7 +162,7 @@ describe 'EAD 2 traject indexing', type: :feature do
 
       it 'geogname' do
         %w[geogname_sim geogname_ssm].each do |field|
-          expect(result['components'].first[field]).to be_nil
+          expect(all_components.first[field]).to be_nil
         end
       end
 
@@ -174,7 +183,7 @@ describe 'EAD 2 traject indexing', type: :feature do
       end
 
       it 'containers' do
-        component = result['components'].find { |c| c['ref_ssi'] == ['aspace_ref6_lx4'] }
+        component = all_components.find { |c| c['ref_ssi'] == ['aspace_ref6_lx4'] }
         expect(component['containers_ssim']).to eq ['box 1']
       end
 
@@ -182,17 +191,16 @@ describe 'EAD 2 traject indexing', type: :feature do
         let(:fixture_path) do
           Arclight::Engine.root.join('spec', 'fixtures', 'ead', 'nlm', 'alphaomegaalpha.xml')
         end
-        let(:level_component) { result['components'].find { |c| c['ref_ssi'] == ['aspace_a951375d104030369a993ff943f61a77'] } }
-        let(:other_level_component) { result['components'].find { |c| c['ref_ssi'] == ['aspace_e6db65d47e891d61d69c2798c68a8f02'] } }
+
+        let(:level_component) { all_components.find { |c| c['ref_ssi'] == ['aspace_a951375d104030369a993ff943f61a77'] } }
+        let(:other_level_component) { all_components.find { |c| c['ref_ssi'] == ['aspace_e6db65d47e891d61d69c2798c68a8f02'] } }
 
         it 'is the level Capitalized' do
           expect(level_component['level_ssm']).to eq(['Series'])
-          expect(level_component['level_sim']).to eq(['Series'])
         end
 
         it 'is the otherlevel attribute when the level attribute is "otherlevel"' do
           expect(other_level_component['level_ssm']).to eq(['Binder'])
-          expect(other_level_component['level_sim']).to eq(['Binder'])
         end
 
         it 'sort' do
@@ -209,7 +217,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'selects the components' do
-      expect(result['components'].length).to eq 404
+      expect(all_components.length).to eq 404
     end
 
     it 'indexes top-level daos' do
@@ -224,7 +232,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     context 'when nested component' do
-      let(:nested_component) { result['components'].find { |c| c['id'] == ['lc0100aspace_32ad9025a3a286358baeae91b5d7696e'] } }
+      let(:nested_component) { all_components.find { |c| c['id'] == ['lc0100aspace_32ad9025a3a286358baeae91b5d7696e'] } }
 
       it 'correctly determines component level' do
         expect(nested_component['component_level_isim']).to eq [2]
@@ -245,8 +253,8 @@ describe 'EAD 2 traject indexing', type: :feature do
     let(:fixture_path) do
       Arclight::Engine.root.join('spec', 'fixtures', 'ead', 'nlm', 'ncaids544-id-test.xml')
     end
-    let(:component_with_descendants) { result['components'].find { |c| c['id'] == ['ncaids544-testd0e452'] } }
-    let(:nested_component) { result['components'].find { |c| c['id'] == ['ncaids544-testd0e631'] } }
+    let(:component_with_descendants) { all_components.find { |c| c['id'] == ['ncaids544-testd0e452'] } }
+    let(:nested_component) { all_components.find { |c| c['id'] == ['ncaids544-testd0e631'] } }
 
     it 'counts child components' do
       expect(component_with_descendants['child_component_count_isim']).to eq [9]
@@ -314,7 +322,7 @@ describe 'EAD 2 traject indexing', type: :feature do
 
     describe 'component-level' do
       it 'indexes own notes, not notes from descendants' do
-        component = result['components'].find { |c| c['id'] == ['aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671'] }
+        component = all_components.find { |c| c['id'] == ['aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671'] }
         expect(component).to include 'scopecontent_ssm'
         expect(component['scopecontent_ssm']).to include(a_string_matching(/provide important background context./))
         expect(component['scopecontent_ssm']).not_to include(a_string_matching(/correspondence, and a nametag./))
@@ -341,7 +349,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'extent at the component level' do
-      component = result['components'].find { |c| c['ref_ssi'] == ['aspace_a951375d104030369a993ff943f61a77'] }
+      component = all_components.find { |c| c['ref_ssi'] == ['aspace_a951375d104030369a993ff943f61a77'] }
       %w[extent_ssm extent_teim].each do |field|
         expect(component[field]).to equal_array_ignoring_whitespace(
           ['1.5 Linear Feet']
@@ -350,58 +358,69 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'selects the components' do
-      expect(result['components'].length).to eq 38
+      expect(all_components.length).to eq 38
     end
 
     context 'nested component' do
       describe 'accessrestrict' do
-        let(:component_with_own_accessrestrict) do
-          result['components'].find { |c| c['ref_ssi'] == ['aspace_dba76dab6f750f31aa5fc73e5402e71d'] }
-        end
-        let(:component_inheriting_accessrestrict_from_parent) do
-          result['components'].find { |c| c['ref_ssi'] == ['aspace_843e8f9f22bac69872d0802d6fffbb04'] }
-        end
-        let(:component_inheriting_accessrestrict_from_grandparent) do
-          result['components'].find { |c| c['ref_ssi'] == ['aspace_4b4fa033c630a45d41fcd608cf0d184d'] }
-        end
-        let(:component_inheriting_accessrestrict_from_collection) do
-          result['components'].find { |c| c['ref_ssi'] == ['aspace_72f14d6c32e142baa3eeafdb6e4d69be'] }
+        context 'with its own accessrestrct' do
+          let(:component_with_own_accessrestrict) do
+            all_components.find { |c| c['ref_ssi'] == ['aspace_dba76dab6f750f31aa5fc73e5402e71d'] }
+          end
+
+          it 'has own accessrestrict' do
+            expect(component_with_own_accessrestrict['accessrestrict_ssm'])
+              .to include(a_string_matching(/Restricted until 2018./))
+            expect(component_with_own_accessrestrict['parent_access_restrict_ssm'])
+              .to include(a_string_matching(/No restrictions on access/))
+          end
         end
 
-        it 'has own accessrestrict' do
-          expect(component_with_own_accessrestrict['accessrestrict_ssm'])
-            .to include(a_string_matching(/Restricted until 2018./))
-          expect(component_with_own_accessrestrict['parent_access_restrict_ssm'])
-            .to include(a_string_matching(/No restrictions on access/))
+        context 'with an accessrestrict on the parent' do
+          let(:component_inheriting_accessrestrict_from_parent) do
+            all_components.find { |c| c['ref_ssi'] == ['aspace_843e8f9f22bac69872d0802d6fffbb04'] }
+          end
+
+          it 'gets accessrestrict from parent component' do
+            expect(component_inheriting_accessrestrict_from_parent['accessrestrict_ssm'])
+              .to be_nil
+            expect(component_inheriting_accessrestrict_from_parent['parent_access_restrict_ssm'])
+              .to include(a_string_matching(/RESTRICTED: Access to these folders requires prior written approval./))
+          end
         end
 
-        it 'gets accessrestrict from parent component' do
-          expect(component_inheriting_accessrestrict_from_parent['accessrestrict_ssm'])
-            .to be_nil
-          expect(component_inheriting_accessrestrict_from_parent['parent_access_restrict_ssm'])
-            .to include(a_string_matching(/RESTRICTED: Access to these folders requires prior written approval./))
+        context 'with an accessrestrict on the grandparent' do
+          let(:component_inheriting_accessrestrict_from_grandparent) do
+            all_components.find { |c| c['ref_ssi'] == ['aspace_4b4fa033c630a45d41fcd608cf0d184d'] }
+          end
+
+          it 'gets accessrestrict from grandparent component' do
+            expect(component_inheriting_accessrestrict_from_grandparent['accessrestrict_ssm']).to be_nil
+            expect(component_inheriting_accessrestrict_from_grandparent['parent_access_restrict_ssm'])
+              .to include(a_string_matching(/RESTRICTED: Access to these folders requires prior written approval./))
+          end
         end
 
-        it 'gets accessrestrict from grandparent component' do
-          expect(component_inheriting_accessrestrict_from_grandparent['accessrestrict_ssm']).to be_nil
-          expect(component_inheriting_accessrestrict_from_grandparent['parent_access_restrict_ssm'])
-            .to include(a_string_matching(/RESTRICTED: Access to these folders requires prior written approval./))
-        end
+        context 'with an accessrestrict on the collection' do
+          let(:component_inheriting_accessrestrict_from_collection) do
+            all_components.find { |c| c['ref_ssi'] == ['aspace_72f14d6c32e142baa3eeafdb6e4d69be'] }
+          end
 
-        it 'gets accessrestrict from collection' do
-          expect(component_inheriting_accessrestrict_from_collection['accessrestrict_ssm']).to be_nil
-          expect(component_inheriting_accessrestrict_from_collection['parent_access_restrict_ssm'])
-            .to eq ['No restrictions on access.']
+          it 'gets accessrestrict from collection' do
+            expect(component_inheriting_accessrestrict_from_collection['accessrestrict_ssm']).to be_nil
+            expect(component_inheriting_accessrestrict_from_collection['parent_access_restrict_ssm'])
+              .to eq ['No restrictions on access.']
+          end
         end
       end
 
       describe 'userestrict' do
         let(:component_with_own_userestrict) do
-          result['components'].find { |c| c['ref_ssi'] == ['aspace_72f14d6c32e142baa3eeafdb6e4d69be'] }
+          all_components.find { |c| c['ref_ssi'] == ['aspace_72f14d6c32e142baa3eeafdb6e4d69be'] }
         end
 
         let(:component_inheriting_userestrict_from_collection) do
-          result['components'].find { |c| c['ref_ssi'] == ['aspace_dba76dab6f750f31aa5fc73e5402e71d'] }
+          all_components.find { |c| c['ref_ssi'] == ['aspace_dba76dab6f750f31aa5fc73e5402e71d'] }
         end
 
         it 'has own userestrict' do
@@ -420,10 +439,10 @@ describe 'EAD 2 traject indexing', type: :feature do
       end
 
       describe 'parents & titles' do
-        let(:component_with_many_parents) { result['components'].find { |c| c['ref_ssi'] == ['aspace_f934f1add34289f28bd0feb478e68275'] } }
+        let(:component_with_many_parents) { all_components.find { |c| c['ref_ssi'] == ['aspace_f934f1add34289f28bd0feb478e68275'] } }
 
         it 'parent_unittitles should be displayable and searchable' do
-          component = result['components'].find { |c| c['id'] == ['aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671'] }
+          component = all_components.find { |c| c['id'] == ['aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671'] }
           %w[parent_unittitles_ssm parent_unittitles_teim].each do |field|
             expect(component[field]).to contain_exactly(
               'Alpha Omega Alpha Archives, 1894-1992'
@@ -456,12 +475,12 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'only indexes containers within a given component' do
-      component = result['components'].find { |c| c['id'] == ['aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'] }
+      component = all_components.find { |c| c['id'] == ['aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'] }
       expect(component['containers_ssim']).to eq ['box 1', 'folder 1']
     end
 
     it 'only indexes containers at the same level of the component' do
-      component = result['components'].find { |c| c['id'] == ['aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671'] }
+      component = all_components.find { |c| c['id'] == ['aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671'] }
       expect(component['containers_ssim']).to be_nil
     end
   end
@@ -484,7 +503,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'indexes controlaccess subjects within a component' do
-      component = result['components'].find { |c| c['id'] == ['aoa271aspace_81c806b82a14c3c79d395bbd383b886f'] }
+      component = all_components.find { |c| c['id'] == ['aoa271aspace_81c806b82a14c3c79d395bbd383b886f'] }
       %w[access_subjects_ssm access_subjects_ssim].each do |field|
         expect(component).to include field
         expect(component[field]).to contain_exactly 'Minutes'
@@ -538,13 +557,13 @@ describe 'EAD 2 traject indexing', type: :feature do
 
     describe 'component-level' do
       it 'indexes <controlaccess> names in a shared names field' do
-        component = result['components'].find { |c| c['id'] == ['aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'] }
+        component = all_components.find { |c| c['id'] == ['aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'] }
         expect(component).to include 'names_ssim'
         expect(component['names_ssim']).to include_ignoring_whitespace 'Robertson\'s Crab House'
       end
 
       it 'indexes names in fields for specific name types, regardless of <controlaccess>' do
-        component = result['components'].find { |c| c['id'] == ['aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'] }
+        component = all_components.find { |c| c['id'] == ['aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'] }
         expect(component['corpname_ssm']).to include_ignoring_whitespace 'Robertson\'s Crab House'
         expect(component['persname_ssm']).to include_ignoring_whitespace 'Anfinsen, Christian B.'
       end
@@ -557,7 +576,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'indexes geognames' do
-      component = result['components'].find { |d| d['id'] == ['aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'] }
+      component = all_components.find { |d| d['id'] == ['aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'] }
       expect(component).to include 'geogname_sim'
       expect(component['geogname_sim']).to include('Popes Creek (Md.)')
 
@@ -572,7 +591,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     it 'creates date_range_sim' do
-      component = result['components'].find { |d| d['id'] == ['aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671'] }
+      component = all_components.find { |d| d['id'] == ['aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671'] }
       date_range = component['date_range_sim']
       expect(date_range).to be_an Array
       expect(date_range.length).to eq 75
@@ -588,8 +607,8 @@ describe 'EAD 2 traject indexing', type: :feature do
 
     it 'indexes the values as stored facetable strings and multiple displayable strings' do
       expect(result).to include 'components'
-      expect(result['components']).not_to be_empty
-      first_component = result['components'].first
+      expect(all_components).not_to be_empty
+      first_component = all_components.first
 
       expect(first_component).to include 'acqinfo_ssim'
       expect(first_component['acqinfo_ssim']).to contain_exactly(
@@ -609,8 +628,8 @@ describe 'EAD 2 traject indexing', type: :feature do
 
       it 'indexes the values as stored facetable strings and multiple displayable strings' do
         expect(result).to include 'components'
-        expect(result['components']).not_to be_empty
-        first_component = result['components'].first
+        expect(all_components).not_to be_empty
+        first_component = all_components.first
 
         expect(first_component).to include 'acqinfo_ssim'
         expect(first_component['acqinfo_ssim']).to equal_array_ignoring_whitespace(
@@ -631,7 +650,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     context 'when <dao> is direct child of <c0x> component' do
-      let(:component) { result['components'].find { |c| c['id'] == ['aoa271aspace_e6db65d47e891d61d69c2798c68a8f02'] } }
+      let(:component) { all_components.find { |c| c['id'] == ['aoa271aspace_e6db65d47e891d61d69c2798c68a8f02'] } }
 
       it 'gets the digital object' do
         expect(component['digital_objects_ssm']).to eq(
@@ -646,7 +665,7 @@ describe 'EAD 2 traject indexing', type: :feature do
     end
 
     context 'when <dao> is child of the <did> in a <c0x> component' do
-      let(:component) { result['components'].find { |c| c['id'] == ['aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'] } }
+      let(:component) { all_components.find { |c| c['id'] == ['aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'] } }
 
       it 'gets the digital objects' do
         expect(component['digital_objects_ssm']).to eq(
@@ -669,12 +688,12 @@ describe 'EAD 2 traject indexing', type: :feature do
     let(:fixture_path) do
       Arclight::Engine.root.join('spec', 'fixtures', 'ead', 'sample', 'no-ids-recordgrp-level.xml')
     end
-    let(:first_component) { result['components'].first }
-    let(:second_component) { result['components'].second }
+    let(:first_component) { all_components.first }
+    let(:second_component) { all_components.second }
 
     it 'mints component ids by hashing absolute paths' do
       expect(result).to include 'components'
-      expect(result['components']).not_to be_empty
+      expect(all_components).not_to be_empty
 
       expect(first_component['ref_ssi']).to contain_exactly('al_4bf70b448ac8351a147acff1dd8b1c0b9a791980')
       expect(first_component['id']).to contain_exactly('ehllHemingwayErnest-sampleal_4bf70b448ac8351a147acff1dd8b1c0b9a791980')


### PR DESCRIPTION
Currently, we index EAD files into solr with a top-level collection object with nested components that flatten out the EAD hierarchy.

The PR expands the use of nested components to model the EAD component hierarchy in Solr as well (inspired by e.g. https://github.com/pulibrary/pulfalight/tree/main/lib/pulfalight/traject)

Future work may be able to build on this to remove our arclight-specific hierarchy fields (level, parents, etc) or use the hierarchy to retrieve the collection title or parent unit titles directly instead of indexing them into each component.
