### PR TITLE
Specify more particularly which icons should be smaller

### DIFF
--- a/app/assets/stylesheets/arclight/modules/icons.scss
+++ b/app/assets/stylesheets/arclight/modules/icons.scss
@@ -1,6 +1,13 @@
-.blacklight-icons svg {
-  height: 1rem;
-  width: 1rem;
+
+.toggle-bookmark, .breadcrumb-item, .document, .al-online-content-icon {
+  .blacklight-icons svg {
+    height: 1rem;
+    width: 1rem;
+  }
+}
+
+.al-online-content-icon .blacklight-icons svg {
+  fill: $online-icon-color;
 }
 
 .btn > .bi:first-child {

--- a/app/assets/stylesheets/arclight/modules/show_collection.scss
+++ b/app/assets/stylesheets/arclight/modules/show_collection.scss
@@ -8,10 +8,6 @@
   float: right;
 }
 
-.al-online-content-icon .blacklight-icons svg {
-  fill: $online-icon-color;
-}
-
 // Access tab
 #access {
   dl dd {


### PR DESCRIPTION
This allows other icons (like the search icon) be the normal size

Fixes #1334