### PR TITLE
Ensure collection sidebar sections left-align

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -70,6 +70,7 @@
   border-bottom: $border-width solid $border-color;
   margin-bottom: $spacer;
   padding-bottom: $spacer * 1.33;
+  margin-left: $spacer;
 
   &:last-child {
     border-bottom: none;


### PR DESCRIPTION
Currently the collection sidebar has a visual inconsistency in that, because the Collection section is (intentionally) displayed within a box, it is slightly left-indented, while the two other collection sections below it are not. So the left alignment is visibly off:

<img width="405" alt="Screen Shot 2022-11-14 at 5 09 49 PM" src="https://user-images.githubusercontent.com/101482/201795410-b8de8b05-3bf2-4490-b591-c1d86dd8930c.png">

This PR indents the sidebar sections that aren't the Collection section to match its indentation, so they all line up. We lose 1rem of horizontal space in those sections, but I think it's worth it to fix the visual incongruity:

<img width="405" alt="Screen Shot 2022-11-14 at 5 17 37 PM" src="https://user-images.githubusercontent.com/101482/201795554-2c3e62c0-b15f-4cb3-9601-581229cb21aa.png">
