### PR TITLE
Adjust layout of collection overview nav items

### DIFF
--- a/app/components/arclight/collection_sidebar_component.html.erb
+++ b/app/components/arclight/collection_sidebar_component.html.erb
@@ -6,7 +6,7 @@
       <li class='nav-item'>
         <%= link_to section_label(section),
           document_section_path(section),
-          class: 'nav-link pl-0',
+          class: 'nav-link pl-0 ps-0 py-1',
           data: { turbolinks: 'false' }
         %>
       </li>


### PR DESCRIPTION
The collection overview nav items would look better left-aligned and with a bit less vertical space separating them.

## Before
<img width="339" alt="Screen Shot 2022-11-08 at 2 08 13 PM" src="https://user-images.githubusercontent.com/101482/200677025-27763f78-f2a6-4645-b750-05fc3cc7b188.png">

## After
<img width="339" alt="Screen Shot 2022-11-08 at 2 12 52 PM" src="https://user-images.githubusercontent.com/101482/200677062-88a83a78-d29d-436d-89eb-a432017deb98.png">
