### PR TITLE
Configure settings before loading the config

### DIFF
--- a/lib/arclight/traject/ead2_component_config.rb
+++ b/lib/arclight/traject/ead2_component_config.rb
@@ -278,14 +278,14 @@ to_field 'did_note_ssm', extract_xpath('./did/note')
 to_field 'components' do |record, accumulator, context|
   child_components = record.xpath('c|c01|c02|c03|c04|c05|c06|c07|c08|c09|c10|c11|c12')
   component_indexer = Traject::Indexer::NokogiriIndexer.new.tap do |i|
-    i.load_config_file(context.settings[:component_traject_config])
-  end
+    i.settings do
+      provide :parent, context
+      provide :root, context.settings[:root]
+      provide :counter, context.settings[:counter]
+      provide :component_traject_config, context.settings[:component_traject_config]
+    end
 
-  component_indexer.settings do
-    provide :parent, context
-    provide :root, context.settings[:root]
-    provide :counter, context.settings[:counter]
-    provide :component_traject_config, context.settings[:component_traject_config]
+    i.load_config_file(context.settings[:component_traject_config])
   end
 
   child_components.each do |child_component|

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -248,10 +248,6 @@ to_field 'components' do |record, accumulator, context|
   child_components = record.xpath("/ead/archdesc/dsc/c|#{('/ead/archdesc/dsc/c01'..'/ead/archdesc/dsc/c12').to_a.join('|')}")
   next unless child_components.any?
 
-  component_indexer = Traject::Indexer::NokogiriIndexer.new.tap do |i|
-    i.load_config_file(context.settings[:component_traject_config])
-  end
-
   counter = Class.new do
     def increment
       @counter ||= -1
@@ -259,12 +255,16 @@ to_field 'components' do |record, accumulator, context|
     end
   end.new
 
-  component_indexer.settings do
-    provide :parent, context
-    provide :root, context
-    provide :counter, counter
-    provide :logger, context.settings[:logger]
-    provide :component_traject_config, context.settings[:component_traject_config]
+  component_indexer = Traject::Indexer::NokogiriIndexer.new.tap do |i|
+    i.settings do
+      provide :parent, context
+      provide :root, context
+      provide :counter, counter
+      provide :logger, context.settings[:logger]
+      provide :component_traject_config, context.settings[:component_traject_config]
+    end
+
+    i.load_config_file(context.settings[:component_traject_config])
   end
 
   child_components.each do |child_component|


### PR DESCRIPTION
Traject uses the first value for a setting, so it's picky about ordering.