### PR TITLE
Reduce margin on Request button

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -133,12 +133,7 @@
     font-weight: 600;
     line-height: 1;
   }
-    @media (min-width: 1200px) {
-      margin-right: ($spacer * 0.5);
-    }
-
 }
-
 
 dl dd {
   overflow-wrap: break-word;

--- a/app/views/arclight/_requests.html.erb
+++ b/app/views/arclight/_requests.html.erb
@@ -1,5 +1,5 @@
 <% if document.requestable? %>
-  <div class='mr-4 me-4 al-request flex-md-fill'>
+  <div class='mr-2 me-2 al-request flex-md-fill'>
     <% document.repository_config.available_request_types.each do |request_type| %>
       <%= render partial: "arclight/requests/#{request_type}", locals: { document: document } %>
     <% end %>


### PR DESCRIPTION
I think we can get away with less margin between the Request button and the bookmark element, especially since we want to reduce the chances of the title wrapping as much as possible.

This also removes a related media query because with the new context, the Request button doesn't really need adjusting based on viewport width.

## Before
<img width="697" alt="Screen Shot 2022-11-07 at 2 43 10 PM" src="https://user-images.githubusercontent.com/101482/200425013-78d07e91-c227-4cea-8155-ba75d65a26c8.png">


## After
<img width="697" alt="Screen Shot 2022-11-07 at 2 58 35 PM" src="https://user-images.githubusercontent.com/101482/200424998-27f482cc-699f-4be4-8047-fdacb1bb0939.png">
