### PR TITLE
Rename configuration fields to omit 'tab'

### DIFF
--- a/app/components/arclight/access_component.rb
+++ b/app/components/arclight/access_component.rb
@@ -15,9 +15,11 @@ module Arclight
 
     # @return Array<Symbol> a list of metadata section names
     def section_names
-      return Array(show_config.context_access_tab_items) if collection?
+      return Array(collection_access_items) if collection?
 
-      Array(show_config.component_access_tab_items)
+      Array(component_access_items)
     end
+
+    delegate :collection_access_items, :component_access_items, to: :show_config
   end
 end

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -85,7 +85,7 @@ class CatalogController < ApplicationController
       access_field
     ]
 
-    config.show.context_access_tab_items = %i[
+    config.show.collection_access_items = %i[
       terms_field
       cite_field
       in_person_field
@@ -97,7 +97,7 @@ class CatalogController < ApplicationController
       component_indexed_terms_field
     ]
 
-    config.show.component_access_tab_items = %i[
+    config.show.component_access_items = %i[
       component_terms_field
       cite_field
       in_person_field


### PR DESCRIPTION
We no longer have tabs in the UI, so having tab in the configuration is confusing