### PR TITLE
Add left padding to main content area

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -114,6 +114,8 @@
 }
 
 .show-document {
+  @extend .ps-lg-4;
+
   .bookmark-toggle {
     @extend .card;
     @extend .bg-light;


### PR DESCRIPTION
The main content area and the sidebar currently feel a bit tight; some additional whitespace between them will help visually separate them and make the UI feel a bit less busy or cramped.

<img width="697" alt="Screen Shot 2022-11-08 at 1 49 01 PM" src="https://user-images.githubusercontent.com/101482/200673944-a4d36b78-4626-4140-af32-79a1d11c334c.png">


This PR adds some additional space between the sidebar and the start of the main content area, at `lg` viewports and wider. Smaller viewports will collapse the sidebar, giving the main content area full-width, so this adjustment isn't needed there.

## After
<img width="697" alt="Screen Shot 2022-11-08 at 1 54 52 PM" src="https://user-images.githubusercontent.com/101482/200674234-f4d35aea-ca9c-4c65-9cff-c380cd341773.png">
