### PR TITLE
Allow repository fields to be specified by what is in the yaml file

### DIFF
--- a/lib/arclight/repository.rb
+++ b/lib/arclight/repository.rb
@@ -1,29 +1,45 @@
 # frozen_string_literal: true
 
-require 'ostruct'
 require 'active_model'
+require 'active_support'
+require 'active_support/core_ext/hash/indifferent_access'
 
 module Arclight
-  #
-  # Static information about a given repository identified by a unique `slug`
+  # Static information about a given repository identified by a unique `slug`.
+  # These data are loaded from config/repositories.yml
   class Repository
     include ActiveModel::Model
-
-    attr_accessor :slug, :name, :description, :visit_note, :contact_html, :location_html, :thumbnail_url, :request_types, :collection_count
+    DEFAULTS = {
+      request_types: {},
+      contact_html: '',
+      location_html: '',
+      visit_note: nil
+    }.freeze
 
     def initialize(attributes = {})
-      super
+      @attributes = DEFAULTS.merge(attributes).with_indifferent_access
+    end
 
-      @request_types ||= {}
+    attr_reader :attributes
+    attr_accessor :collection_count
+
+    def method_missing(field, *args, &block)
+      return attributes[field] if attributes.include?(field)
+
+      super
+    end
+
+    def respond_to_missing?(field, *args)
+      attributes.include?(field) || super
     end
 
     # rubocop:disable Rails/OutputSafety
     def contact
-      contact_html&.html_safe
+      contact_html.html_safe
     end
 
     def location
-      location_html&.html_safe
+      location_html.html_safe
     end
     # rubocop:enable Rails/OutputSafety
 

--- a/spec/lib/arclight/repository_spec.rb
+++ b/spec/lib/arclight/repository_spec.rb
@@ -118,4 +118,12 @@ RSpec.describe Arclight::Repository do
       end
     end
   end
+
+  describe 'adding custom fields' do
+    subject { instance.curators_note }
+
+    let(:instance) { described_class.new(curators_note: 'hey') }
+
+    it { is_expected.to eq 'hey' }
+  end
 end


### PR DESCRIPTION
This allows us to add new fields to the yaml for the downstream implementations. See https://github.com/sul-dlss/vt-arclight/issues/125