### PR TITLE
Use explicit data attributes for the truncation component

### DIFF
--- a/app/assets/javascripts/arclight/truncator.js
+++ b/app/assets/javascripts/arclight/truncator.js
@@ -1,8 +1,8 @@
 function setupTruncation(container) {
   // target elements
-  const contentOuter = container.querySelector('.content')
+  const contentOuter = container.querySelector('[data-arclight-truncate-target="content"]')
   const contentInner = Array.from(contentOuter.children)
-  const button = container.querySelector('button')
+  const button = container.querySelector('[data-action="click->arclightTruncate#trigger"]')
 
   // calculate total scrollable inner height vs. observed outer height
   const outerHeight = contentOuter.clientHeight
@@ -23,10 +23,10 @@ function setupTruncation(container) {
 
 Blacklight.onLoad(() => {
   // activate on initial page load
-  document.querySelectorAll('[data-arclight-truncate=true]').forEach(setupTruncation)
+  document.querySelectorAll('[data-controller="arclight-truncate"]').forEach(setupTruncation)
 
   // activate when the page is resized
   window.addEventListener('resize', () => {
-    document.querySelectorAll('[data-arclight-truncate=true]').forEach(setupTruncation);
+    document.querySelectorAll('[data-controller="arclight-truncate"]').forEach(setupTruncation)
   })
 })

--- a/app/components/arclight/index_metadata_field_component.html.erb
+++ b/app/components/arclight/index_metadata_field_component.html.erb
@@ -1,14 +1,16 @@
 <div class="row">
-  <%= tag.div(class: @classes, data: { 'arclight-truncate': truncate? }) do %>
-    <% if truncate? %>
-      <%= tag.div @field.render, class: 'content' %>
-      <%= button_tag(type: :button, class: 'btn btn-sm btn-link', aria: { hidden: true }) do %>
+  <% if truncate? %>
+    <%= tag.div(class: @classes, data: { controller: 'arclight-truncate' }) do %>
+      <%= tag.div @field.render, class: 'content', data: { arclight_truncate_target: 'content' } %>
+      <%= button_tag(type: :button, class: 'btn btn-sm btn-link',
+                     data: { action: 'click->arclightTruncate#trigger' },
+                     aria: { hidden: true }) do %>
         <%= tag.span t('arclight.truncation.view_more'), class: 'view-more' %>
         <%= tag.span t('arclight.truncation.view_less'), class: 'view-less' %>
         <%= tag.span(class: 'icon') %>
       <% end %>
-    <% else %>
-      <%= @field.render %>
     <% end %>
+  <% else %>
+    <%= tag.div @field.render, class: @classes %>
   <% end %>
 </div>


### PR DESCRIPTION
This will avoid the problem where the markup inadvertently changes the behavior.