### PR TITLE
Align the Arclight componets with the blacklight components

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -59,12 +59,6 @@ article.document {
   }
 }
 
-.documents-compact {
-  h3 {
-    font-size: $h5-font-size;
-  }
-}
-
 .al-grouped-results {
   .breadcrumb-links {
     font-size: $font-size-sm;
@@ -119,15 +113,6 @@ article.document {
   }
 }
 
-.documents-compact {
-  .document {
-    .breadcrumb-links,
-    .al-repository-footer {
-      font-size: $font-size-sm;
-    }
-  }
-}
-
 .al-data-range-histogram {
   margin-bottom: $spacer;
 }
@@ -141,22 +126,34 @@ article.document {
 .documents-compact {
   margin-bottom: $spacer;
 
+  h3 {
+    font-size: $h5-font-size;
+  }
+
   .document {
     border-bottom: $default-border-styling;
+    display: flex;
     padding: $spacer 0;
 
     &:first-child {
       padding-top: 0;
+    }
+    .breadcrumb-links,
+    .al-repository-footer {
+      font-size: $font-size-sm;
     }
   }
 }
 
 .index-document-functions {
   display: flex;
+  @extend .justify-content-end;
 }
 
 .al-document-container.text-muted {
   color: $gray-600 !important;
+  font-size: 16px;
+  float: right;
 }
 
 .col-no-left-padding {

--- a/app/components/arclight/search_result_component.html.erb
+++ b/app/components/arclight/search_result_component.html.erb
@@ -7,33 +7,14 @@
   itemscope: true,
   itemtype: @document.itemtype,
   class: classes.flatten.join(' ') do %>
-    <div class="col-auto">
+    <div class="px-2">
       <%= icon %>
     </div>
+    <div class="container">
+      <%= render Arclight::SearchResultTitleComponent.new(document: document, compact: compact?) %>
 
-    <div class="col-sm-9 col-no-left-padding d-flex flex-wrap">
-      <div class="documentHeader my-w-75 w-md-100 order-0" data-document-id="<%= document.id %>">
-        <h3 class="index_title document-title-heading">
-          <%= helpers.link_to_document document, counter: @counter %>
-          <%= content_tag('span', class: 'al-document-extent badge') do %>
-            <%= document.extent %>
-          <% end if document.extent && !compact? %>
-        </h3>
-      </div>
-
-      <div class="my-w-25 w-md-100 order-12 order-md-1 d-flex justify-content-end">
-        <%= content_tag('div', class: 'al-document-container col col-no-left-padding text-muted ml-auto') do %>
-          <%= document.containers.join(', ') %>
-        <% end if document.containers.present? %>
-      </div>
-
-      <div class="order-2 mb-2">
+      <div class="row">
         <%= metadata %>
       </div>
-    </div>
-
-
-    <div class="col-sm-2">
-      <%= helpers.render_index_doc_actions document, wrapping_class: 'd-inline-flex justify-content-end' %>
     </div>
 <% end %>

--- a/app/components/arclight/search_result_component.rb
+++ b/app/components/arclight/search_result_component.rb
@@ -7,10 +7,6 @@ module Arclight
   class SearchResultComponent < Blacklight::DocumentComponent
     attr_reader :document
 
-    def classes
-      super + ['row']
-    end
-
     def compact?
       presenter.view_config.key.to_s == 'compact'
     end

--- a/app/components/arclight/search_result_title_component.html.erb
+++ b/app/components/arclight/search_result_title_component.html.erb
@@ -1,0 +1,13 @@
+<header class="documentHeader row" data-document-id="<%= @document.id %>">
+  <h3 class="index_title document-title-heading col">
+    <%= helpers.link_to_document @document, counter: @counter %>
+    <%= tag.span @document.extent, class: 'al-document-extent badge' if @document.extent && !compact? %>
+    <%= tag.span class: 'al-document-container text-muted ml-auto' do %>
+      <%= @document.containers.join(', ') %>
+    <% end if @document.containers.present? %>
+  </h3>
+
+  <% actions.each do |action| %>
+    <%= action %>
+  <% end %>
+</header>

--- a/app/components/arclight/search_result_title_component.rb
+++ b/app/components/arclight/search_result_title_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Arclight
+  # Render a document title for a search result
+  class SearchResultTitleComponent < Blacklight::DocumentTitleComponent
+    def initialize(compact:, **args)
+      @compact = compact
+      super(**args)
+    end
+
+    def compact?
+      @compact
+    end
+  end
+end


### PR DESCRIPTION
This makes the search results match up more directly with the Blacklight components so that it is easier to understand how the two gems relate to each other.