### PR TITLE
Style bookmarks on the search results page

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -103,23 +103,20 @@
   }
 }
 
-.bookmark-toggle .toggle-bookmark {
-  display: inline;
-  margin-bottom: 0;
-  white-space: nowrap;
-}
-
 .bookmark-toggle {
-  display: inline;
-}
+  @extend .card;
+  @extend .bg-light;
+  @extend .p-2;
 
-.show-document {
-  .bookmark-toggle {
-    @extend .card;
-    @extend .bg-light;
-    @extend .p-2;
+  display: inline;
+
+  .toggle-bookmark {
+    display: inline;
+    margin-bottom: 0;
+    white-space: nowrap;
   }
 }
+
 
 .al-hierarchy-side-content {
   .al-request-form {

--- a/app/components/arclight/search_result_component.html.erb
+++ b/app/components/arclight/search_result_component.html.erb
@@ -30,7 +30,7 @@
         <div class="d-inline-flex">
           <%= tag.span blacklight_icon(:online), class: 'al-online-content-icon' if document.online_content? %>
 
-          <%= helpers.render_index_doc_actions document, wrapping_class: 'd-inline-flex justify-content-end' %>
+          <%= helpers.render_index_doc_actions document, wrapping_class: 'justify-content-end' %>
         </div>
       </div>
 


### PR DESCRIPTION
The same way they are styled on the show page.


Before:
<img width="1001" alt="Screenshot 2022-11-04 at 4 49 52 PM" src="https://user-images.githubusercontent.com/92044/200080343-61c45058-d25e-49e0-b3d4-aedfa2290490.png">

After:
<img width="989" alt="Screenshot 2022-11-04 at 4 50 33 PM" src="https://user-images.githubusercontent.com/92044/200080345-3fcbac70-5c88-464b-a624-1c3e27df197b.png">
