### PR TITLE
Make Online content box more responsive

### DIFF
--- a/app/components/arclight/online_content_filter_component.html.erb
+++ b/app/components/arclight/online_content_filter_component.html.erb
@@ -1,10 +1,10 @@
 <div class="online-contents">
   <div class="alert alert-success d-flex align-items-center">
-    <div>
-      <span class="media-body al-online-content-icon" aria-hidden="true"><%= helpers.blacklight_icon :online %></span>
-      <h2 class="d-inline"><%= t('arclight.views.show.online_content.title') %></h2>
+    <div class="d-flex">
+      <span class="media-body al-online-content-icon mr-2 me-2" aria-hidden="true"><%= helpers.blacklight_icon :online %></span>
+      <h2 class="d-none d-lg-inline"><%= t('arclight.views.show.online_content.title') %></h2>
     </div>
-    <div class="ml-3 ms-3">
+    <div class="ml-3 ms-3 ml-xl-5 ms-xl-5">
       <div><%= t('arclight.views.show.online_content.description') %></div>
       <%= link_to t('arclight.views.show.online_content.link_text'), helpers.search_action_path(f: { collection_sim: [collection_name], has_online_content_ssim: ['online'] }) %>
     </div>

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -70,7 +70,7 @@ en:
         has_content: Collection contents
         online_content:
           description: Some materials from this collection are available online.
-          link_text: Show only online content.
+          link_text: Show only online content
           title: Online content
         our_collections: Our Collections
         sections:


### PR DESCRIPTION
The way the "Online content" text wraps below the icon looks a bit clunky: 

<img width="651" alt="Screen Shot 2022-11-07 at 4 31 54 PM" src="https://user-images.githubusercontent.com/101482/200439317-43270178-9439-4b7a-8885-3319de532c02.png">

And on wider viewports the info text is pretty tight to the "Online content" text even though there is empty space in the box:

<img width="873" alt="Screen Shot 2022-11-07 at 4 47 22 PM" src="https://user-images.githubusercontent.com/101482/200439551-b39a4efa-fc0e-4541-aace-19d7368e8a3c.png">


This PR improves the text wrapping, hides the text on smaller viewports, and adds some margin on wider viewports.

## After
<img width="487" alt="Screen Shot 2022-11-07 at 4 42 40 PM" src="https://user-images.githubusercontent.com/101482/200439637-cc1ae009-48d7-415f-b97a-5df2f4c50735.png">

---

<img width="633" alt="Screen Shot 2022-11-07 at 4 42 16 PM" src="https://user-images.githubusercontent.com/101482/200439634-3fc0bd86-2906-4270-b404-da7ab71b3ac2.png">

---

<img width="773" alt="Screen Shot 2022-11-07 at 4 41 19 PM" src="https://user-images.githubusercontent.com/101482/200439631-66bbbec6-f127-4338-9a6e-6fffa6fbd743.png">

---

<img width="883" alt="Screen Shot 2022-11-07 at 4 41 45 PM" src="https://user-images.githubusercontent.com/101482/200439632-7513b446-b0ee-4f54-a3a4-43cae9f23825.png">



