### PR TITLE
Add bit of margin to info button icon

### DIFF
--- a/app/assets/stylesheets/arclight/modules/icons.scss
+++ b/app/assets/stylesheets/arclight/modules/icons.scss
@@ -2,3 +2,7 @@
   height: 1rem;
   width: 1rem;
 }
+
+.bi-info-circle-fill {
+  @extend .me-1
+}


### PR DESCRIPTION
Super minor visual thing but the collection info button's icon feel a little crowded against the button label:

<img width="363" alt="Screen Shot 2022-11-14 at 5 27 31 PM" src="https://user-images.githubusercontent.com/101482/201796856-e493298e-ef2d-449c-ae93-6be7c0dcab42.png">

This PR just gives it a bit of horizontal separation:

<img width="363" alt="Screen Shot 2022-11-14 at 5 29 52 PM" src="https://user-images.githubusercontent.com/101482/201796938-01175e56-2ba5-460d-a231-e879f59abd75.png">
