### PR TITLE
Provide a fallback for the logo link

### DIFF
--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,7 +1,7 @@
 <header>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark topbar" aria-label="utilities" role="navigation">
     <div class="<%= container_classes %>">
-      <%= link_to application_name, blacklight_config.logo_link, class: "navbar-brand mb-0 navbar-logo" %>
+      <%= link_to application_name, blacklight_config.logo_link || Rails.application.routes.url_helpers.root_path, class: "navbar-brand mb-0 navbar-logo" %>
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-bs-toggle='collapse' data-target="#user-util-collapse" data-bs-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>


### PR DESCRIPTION
Without this, we can get some pretty weird routing errors.