### PR TITLE
Update name facet field name

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -167,7 +167,7 @@
        <str name="facet.field">level_sim</str>
        <str name="facet.field">creator_sim</str>
        <str name="facet.field">date_range_sim</str>
-       <str name="facet.field">names_sim</str>
+       <str name="facet.field">names_ssim</str>
        <str name="facet.field">geogname_sim</str>
        <str name="facet.field">access_subjects_sim</str>
        <str name="facet.field">repository_sim</str>


### PR DESCRIPTION
It looks like the field name must have changed when we switched to traject:

c266615

Replaces #1295