### PR TITLE
Create date_normalizer as a setting in component indexer

### DIFF
--- a/lib/arclight/traject/ead2_component_config.rb
+++ b/lib/arclight/traject/ead2_component_config.rb
@@ -24,6 +24,7 @@ settings do
   # provide 'parent' # the immediate parent component (or collection) indexing context
   # provide 'counter' # a global component counter to provide a global sort order for nested components
   provide 'component_traject_config', __FILE__
+  provide 'date_normalizer', 'Arclight::NormalizedDate'
   provide 'reader_class_name', 'Arclight::Traject::NokogiriNamespacelessReader'
   provide 'logger', Logger.new($stderr)
 end
@@ -96,22 +97,18 @@ to_field 'unitdate_bulk_ssim', extract_xpath('./did/unitdate[@type="bulk"]')
 to_field 'unitdate_inclusive_ssm', extract_xpath('./did/unitdate[@type="inclusive"]')
 to_field 'unitdate_other_ssim', extract_xpath('./did/unitdate[not(@type)]')
 
-to_field 'normalized_title_ssm' do |_record, accumulator, context|
-  dates = Arclight::NormalizedDate.new(
+to_field 'normalized_date_ssm' do |_record, accumulator, context|
+  accumulator << settings['date_normalizer'].constantize.new(
     context.output_hash['unitdate_inclusive_ssm'],
     context.output_hash['unitdate_bulk_ssim'],
     context.output_hash['unitdate_other_ssim']
   ).to_s
-  title = context.output_hash['title_ssm']&.first
-  accumulator << Arclight::NormalizedTitle.new(title, dates).to_s
 end
 
-to_field 'normalized_date_ssm' do |_record, accumulator, context|
-  accumulator << Arclight::NormalizedDate.new(
-    context.output_hash['unitdate_inclusive_ssm'],
-    context.output_hash['unitdate_bulk_ssim'],
-    context.output_hash['unitdate_other_ssim']
-  ).to_s
+to_field 'normalized_title_ssm' do |_record, accumulator, context|
+  title = context.output_hash['title_ssm']&.first
+  date = context.output_hash['normalized_date_ssm']&.first
+  accumulator << Arclight::NormalizedTitle.new(title, date).to_s
 end
 
 to_field 'component_level_isim' do |_record, accumulator|


### PR DESCRIPTION
This will allow us to specify our date formatting in our own class in an individual instance. Then we can set that class to be the `date_normalizer` in the traject config. It still defaults to `Arclight::NormalizedDate`
