### PR TITLE
Fix icons for series/collection breadcrumbs

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -9,6 +9,8 @@
   padding-bottom: $spacer * .5;
   margin-bottom: $spacer * .75;
   width: 100%;
+  
+  $bent-arrow: "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='20' height='15'><path fill-rule='evenodd' d='M1.5 1.5A.5.5 0 0 0 1 2v4.8a2.5 2.5 0 0 0 2.5 2.5h9.793l-3.347 3.346a.5.5 0 0 0 .708.708l4.2-4.2a.5.5 0 0 0 0-.708l-4-4a.5.5 0 0 0-.708.708L13.293 8.3H3.5A1.5 1.5 0 0 1 2 6.8V2a.5.5 0 0 0-.5-.5z'></path></svg>";
 
   .breadcrumb {
     .breadcrumb-item .breadcrumb {
@@ -20,8 +22,18 @@
     }
 
     .breadcrumb-item-3:first-of-type {
+      // This is if the series is a parent of this item.
       &::before {
-        content: escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='20' height='15'><path fill-rule='evenodd' d='M1.5 1.5A.5.5 0 0 0 1 2v4.8a2.5 2.5 0 0 0 2.5 2.5h9.793l-3.347 3.346a.5.5 0 0 0 .708.708l4.2-4.2a.5.5 0 0 0 0-.708l-4-4a.5.5 0 0 0-.708.708L13.293 8.3H3.5A1.5 1.5 0 0 1 2 6.8V2a.5.5 0 0 0-.5-.5z'></path></svg>"));
+        content: escape-svg(url($bent-arrow));
+      }
+    }
+  }
+
+  .breadcrumb-item-4 {
+    &:first-child > .breadcrumb-text:first-child {
+      // This is if we're on a series (no svg node like on a collection). We still want the bent arrow to show.
+      &::before {
+        content: escape-svg(url($bent-arrow));
       }
     }
   }

--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -167,14 +167,6 @@ article.document {
   padding-right: 0 !important;
 }
 
-.breadcrumb .media .col, h1.media .col {
-  flex-basis: auto;
-}
-
-.breadcrumb .media svg, h1.media svg {
-  fill: $gray-600;
-}
-
 .breadcrumb-links a {
   border-bottom: 1px dashed $gray-600;
   color: $body-color;

--- a/app/assets/stylesheets/arclight/modules/show_collection.scss
+++ b/app/assets/stylesheets/arclight/modules/show_collection.scss
@@ -20,9 +20,6 @@
   fill: $green;
 }
 
-p.media .col {
-  flex: auto;
-}
 // Access tab
 #access {
   dl dd {
@@ -49,9 +46,5 @@ p.media .col {
 }
 
 .al-digital-object.breadcrumb-item {
-  margin-bottom: ($spacer * 0.5);
-}
-
-p.media.breadcrumb-item {
   margin-bottom: ($spacer * 0.5);
 }

--- a/app/components/arclight/breadcrumbs_hierarchy_component.html.erb
+++ b/app/components/arclight/breadcrumbs_hierarchy_component.html.erb
@@ -2,30 +2,31 @@
   <li class="breadcrumb-home-link">
     <%= link_to t('arclight.routes.home'), root_path %>
   </li>
-  <li class="media breadcrumb-item breadcrumb-item-1">
+  <li class="breadcrumb-item breadcrumb-item-1">
     <span aria-hidden="true"><%= blacklight_icon :repository, classes: 'al-repository-content-icon' %></span>
-    <span class="col"><%= repository %></span>
+    <span class="breadcrumb-text"><%= repository %></span>
     <ol class="breadcrumb">
       <% if collection %>
-        <li class="media breadcrumb-item breadcrumb-item-2">
+        <li class="breadcrumb-item breadcrumb-item-2">
           <span aria-hidden="true"><%= blacklight_icon :collection, classes: 'al-collection-content-icon' %></span>
-          <span class="col"><%= link_to collection.label, solr_document_path(collection.global_id) %></span>
+          <span class="breadcrumb-text"><%= link_to collection.label, solr_document_path(collection.global_id) %></span>
 
           <ol class="breadcrumb">
             <% parents_under_collection.each do |parent| %>
-              <li class="breadcrumb-item breadcrumb-item-3 media">
-                <span class="col"><%= link_to parent.label, solr_document_path(parent.global_id) %></span>
+              <li class="breadcrumb-item breadcrumb-item-3">
+                <span class="breadcrumb-text"><%= link_to parent.label, solr_document_path(parent.global_id) %></span>
               </li>
             <% end %>
 
-            <li class="breadcrumb-item breadcrumb-item-4 media">
-             <span class="col"><%= @presenter.heading %></span>
+            <li class="breadcrumb-item breadcrumb-item-4">
+             <span class="breadcrumb-text"><%= @presenter.heading %></span>
             </li>
           </ol>
         </li>
       <% else # this is a collection %>
-        <li class="breadcrumb-item breadcrumb-item-4 media">
-          <span class="col"><%= @presenter.heading %></span>
+        <li class="breadcrumb-item breadcrumb-item-4">
+          <span aria-hidden="true"><%= blacklight_icon :collection, classes: 'al-collection-content-icon' %></span>
+          <span class="breadcrumb-text"><%= @presenter.heading %></span>
         </li>
       <% end %>
     </ol>


### PR DESCRIPTION
when on the page for a series or collection page.

Fixes #1238
<img width="898" alt="Screenshot 2022-11-01 at 10 15 59 AM" src="https://user-images.githubusercontent.com/92044/199268454-08119f6d-4231-4131-bfc6-1d01a9282c18.png">
<img width="546" alt="Screenshot 2022-11-01 at 10 15 50 AM" src="https://user-images.githubusercontent.com/92044/199268457-1f4de3df-42fb-4aa2-85fb-ba121e689a3f.png">
<img width="538" alt="Screenshot 2022-11-01 at 10 15 43 AM" src="https://user-images.githubusercontent.com/92044/199268459-e577a3c0-2a2d-4720-a300-caa3bc8fd01d.png">
