### PR TITLE
Make the show icon on the search results page a results_document_tool

### DIFF
--- a/app/components/arclight/online_status_indicator_component.rb
+++ b/app/components/arclight/online_status_indicator_component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Arclight
+  # Render an oembed viewer for a document
+  class OnlineStatusIndicatorComponent < Blacklight::Component
+    def initialize(document:, **)
+      @document = document
+      super
+    end
+
+    def render?
+      @document.online_content?
+    end
+
+    def call
+      tag.span blacklight_icon(:online), class: 'al-online-content-icon'
+    end
+  end
+end

--- a/app/components/arclight/search_result_component.html.erb
+++ b/app/components/arclight/search_result_component.html.erb
@@ -28,8 +28,6 @@
         <% end if document.containers.present? %>
 
         <div class="d-inline-flex">
-          <%= tag.span blacklight_icon(:online), class: 'al-online-content-icon' if document.online_content? %>
-
           <%= helpers.render_index_doc_actions document, wrapping_class: 'd-inline-flex justify-content-end' %>
         </div>
       </div>

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -46,6 +46,7 @@ class CatalogController < ApplicationController
 
 
     config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
+    config.add_results_document_tool(:online, component: Arclight::OnlineStatusIndicatorComponent)
 
     config.add_results_collection_tool(:group_toggle)
     config.add_results_collection_tool(:sort_widget)


### PR DESCRIPTION
This allows it to be configurable in the CatalogController, so you could remove it if you don't want it.