### PR TITLE
Provide a docker-compose that can run solr

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ See the [CONTRIBUTORS](CONTRIBUTORS.md) file.
 
 ## Development
 
-ArcLight development uses [`solr_wrapper`](https://rubygems.org/gems/solr_wrapper/versions/0.18.1) and [`engine_cart`](https://rubygems.org/gems/engine_cart) to host development instances of Solr and Rails server on your local machine.
+ArcLight requires Solr to be running.  For development you can start this using `solr_wrapper` or you may choose to use Docker. Start Solr using Docker by doing `docker compose up`.
 
 ### Run the test suite
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.7"
+
+services:
+  solr:
+    image: solr:latest
+    volumes:
+      - $PWD/solr/conf:/opt/solr/conf
+    ports:
+      - 8983:8983
+    entrypoint:
+      - docker-entrypoint.sh
+      - solr-precreate
+      - blacklight-core
+      - /opt/solr/conf
+      - "-Xms256m"
+      - "-Xmx512m"


### PR DESCRIPTION
This approach has the advantage that you don't need to re-index every time you restart the solr service.