### PR TITLE
Make breadcrumbs just another index field

### DIFF
--- a/app/components/arclight/index_metadata_field_component.rb
+++ b/app/components/arclight/index_metadata_field_component.rb
@@ -9,6 +9,10 @@ module Arclight
       @classes = classes + ["al-document-#{@field.key.dasherize}"]
     end
 
+    def render?
+      helpers.document_index_view_type != :compact || @field.field_config.compact
+    end
+
     def truncate?
       !!@field.field_config.truncate
     end

--- a/app/components/arclight/search_result_breadcrumbs_component.rb
+++ b/app/components/arclight/search_result_breadcrumbs_component.rb
@@ -2,19 +2,18 @@
 
 module Arclight
   # Render the breadcrumbs for a search result document
-  class SearchResultBreadcrumbsComponent < Blacklight::Component
-    attr_reader :document
+  class SearchResultBreadcrumbsComponent < Blacklight::MetadataFieldComponent
+    delegate :document, to: :@field
 
-    def initialize(document:, count:)
-      @document = document
-      @count = count
+    def initialize(field:, **kwargs)
+      @field = field
       super
     end
 
     def breadcrumbs
       offset = grouped? ? 2 : 0
 
-      Arclight::BreadcrumbComponent.new(document: document, count: @count, offset: offset)
+      Arclight::BreadcrumbComponent.new(document: document, count: breadcrumb_count, offset: offset)
     end
 
     def rendered_breadcrumbs
@@ -25,6 +24,14 @@ module Arclight
       rendered_breadcrumbs.present?
     end
 
+    def breadcrumb_count
+      @field.field_config.compact&.dig(:count) if compact?
+    end
+
     delegate :grouped?, to: :helpers
+
+    def compact?
+      helpers.document_index_view_type == :compact
+    end
   end
 end

--- a/app/components/arclight/search_result_component.html.erb
+++ b/app/components/arclight/search_result_component.html.erb
@@ -28,8 +28,7 @@
       </div>
 
       <div class="order-2 mb-2">
-        <%= render Arclight::IndexMetadataFieldComponent.with_collection(@presenter&.field_presenters.select { |field| !compact? || field.field_config.compact }) %>
-        <%= render Arclight::SearchResultBreadcrumbsComponent.new(document: document, count: compact? ? 2 : nil) %>
+        <%= metadata %>
       </div>
     </div>
 

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -164,9 +164,10 @@ class CatalogController < ApplicationController
       words_connector: '<br/>',
       two_words_connector: '<br/>',
       last_word_connector: '<br/>'
-    }, compact: true
-    config.add_index_field 'creator', accessor: true
-    config.add_index_field 'abstract_or_scope', accessor: true, truncate: true, repository_context: true, helper_method: :render_html_tags
+    }, compact: true, component: Arclight::IndexMetadataFieldComponent
+    config.add_index_field 'creator', accessor: true, component: Arclight::IndexMetadataFieldComponent
+    config.add_index_field 'abstract_or_scope', accessor: true, truncate: true, repository_context: true, helper_method: :render_html_tags, component: Arclight::IndexMetadataFieldComponent
+    config.add_index_field 'breadcrumbs', accessor: :itself, component: Arclight::SearchResultBreadcrumbsComponent, compact: { count: 2 }
 
     config.add_facet_field 'has_online_content_ssim', label: 'Access', query: {
       online: { label: 'Online access', fq: 'has_online_content_ssim:true' }


### PR DESCRIPTION
This should allow downstream applications to customize (or remove: https://github.com/sul-dlss/vt-arclight/issues/161) these breadcrumbs.