### PR TITLE
Update solr schema to play nice with solr atomic update

### DIFF
--- a/app/components/arclight/group_component.rb
+++ b/app/components/arclight/group_component.rb
@@ -17,7 +17,7 @@ module Arclight
     end
 
     def search_within_collection_url
-      search_catalog_path(helpers.search_without_group.merge(f: { collection_sim: [document.collection_name] }))
+      search_catalog_path(helpers.search_without_group.merge(f: { collection_ssim: [document.collection_name] }))
     end
   end
 end

--- a/app/components/arclight/online_content_filter_component.html.erb
+++ b/app/components/arclight/online_content_filter_component.html.erb
@@ -6,7 +6,7 @@
     </div>
     <div class="ml-3 ms-3 ml-xl-5 ms-xl-5">
       <div><%= t('arclight.views.show.online_content.description') %></div>
-      <%= link_to t('arclight.views.show.online_content.link_text'), helpers.search_action_path(f: { collection_sim: [collection_name], has_online_content_ssim: ['online'] }) %>
+      <%= link_to t('arclight.views.show.online_content.link_text'), helpers.search_action_path(f: { collection_ssim: [collection_name], has_online_content_ssim: ['online'] }) %>
     </div>
   </div>
 </div>

--- a/app/components/arclight/search_bar_component.html.erb
+++ b/app/components/arclight/search_bar_component.html.erb
@@ -1,13 +1,13 @@
 <%= render(Blacklight::SearchBarComponent.new(
       **@kwargs,
-      params: @params.merge(f: (@params[:f] || {}).except(:collection_sim)))) do |c| %>
+      params: @params.merge(f: (@params[:f] || {}).except(:collection_ssim)))) do |c| %>
 
   <% c.with_before_input_group do %>
     <div class="input-group within-collection-dropdown">
       <label class="input-group-text" for="within_collection">
         <%= t('arclight.within_collection_dropdown.label_html') %>
       </label>
-      <%= select_tag ('f[collection_sim][]' if collection_name.present?), within_collection_options, id: 'within_collection', class: 'form-select search-field rounded-end' %>
+      <%= select_tag ('f[collection_ssim][]' if collection_name.present?), within_collection_options, id: 'within_collection', class: 'form-select search-field rounded-end' %>
     </div>
   <% end %>
 

--- a/app/components/arclight/search_bar_component.rb
+++ b/app/components/arclight/search_bar_component.rb
@@ -25,7 +25,7 @@ module Arclight
     end
 
     def collection_name
-      @collection_name ||= Array(@params.dig(:f, :collection_sim)).first ||
+      @collection_name ||= Array(@params.dig(:f, :collection_ssim)).first ||
                            helpers.current_context_document&.collection_name
     end
   end

--- a/app/controllers/arclight/repositories_controller.rb
+++ b/app/controllers/arclight/repositories_controller.rb
@@ -12,7 +12,7 @@ module Arclight
       @repository = Arclight::Repository.find_by!(slug: params[:id])
       search_service = Blacklight.repository_class.new(blacklight_config)
       @response = search_service.search(
-        q: "level_sim:Collection repository_sim:\"#{@repository.name}\"",
+        q: "level_ssim:Collection repository_ssim:\"#{@repository.name}\"",
         rows: 100
       )
       @collections = @response.documents
@@ -30,11 +30,11 @@ module Arclight
     def fetch_collection_counts
       search_service = Blacklight.repository_class.new(blacklight_config)
       results = search_service.search(
-        q: 'level_sim:Collection',
-        'facet.field': 'repository_sim',
+        q: 'level_ssim:Collection',
+        'facet.field': 'repository_ssim',
         rows: 0
       )
-      Hash[*results.facet_fields['repository_sim']]
+      Hash[*results.facet_fields['repository_ssim']]
     end
   end
 end

--- a/app/helpers/arclight_helper.rb
+++ b/app/helpers/arclight_helper.rb
@@ -10,8 +10,8 @@ module ArclightHelper
   def repository_collections_path(repository)
     search_action_url(
       f: {
-        repository_sim: [repository.name],
-        level_sim: ['Collection']
+        repository_ssim: [repository.name],
+        level_ssim: ['Collection']
       }
     )
   end
@@ -38,7 +38,7 @@ module ArclightHelper
   end
 
   def collection_active?
-    search_state.filter('level_sim').values == ['Collection']
+    search_state.filter('level_ssim').values == ['Collection']
   end
 
   def collection_active_class
@@ -70,7 +70,7 @@ module ArclightHelper
   #
   # @return [Repository]
   def repository_faceted_on
-    repos = search_state.filter('repository_sim').values
+    repos = search_state.filter('repository_ssim').values
     return unless repos.one?
 
     Arclight::Repository.find_by(name: repos.first)

--- a/app/models/concerns/arclight/catalog.rb
+++ b/app/models/concerns/arclight/catalog.rb
@@ -8,9 +8,9 @@ module Arclight
 
     included do
       before_action only: :index do
-        if (params.dig(:f, :collection_sim) || []).any?(&:blank?)
-          params[:f][:collection_sim].compact_blank!
-          params[:f].delete(:collection_sim) if params[:f][:collection_sim].blank?
+        if (params.dig(:f, :collection_ssim) || []).any?(&:blank?)
+          params[:f][:collection_ssim].compact_blank!
+          params[:f].delete(:collection_ssim) if params[:f][:collection_ssim].blank?
         end
       end
 

--- a/app/models/concerns/arclight/search_behavior.rb
+++ b/app/models/concerns/arclight/search_behavior.rb
@@ -22,7 +22,7 @@ module Arclight
       solr_parameters[:fq] << "_nest_parent_:#{blacklight_params[:id]}"
       solr_parameters[:rows] = blacklight_params[:per_page]&.to_i || blacklight_params[:limit]&.to_i || 999_999_999
       solr_parameters[:start] = blacklight_params[:offset] if blacklight_params[:offset]
-      solr_parameters[:sort] = 'sort_ii asc'
+      solr_parameters[:sort] = 'sort_isi asc'
       solr_parameters[:facet] = false
     end
     # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity

--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -86,7 +86,7 @@ module Arclight
     end
 
     def number_of_children
-      first('child_component_count_isim') || 0
+      first('child_component_count_isi') || 0
     end
 
     def children?

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -16,7 +16,7 @@ crumb :repository do |repository|
 end
 
 crumb :search_results do |search_state|
-  if search_state.filter('level_sim').values == ['Collection']
+  if search_state.filter('level_ssim').values == ['Collection']
     link t('arclight.routes.collections')
   else
     link t('arclight.routes.search_results')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 Arclight::Engine.routes.draw do
-  get 'collections' => 'catalog#index', defaults: { f: { level_sim: ['Collection'] } }, as: :collections
+  get 'collections' => 'catalog#index', defaults: { f: { level_ssim: ['Collection'] } }, as: :collections
   resources :repositories, only: %i[index show], controller: 'arclight/repositories'
 end

--- a/lib/arclight/traject/ead2_component_config.rb
+++ b/lib/arclight/traject/ead2_component_config.rb
@@ -60,6 +60,11 @@ DID_SEARCHABLE_NOTES_FIELDS = %w[
   physloc
 ].freeze
 
+# ==================
+# Component elements
+#
+# NOTE: All fields should be stored in Solr
+# ==================
 to_field 'ref_ssi' do |record, accumulator, _context|
   accumulator << if record.attribute('id').blank?
                    strategy = Arclight::MissingIdStrategy.selected
@@ -89,9 +94,9 @@ to_field 'id' do |_record, accumulator, context|
   ].join
 end
 
-to_field 'title_filing_si', extract_xpath('./did/unittitle'), first_only
+to_field 'title_filing_ssi', extract_xpath('./did/unittitle'), first_only
 to_field 'title_ssm', extract_xpath('./did/unittitle')
-to_field 'title_teim', extract_xpath('./did/unittitle')
+to_field 'title_tesim', extract_xpath('./did/unittitle')
 
 to_field 'unitdate_bulk_ssim', extract_xpath('./did/unitdate[@type="bulk"]')
 to_field 'unitdate_inclusive_ssm', extract_xpath('./did/unitdate[@type="inclusive"]')
@@ -137,7 +142,7 @@ to_field 'parent_unittitles_ssm' do |_rec, accumulator, _context|
   accumulator.concat settings[:parent].output_hash['normalized_title_ssm'] || []
 end
 
-to_field 'parent_unittitles_teim' do |_record, accumulator, context|
+to_field 'parent_unittitles_tesim' do |_record, accumulator, context|
   accumulator.concat context.output_hash['parent_unittitles_ssm']
 end
 
@@ -148,16 +153,16 @@ to_field 'parent_levels_ssm' do |_record, accumulator, _context|
 end
 
 to_field 'unitid_ssm', extract_xpath('./did/unitid')
-to_field 'repository_sim' do |_record, accumulator, _context|
+to_field 'repository_ssim' do |_record, accumulator, _context|
   accumulator << settings[:root].clipboard[:repository]
 end
 
-to_field 'collection_sim' do |_record, accumulator, _context|
+to_field 'collection_ssim' do |_record, accumulator, _context|
   accumulator.concat settings[:root].output_hash['normalized_title_ssm']
 end
 
 to_field 'extent_ssm', extract_xpath('./did/physdesc/extent')
-to_field 'extent_teim', extract_xpath('./did/physdesc/extent')
+to_field 'extent_tesim', extract_xpath('./did/physdesc/extent')
 
 to_field 'creator_ssm', extract_xpath('./did/origination')
 to_field 'creator_ssim', extract_xpath('./did/origination')
@@ -168,7 +173,7 @@ end
 to_field 'has_online_content_ssim', extract_xpath('.//dao') do |_record, accumulator|
   accumulator.replace([accumulator.any?])
 end
-to_field 'child_component_count_isim' do |record, accumulator|
+to_field 'child_component_count_isi' do |record, accumulator|
   accumulator << record.xpath('c|c01|c02|c03|c04|c05|c06|c07|c08|c09|c10|c11|c12').count
 end
 
@@ -182,13 +187,13 @@ to_field 'level_ssm' do |record, accumulator|
   accumulator << Arclight::LevelLabel.new(level, other_level).to_s
 end
 
-to_field 'level_sim' do |_record, accumulator, context|
+to_field 'level_ssim' do |_record, accumulator, context|
   next unless context.output_hash['level_ssm']
 
   accumulator.concat context.output_hash['level_ssm']&.map(&:capitalize)
 end
 
-to_field 'sort_ii' do |_record, accumulator, _context|
+to_field 'sort_isi' do |_record, accumulator, _context|
   accumulator.replace([settings[:counter].increment])
 end
 
@@ -215,7 +220,7 @@ to_field 'digital_objects_ssm', extract_xpath('./dao|./did/dao', to_text: false)
   end
 end
 
-to_field 'date_range_sim', extract_xpath('./did/unitdate/@normal', to_text: false) do |_record, accumulator|
+to_field 'date_range_ssim', extract_xpath('./did/unitdate/@normal', to_text: false) do |_record, accumulator|
   range = Arclight::YearRange.new
   next range.years if accumulator.blank?
 
@@ -226,10 +231,10 @@ end
 
 NAME_ELEMENTS.map do |selector|
   to_field 'names_ssim', extract_xpath("./controlaccess/#{selector}"), unique
-  to_field "#{selector}_ssm", extract_xpath(".//#{selector}")
+  to_field "#{selector}_ssim", extract_xpath(".//#{selector}")
 end
 
-to_field 'geogname_sim', extract_xpath('./controlaccess/geogname')
+to_field 'geogname_ssim', extract_xpath('./controlaccess/geogname')
 to_field 'geogname_ssm', extract_xpath('./controlaccess/geogname')
 to_field 'places_ssim', extract_xpath('./controlaccess/geogname')
 
@@ -250,7 +255,7 @@ to_field 'acqinfo_ssim', extract_xpath('/ead/archdesc/descgrp/acqinfo/*[local-na
 to_field 'acqinfo_ssim', extract_xpath('./acqinfo/*[local-name()!="head"]')
 to_field 'acqinfo_ssim', extract_xpath('./descgrp/acqinfo/*[local-name()!="head"]')
 
-to_field 'language_ssm', extract_xpath('./did/langmaterial')
+to_field 'language_ssim', extract_xpath('./did/langmaterial')
 to_field 'containers_ssim' do |record, accumulator|
   record.xpath('./did/container').each do |node|
     accumulator << [node.attribute('type'), node.text].join(' ').strip
@@ -260,7 +265,7 @@ end
 SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_ssm", extract_xpath("./#{selector}/*[local-name()!='head']", to_text: false)
   to_field "#{selector}_heading_ssm", extract_xpath("./#{selector}/head")
-  to_field "#{selector}_teim", extract_xpath("./#{selector}/*[local-name()!='head']")
+  to_field "#{selector}_tesim", extract_xpath("./#{selector}/*[local-name()!='head']")
 end
 DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_ssm", extract_xpath("./did/#{selector}", to_text: false)

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -68,12 +68,14 @@ end
 
 # ==================
 # Top level document
+#
+# NOTE: All fields should be stored in Solr
 # ==================
 
 to_field 'id', extract_xpath('/ead/eadheader/eadid'), strip, gsub('.', '-')
-to_field 'title_filing_si', extract_xpath('/ead/eadheader/filedesc/titlestmt/titleproper[@type="filing"]')
+to_field 'title_filing_ssi', extract_xpath('/ead/eadheader/filedesc/titlestmt/titleproper[@type="filing"]')
 to_field 'title_ssm', extract_xpath('/ead/archdesc/did/unittitle')
-to_field 'title_teim', extract_xpath('/ead/archdesc/did/unittitle')
+to_field 'title_tesim', extract_xpath('/ead/archdesc/did/unittitle')
 to_field 'ead_ssi', extract_xpath('/ead/eadheader/eadid')
 
 to_field 'unitdate_ssm', extract_xpath('/ead/archdesc/did/unitdate')
@@ -87,7 +89,7 @@ to_field 'level_ssm' do |_record, accumulator|
 end
 
 # Keep the original top-level archdesc/@level for Level facet in addition to 'Collection'
-to_field 'level_sim' do |record, accumulator|
+to_field 'level_ssim' do |record, accumulator|
   level = record.at_xpath('/ead/archdesc').attribute('level')&.value
   other_level = record.at_xpath('/ead/archdesc').attribute('otherlevel')&.value
 
@@ -96,7 +98,7 @@ to_field 'level_sim' do |record, accumulator|
 end
 
 to_field 'unitid_ssm', extract_xpath('/ead/archdesc/did/unitid')
-to_field 'unitid_teim', extract_xpath('/ead/archdesc/did/unitid')
+to_field 'unitid_tesim', extract_xpath('/ead/archdesc/did/unitid')
 
 to_field 'normalized_title_ssm' do |_record, accumulator, context|
   dates = Arclight::NormalizedDate.new(
@@ -120,7 +122,7 @@ to_field 'collection_title_tesim' do |_record, accumulator, context|
   accumulator.concat context.output_hash.fetch('normalized_title_ssm', [])
 end
 
-to_field 'collection_sim' do |_record, accumulator, context|
+to_field 'collection_ssim' do |_record, accumulator, context|
   accumulator.concat context.output_hash.fetch('normalized_title_ssm', [])
 end
 
@@ -128,39 +130,30 @@ to_field 'repository_ssm' do |_record, accumulator, context|
   accumulator << context.clipboard[:repository]
 end
 
-to_field 'repository_sim' do |_record, accumulator, context|
+to_field 'repository_ssim' do |_record, accumulator, context|
   accumulator << context.clipboard[:repository]
 end
 
 to_field 'geogname_ssm', extract_xpath('/ead/archdesc/controlaccess/geogname')
-to_field 'geogname_sim', extract_xpath('/ead/archdesc/controlaccess/geogname')
+to_field 'geogname_ssim', extract_xpath('/ead/archdesc/controlaccess/geogname')
 
 to_field 'creator_ssm', extract_xpath('/ead/archdesc/did/origination')
-to_field 'creator_sim', extract_xpath('/ead/archdesc/did/origination')
 to_field 'creator_ssim', extract_xpath('/ead/archdesc/did/origination')
 to_field 'creator_sort' do |record, accumulator|
   accumulator << record.xpath('/ead/archdesc/did/origination').map { |c| c.text.strip }.join(', ')
 end
 
-to_field 'creator_persname_ssm', extract_xpath('/ead/archdesc/did/origination/persname')
 to_field 'creator_persname_ssim', extract_xpath('/ead/archdesc/did/origination/persname')
-to_field 'creator_corpname_ssm', extract_xpath('/ead/archdesc/did/origination/corpname')
-to_field 'creator_corpname_sim', extract_xpath('/ead/archdesc/did/origination/corpname')
 to_field 'creator_corpname_ssim', extract_xpath('/ead/archdesc/did/origination/corpname')
-to_field 'creator_famname_ssm', extract_xpath('/ead/archdesc/did/origination/famname')
 to_field 'creator_famname_ssim', extract_xpath('/ead/archdesc/did/origination/famname')
 
-to_field 'persname_sim', extract_xpath('//persname')
-
 to_field 'creators_ssim' do |_record, accumulator, context|
-  accumulator.concat context.output_hash['creator_persname_ssm'] if context.output_hash['creator_persname_ssm']
-  accumulator.concat context.output_hash['creator_corpname_ssm'] if context.output_hash['creator_corpname_ssm']
-  accumulator.concat context.output_hash['creator_famname_ssm'] if context.output_hash['creator_famname_ssm']
+  accumulator.concat context.output_hash['creator_persname_ssim'] if context.output_hash['creator_persname_ssim']
+  accumulator.concat context.output_hash['creator_corpname_ssim'] if context.output_hash['creator_corpname_ssim']
+  accumulator.concat context.output_hash['creator_famname_ssim'] if context.output_hash['creator_famname_ssim']
 end
 
-to_field 'places_sim', extract_xpath('/ead/archdesc/controlaccess/geogname')
 to_field 'places_ssim', extract_xpath('/ead/archdesc/controlaccess/geogname')
-to_field 'places_ssm', extract_xpath('/ead/archdesc/controlaccess/geogname')
 
 to_field 'access_terms_ssm', extract_xpath('/ead/archdesc/userestrict/*[local-name()!="head"]')
 
@@ -193,11 +186,10 @@ to_field 'digital_objects_ssm', extract_xpath('/ead/archdesc/did/dao|/ead/archde
 end
 
 to_field 'extent_ssm', extract_xpath('/ead/archdesc/did/physdesc/extent')
-to_field 'extent_teim', extract_xpath('/ead/archdesc/did/physdesc/extent')
-to_field 'genreform_sim', extract_xpath('/ead/archdesc/controlaccess/genreform')
-to_field 'genreform_ssm', extract_xpath('/ead/archdesc/controlaccess/genreform')
+to_field 'extent_tesim', extract_xpath('/ead/archdesc/did/physdesc/extent')
+to_field 'genreform_ssim', extract_xpath('/ead/archdesc/controlaccess/genreform')
 
-to_field 'date_range_sim', extract_xpath('/ead/archdesc/did/unitdate/@normal', to_text: false) do |_record, accumulator|
+to_field 'date_range_ssim', extract_xpath('/ead/archdesc/did/unitdate/@normal', to_text: false) do |_record, accumulator|
   range = Arclight::YearRange.new
   next range.years if accumulator.blank?
 
@@ -209,7 +201,7 @@ end
 SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_ssm", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']", to_text: false)
   to_field "#{selector}_heading_ssm", extract_xpath("/ead/archdesc/#{selector}/head") unless selector == 'prefercite'
-  to_field "#{selector}_teim", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']")
+  to_field "#{selector}_tesim", extract_xpath("/ead/archdesc/#{selector}/*[local-name()!='head']")
 end
 
 DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
@@ -219,13 +211,10 @@ end
 NAME_ELEMENTS.map do |selector|
   to_field 'names_coll_ssim', extract_xpath("/ead/archdesc/controlaccess/#{selector}")
   to_field 'names_ssim', extract_xpath("//#{selector}"), unique
-  to_field "#{selector}_ssm", extract_xpath("//#{selector}"), unique
+  to_field "#{selector}_ssim", extract_xpath("//#{selector}"), unique
 end
 
-to_field 'corpname_sim', extract_xpath('//corpname')
-
-to_field 'language_sim', extract_xpath('/ead/archdesc/did/langmaterial')
-to_field 'language_ssm', extract_xpath('/ead/archdesc/did/langmaterial')
+to_field 'language_ssim', extract_xpath('/ead/archdesc/did/langmaterial')
 
 to_field 'descrules_ssm', extract_xpath('/ead/eadheader/profiledesc/descrules')
 

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -136,14 +136,14 @@ class CatalogController < ApplicationController
     # :index_range can be an array or range of prefixes that will be used to create the navigation
     #  (note: It is case sensitive when searching values)
 
-    config.add_facet_field 'collection_sim', label: 'Collection', limit: 10
+    config.add_facet_field 'collection_ssim', label: 'Collection', limit: 10
     config.add_facet_field 'creator_ssim', label: 'Creator', limit: 10
     config.add_facet_field 'creators_ssim', label: 'Creator', show: false
-    config.add_facet_field 'date_range_sim', label: 'Date range', range: true
-    config.add_facet_field 'level_sim', label: 'Level', limit: 10
+    config.add_facet_field 'date_range_ssim', label: 'Date range', range: true
+    config.add_facet_field 'level_ssim', label: 'Level', limit: 10
     config.add_facet_field 'names_ssim', label: 'Names', limit: 10
-    config.add_facet_field 'repository_sim', label: 'Repository', limit: 10
-    config.add_facet_field 'geogname_sim', label: 'Place', limit: 10
+    config.add_facet_field 'repository_ssim', label: 'Repository', limit: 10
+    config.add_facet_field 'geogname_ssim', label: 'Place', limit: 10
     config.add_facet_field 'places_ssim', label: 'Places', show: false
     config.add_facet_field 'access_subjects_ssim', label: 'Subject', limit: 10
     config.add_facet_field 'component_level_isim', show: false
@@ -200,7 +200,7 @@ class CatalogController < ApplicationController
     config.add_search_field 'within_collection' do |field|
       field.include_in_simple_select = false
       field.solr_parameters = {
-        fq: '-level_sim:Collection'
+        fq: '-level_ssim:Collection'
       }
     end
 
@@ -271,7 +271,7 @@ class CatalogController < ApplicationController
     config.add_summary_field 'creators_ssim', label: 'Creator', link_to_facet: true
     config.add_summary_field 'abstract_ssm', label: 'Abstract', helper_method: :render_html_tags
     config.add_summary_field 'extent_ssm', label: 'Extent'
-    config.add_summary_field 'language_ssm', label: 'Language'
+    config.add_summary_field 'language_ssim', label: 'Language'
     config.add_summary_field 'prefercite_ssm', label: 'Preferred citation', helper_method: :render_html_tags
 
     # Collection Show Page - Background Section

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -280,9 +280,9 @@
    <field name="id" type="string" indexed="true" stored="true" required="true" />
    <field name="_version_" type="plong" indexed="true" stored="true" multiValued="false" />
    <field name="timestamp" type="pdate" indexed="true" stored="true" default="NOW" multiValued="false"/>
-   <!-- default, catch all search field -->
+   <!-- default, catch all search field, also used for search term highlighting (requires stored="true") -->
    <field name="text" type="text" indexed="true" stored="true" multiValued="true"/>
-   <field name="unitid_identifier_match" type="identifier_match" indexed="true" multiValued="true" />
+   <field name="unitid_identifier_match" type="identifier_match" indexed="true" stored="false" multiValued="true" />
 
    <field name="_root_" type="string" indexed="true" stored="true" docValues="false" />
    <field name="_nest_parent_" type="string" indexed="true" stored="true"/>
@@ -307,6 +307,7 @@
         unknown fields indexed and/or stored by default -->
    <!--dynamicField name="*" type="ignored" multiValued="true" /-->
 
+   <!-- To play nice with atomic updates, only use non-stored fields for copyFields -->
    <dynamicField name="*_tesim" type="text_en"   stored="true"  indexed="true"  multiValued="true"  />
    <dynamicField name="*_teim"  type="text_en"   stored="false" indexed="true"  multiValued="true"  />
    <dynamicField name="*_si"    type="string"    stored="false" indexed="true"  multiValued="false" />
@@ -317,6 +318,7 @@
    <dynamicField name="*_isim"  type="pint"      stored="true"  indexed="true"  multiValued="true"  />
    <dynamicField name="*_is"    type="pint"      stored="true"  indexed="false" multiValued="false" />
    <dynamicField name="*_ii"    type="pint"      stored="false" indexed="true"  multiValued="false" />
+   <dynamicField name="*_isi"   type="pint"      stored="true"  indexed="true"  multiValued="false" />
  </fields>
 
  <!-- Field to use to determine and enforce document uniqueness.
@@ -331,42 +333,42 @@
    <!-- Copy Fields -->
 
    <!-- field-based searches -->
-   <copyField source="normalized_title_ssm" dest="title_tesim"/>
-   <copyField source="places_ssm" dest="place_tesim"/>
-   <copyField source="names_ssim" dest="name_tesim"/>
-   <copyField source="access_subjects_ssim" dest="subject_tesim"/>
+   <copyField source="normalized_title_ssm" dest="normalized_title_teim"/>
+   <copyField source="places_ssim" dest="place_teim"/>
+   <copyField source="names_ssim" dest="name_teim"/>
+   <copyField source="access_subjects_ssim" dest="subject_teim"/>
 
    <!-- The catch all `text` field -->
    <!-- grab the fielded searches -->
    <copyField source="normalized_title_ssm" dest="text" />
-   <copyField source="places_ssm" dest="text" />
+   <copyField source="places_ssim" dest="text" />
    <copyField source="names_ssim" dest="text" />
    <copyField source="access_subjects_ssim" dest="text" />
    <!-- grab the searchable notes -->
-   <copyField source="abstract_teim" dest="text" />
-   <copyField source="accessrestricct_teim" dest="text" />
-   <copyField source="accruals_teim" dest="text" />
-   <copyField source="acqinfo_teim" dest="text" />
-   <copyField source="altformavail_teim" dest="text" />
-   <copyField source="appraisal_teim" dest="text" />
-   <copyField source="arrangement_teim" dest="text" />
-   <copyField source="bibliography_teim" dest="text" />
-   <copyField source="bioghist_teim" dest="text" />
-   <copyField source="custodhist_teim" dest="text" />
-   <copyField source="did_note_teim" dest="text" />
-   <copyField source="fileplan_teim" dest="text" />
-   <copyField source="materialspec_teim" dest="text" />
-   <copyField source="note_teim" dest="text" />
-   <copyField source="odd_teim" dest="text" />
-   <copyField source="originalsloc_teim" dest="text" />
-   <copyField source="physdesc_teim" dest="text" />
-   <copyField source="physloc_teim" dest="text" />
-   <copyField source="phystech_teim" dest="text" />
-   <copyField source="processinfo_teim" dest="text" />
-   <copyField source="relatedmaterial_teim" dest="text" />
-   <copyField source="scopecontent_teim" dest="text" />
-   <copyField source="separatedmaterial_teim" dest="text" />
-   <copyField source="userestrict_teim" dest="text" />
+   <copyField source="abstract_tesim" dest="text" />
+   <copyField source="accessrestricct_tesim" dest="text" />
+   <copyField source="accruals_tesim" dest="text" />
+   <copyField source="acqinfo_tesim" dest="text" />
+   <copyField source="altformavail_tesim" dest="text" />
+   <copyField source="appraisal_tesim" dest="text" />
+   <copyField source="arrangement_tesim" dest="text" />
+   <copyField source="bibliography_tesim" dest="text" />
+   <copyField source="bioghist_tesim" dest="text" />
+   <copyField source="custodhist_tesim" dest="text" />
+   <copyField source="did_note_tesim" dest="text" />
+   <copyField source="fileplan_tesim" dest="text" />
+   <copyField source="materialspec_tesim" dest="text" />
+   <copyField source="note_tesim" dest="text" />
+   <copyField source="odd_tesim" dest="text" />
+   <copyField source="originalsloc_tesim" dest="text" />
+   <copyField source="physdesc_tesim" dest="text" />
+   <copyField source="physloc_tesim" dest="text" />
+   <copyField source="phystech_tesim" dest="text" />
+   <copyField source="processinfo_tesim" dest="text" />
+   <copyField source="relatedmaterial_tesim" dest="text" />
+   <copyField source="scopecontent_tesim" dest="text" />
+   <copyField source="separatedmaterial_tesim" dest="text" />
+   <copyField source="userestrict_tesim" dest="text" />
    <!-- grab structured data that's important -->
    <copyField source="unitid_ssm" dest="text" />
    <copyField source="unitid_ssm" dest="unitid_identifier_match" />
@@ -382,9 +384,9 @@
 
    <!-- for suggestions -->
    <copyField source="normalized_title_ssm" dest="suggest"/>
-   <copyField source="collection_sim" dest="suggest"/>
+   <copyField source="collection_ssim" dest="suggest"/>
    <copyField source="names_ssim" dest="suggest"/>
-   <copyField source="repository_sim" dest="suggest"/>
+   <copyField source="repository_ssim" dest="suggest"/>
    <copyField source="places_ssim" dest="suggest"/>
    <copyField source="access_subjects_ssim" dest="suggest"/>
 

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -88,45 +88,49 @@
        <str name="qf">
          collection_title_tesim^150
          title_tesim^100
-         name_tesim^10
-         place_tesim^10
+         normalized_title_teim^100
+         name_teim^10
+         place_teim^10
          unitid_identifier_match^5
-         subject_tesim^2
+         subject_teim^2
          text
        </str>
        <str name="pf">
          collection_title_tesim^150
          title_tesim^100
-         name_tesim^10
-         place_tesim^10
+         normalized_title_teim^100
+         name_teim^10
+         place_teim^10
          unitid_identifier_match^5
-         subject_tesim^2
+         subject_teim^2
          text
        </str>
 
        <str name="qf_name">
-         name_tesim
+         name_teim
        </str>
        <str name="pf_name">
-         name_tesim
+         name_teim
        </str>
        <str name="qf_place">
-         place_tesim
+         place_teim
        </str>
        <str name="pf_place">
-         place_tesim
+         place_teim
        </str>
        <str name="qf_subject">
-         subject_tesim
+         subject_teim
        </str>
        <str name="pf_subject">
-         subject_tesim
+         subject_teim
        </str>
        <str name="qf_title">
          title_tesim
+         normalized_title_teim
        </str>
        <str name="pf_title">
          title_tesim
+         normalized_title_teim
        </str>
 
        <int name="ps">3</int>
@@ -137,13 +141,13 @@
          score,
          abstract_ssm,
          accessrestrict_ssm,
-         child_component_count_isim,
+         child_component_count_isi,
          containers_ssim,
          creator_ssm,
          extent_ssm,
          geogname_ssm,
          has_online_content_ssim,
-         language_ssm,
+         language_ssim,
          level_ssm,
          repository_ssm,
          scopecontent_ssm,
@@ -164,14 +168,14 @@
 
        <str name="facet">true</str>
        <str name="facet.mincount">1</str>
-       <str name="facet.field">level_sim</str>
-       <str name="facet.field">creator_sim</str>
-       <str name="facet.field">date_range_sim</str>
+       <str name="facet.field">level_ssim</str>
+       <str name="facet.field">creator_ssim</str>
+       <str name="facet.field">date_range_ssim</str>
        <str name="facet.field">names_ssim</str>
-       <str name="facet.field">geogname_sim</str>
-       <str name="facet.field">access_subjects_sim</str>
-       <str name="facet.field">repository_sim</str>
-       <str name="facet.field">collection_sim</str>
+       <str name="facet.field">geogname_ssim</str>
+       <str name="facet.field">access_subjects_ssim</str>
+       <str name="facet.field">repository_ssim</str>
+       <str name="facet.field">collection_ssim</str>
 
        <str name="spellcheck">true</str>
        <str name="spellcheck.dictionary">default</str>

--- a/spec/components/arclight/search_bar_component_spec.rb
+++ b/spec/components/arclight/search_bar_component_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe Arclight::SearchBarComponent, type: :component do
 
   describe 'within collection dropdown' do
     context 'when in a collection context on the search results page' do
-      let(:params) { { f: { collection_sim: ['some collection'] } } }
+      let(:params) { { f: { collection_ssim: ['some collection'] } } }
 
       it 'renders a name attribute on the select (so it will be sent through the form)' do
-        expect(rendered).to have_css('select[name="f[collection_sim][]"]')
+        expect(rendered).to have_css('select[name="f[collection_ssim][]"]')
       end
 
       it 'has the "this collection" option selected' do
@@ -36,7 +36,7 @@ RSpec.describe Arclight::SearchBarComponent, type: :component do
       end
 
       it 'renders a name attribute on the select (so it will be sent through the form)' do
-        expect(rendered).to have_css('select[name="f[collection_sim][]"]')
+        expect(rendered).to have_css('select[name="f[collection_ssim][]"]')
       end
 
       it 'has the "this collection" option selected' do

--- a/spec/features/collection_filtering_spec.rb
+++ b/spec/features/collection_filtering_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe 'Collection filtering' do
   context 'when in a search result filtered by collection' do
     it 'has the a select input with the "this collection" option selected' do
-      visit search_catalog_path(f: { collection_sim: ['Alpha Omega Alpha Archives, 1894-1992'] })
+      visit search_catalog_path(f: { collection_ssim: ['Alpha Omega Alpha Archives, 1894-1992'] })
 
       within 'form.search-query-form' do
         expect(page).to have_select('Search', selected: 'this collection')
@@ -13,7 +13,7 @@ RSpec.describe 'Collection filtering' do
     end
 
     it 'clears the collection filter when "all collections" is selected' do
-      visit search_catalog_path(q: 'File', f: { collection_sim: ['Alpha Omega Alpha Archives, 1894-1992'] })
+      visit search_catalog_path(q: 'File', f: { collection_ssim: ['Alpha Omega Alpha Archives, 1894-1992'] })
 
       expect(page).to have_css('.constraint-value .filter-value', text: 'Alpha Omega Alpha Archives, 1894-1992')
 

--- a/spec/features/fielded_search_results_spec.rb
+++ b/spec/features/fielded_search_results_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Field-based search results' do
     describe '#all_fields' do
       context 'for collections, fielded content is searchable by' do
         it 'title' do
-          visit search_catalog_path q: 'student life', search_field: 'all_fields', f: { level_sim: ['Collection'] }
+          visit search_catalog_path q: 'student life', search_field: 'all_fields', f: { level_ssim: ['Collection'] }
           within('.document-position-1') do
             expect(page).to have_css '.index_title', text: /Stanford University student life photograph album/
           end
@@ -44,7 +44,7 @@ RSpec.describe 'Field-based search results' do
 
       context 'for components, fielded content is searchable by' do
         it 'title' do
-          visit search_catalog_path q: 'a brief account', search_field: 'all_fields', f: { level_sim: ['File'] }
+          visit search_catalog_path q: 'a brief account', search_field: 'all_fields', f: { level_ssim: ['File'] }
           within('.document-position-1') do
             expect(page).to have_css '.index_title', text: /A brief account/
           end

--- a/spec/features/grouped_results_spec.rb
+++ b/spec/features/grouped_results_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Grouped search results' do
     visit search_catalog_path q: 'alpha omega', group: 'true'
     expect(page).to have_css '.al-grouped-more', text: /Top 3 results/
     expect(page).to have_css(
-      '.al-grouped-more a[href*="/catalog?f%5Bcollection_sim%5D%5B%5D=Alpha+Omega+Alpha+Archives%2C+1894-1992"]',
+      '.al-grouped-more a[href*="/catalog?f%5Bcollection_ssim%5D%5B%5D=Alpha+Omega+Alpha+Archives%2C+1894-1992"]',
       text: 'view all 6'
     )
   end

--- a/spec/features/masthead_links_spec.rb
+++ b/spec/features/masthead_links_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Masthead links' do
     end
 
     it 'is active when collection search is activated' do
-      visit search_catalog_path f: { level_sim: ['Collection'] }, search_field: 'all_fields'
+      visit search_catalog_path f: { level_ssim: ['Collection'] }, search_field: 'all_fields'
       within '.al-masthead' do
         expect(page).to have_css 'li.nav-item.active', text: 'Collections'
       end

--- a/spec/features/search_breadcrumb_spec.rb
+++ b/spec/features/search_breadcrumb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Search Breadcrumb' do
     end
 
     it do
-      visit search_catalog_path f: { level_sim: ['Collection'] }, search_field: 'all_fields'
+      visit search_catalog_path f: { level_ssim: ['Collection'] }, search_field: 'all_fields'
       within '.al-search-breadcrumb' do
         expect(page).to have_link 'Home'
         expect(page).to have_content 'Collections'

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Search results' do
     end
 
     it 'renders the online content label when there is online content' do
-      visit search_catalog_path f: { level_sim: ['Collection'] }, search_field: 'all_fields'
+      visit search_catalog_path f: { level_ssim: ['Collection'] }, search_field: 'all_fields'
 
       online_doc = page.all('.document').find do |el|
         el.all(
@@ -75,12 +75,12 @@ RSpec.describe 'Search results' do
       visit search_catalog_path q: '', search_field: 'all_fields'
 
       within('#facets') do
-        within('.blacklight-collection_sim') do
+        within('.blacklight-collection_ssim') do
           expect(page).to have_css('h3 button', text: 'Collection')
           expect(page).to have_css('li .facet-label', text: 'Alpha Omega Alpha Archives, 1894-1992', visible: :hidden)
         end
 
-        within('.blacklight-level_sim') do
+        within('.blacklight-level_ssim') do
           expect(page).to have_css('h3 button', text: 'Level')
           expect(page).to have_css('li .facet-label', text: 'Series', visible: :hidden) # level != "otherlevel"
           expect(page).to have_css('li .facet-label', text: 'Binder', visible: :hidden) # "otherlevel" with alt value
@@ -99,12 +99,12 @@ RSpec.describe 'Search results' do
           expect(page).to have_css('li .facet-label', text: '1118 Badger Vine Special Collections', visible: :hidden)
         end
 
-        within('.blacklight-repository_sim') do
+        within('.blacklight-repository_ssim') do
           expect(page).to have_css('h3 button', text: 'Repository')
           expect(page).to have_css('li .facet-label', text: 'National Library of Medicine. History of Medicine Division', visible: :hidden)
         end
 
-        within('.blacklight-geogname_sim') do
+        within('.blacklight-geogname_ssim') do
           expect(page).to have_css('h3 button', text: 'Place')
           expect(page).to have_css('li .facet-label', text: 'Mindanao Island (Philippines)', visible: :hidden)
           expect(page).to have_css('li .facet-label', text: 'Yosemite National Park (Calif.)', visible: :hidden)
@@ -125,7 +125,7 @@ RSpec.describe 'Search results' do
 
     it 'renders the repository card when faceted on repository' do
       visit search_catalog_path f: {
-        repository_sim: ['National Library of Medicine. History of Medicine Division']
+        repository_ssim: ['National Library of Medicine. History of Medicine Division']
       }, search_field: 'all_fields'
 
       expect(page).to have_css('.al-repository-card')

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -56,7 +56,7 @@ describe 'EAD 2 traject indexing' do
     end
 
     it 'title' do
-      %w[title_ssm title_teim].each do |field|
+      %w[title_ssm title_tesim].each do |field|
         expect(result[field]).to include_ignoring_whitespace 'Stanford University student life photograph album'
       end
       expect(result['normalized_title_ssm']).to include 'Stanford University student life photograph album, circa 1900-1906'
@@ -64,7 +64,7 @@ describe 'EAD 2 traject indexing' do
 
     it 'level' do
       expect(result['level_ssm']).to eq ['collection']
-      expect(result['level_sim']).to eq ['Collection']
+      expect(result['level_ssim']).to eq ['Collection']
     end
 
     it 'dates' do
@@ -74,8 +74,8 @@ describe 'EAD 2 traject indexing' do
       expect(result['unitdate_other_ssim']).to be_nil
     end
 
-    it 'creates date_range_sim' do
-      date_range = result['date_range_sim']
+    it 'creates date_range_ssim' do
+      date_range = result['date_range_ssim']
       expect(date_range).to be_an Array
       expect(date_range.length).to eq 7
       expect(date_range.first).to eq 1900
@@ -83,13 +83,13 @@ describe 'EAD 2 traject indexing' do
     end
 
     it 'repository' do
-      %w[repository_sim repository_ssm].each do |field|
+      %w[repository_ssim repository_ssm].each do |field|
         expect(result[field]).to include 'Stanford University Libraries. Special Collections and University Archives'
       end
     end
 
     it 'geogname' do
-      %w[geogname_sim geogname_ssm].each do |field|
+      %w[geogname_ssim geogname_ssm].each do |field|
         expect(result[field]).to include_ignoring_whitespace 'Yosemite National Park (Calif.)'
       end
     end
@@ -99,7 +99,7 @@ describe 'EAD 2 traject indexing' do
     end
 
     it 'creator' do
-      %w[creator_ssm creator_ssim creator_corpname_ssm creator_corpname_ssim creators_ssim creator_sort].each do |field|
+      %w[creator_ssm creator_ssim creator_corpname_ssim creators_ssim creator_sort].each do |field|
         expect(result[field]).to equal_array_ignoring_whitespace ['Stanford University']
       end
     end
@@ -113,7 +113,7 @@ describe 'EAD 2 traject indexing' do
     end
 
     it 'collection has normalized_title' do
-      %w[collection_sim collection_title_tesim].each do |field|
+      %w[collection_ssim collection_title_tesim].each do |field|
         expect(result[field]).to include_ignoring_whitespace 'Stanford University student life photograph album, circa 1900-1906'
       end
     end
@@ -147,13 +147,13 @@ describe 'EAD 2 traject indexing' do
       end
 
       it 'geogname' do
-        %w[geogname_sim geogname_ssm].each do |field|
+        %w[geogname_ssim geogname_ssm].each do |field|
           expect(all_components.first[field]).to be_nil
         end
       end
 
       it 'collection has normalized title' do
-        expect(first_component['collection_sim']).to include_ignoring_whitespace 'Stanford University student life photograph album, circa 1900-1906'
+        expect(first_component['collection_ssim']).to include_ignoring_whitespace 'Stanford University student life photograph album, circa 1900-1906'
       end
 
       it 'containers' do
@@ -178,9 +178,15 @@ describe 'EAD 2 traject indexing' do
         end
 
         it 'sort' do
-          expect(other_level_component['sort_ii']).to eq([2])
-          expect(level_component['sort_ii']).to eq([32])
+          expect(other_level_component['sort_isi']).to eq([2])
+          expect(level_component['sort_isi']).to eq([32])
         end
+      end
+
+      it 'only indexes into fields that will support future atomic updates' do
+        expect(result.keys).not_to include(/_sim$/)
+        expect(result.keys).not_to include(/_ii$/)
+        expect(result.keys).not_to include(/_teim$/)
       end
     end
   end
@@ -231,7 +237,7 @@ describe 'EAD 2 traject indexing' do
     let(:nested_component) { all_components.find { |c| c['id'] == ['ncaids544-testd0e631'] } }
 
     it 'counts child components' do
-      expect(component_with_descendants['child_component_count_isim']).to eq [9]
+      expect(component_with_descendants['child_component_count_isi']).to eq [9]
     end
 
     it 'correctly gets the component levels' do
@@ -246,7 +252,7 @@ describe 'EAD 2 traject indexing' do
 
     it 'bioghist' do
       expect(result['bioghist_ssm'].first).to match(/Alpha Omega Alpha Honor Medical Society was founded/)
-      expect(result['bioghist_teim'].second).to match(/Hippocratic oath/)
+      expect(result['bioghist_tesim'].second).to match(/Hippocratic oath/)
       expect(result['bioghist_heading_ssm'].first).to match(/^Historical Note/)
     end
 
@@ -301,6 +307,12 @@ describe 'EAD 2 traject indexing' do
         expect(component['scopecontent_ssm']).to include(a_string_matching(/provide important background context./))
         expect(component['scopecontent_ssm']).not_to include(a_string_matching(/correspondence, and a nametag./))
       end
+
+      it 'only indexes into fields that will support future atomic updates' do
+        expect(all_components.flat_map(&:keys)).not_to include(/_sim$/)
+        expect(all_components.flat_map(&:keys)).not_to include(/_ii$/)
+        expect(all_components.flat_map(&:keys)).not_to include(/_teim$/)
+      end
     end
   end
 
@@ -315,7 +327,7 @@ describe 'EAD 2 traject indexing' do
     end
 
     it 'extent at the collection level' do
-      %w[extent_ssm extent_teim].each do |field|
+      %w[extent_ssm extent_tesim].each do |field|
         expect(result[field]).to equal_array_ignoring_whitespace(
           ['15.0 linear feet (36 boxes + oversize folder)']
         )
@@ -324,7 +336,7 @@ describe 'EAD 2 traject indexing' do
 
     it 'extent at the component level' do
       component = all_components.find { |c| c['ref_ssi'] == ['aspace_a951375d104030369a993ff943f61a77'] }
-      %w[extent_ssm extent_teim].each do |field|
+      %w[extent_ssm extent_tesim].each do |field|
         expect(component[field]).to equal_array_ignoring_whitespace(
           ['1.5 Linear Feet']
         )
@@ -417,7 +429,7 @@ describe 'EAD 2 traject indexing' do
 
         it 'parent_unittitles should be displayable and searchable' do
           component = all_components.find { |c| c['id'] == ['aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671'] }
-          %w[parent_unittitles_ssm parent_unittitles_teim].each do |field|
+          %w[parent_unittitles_ssm parent_unittitles_tesim].each do |field|
             expect(component[field]).to contain_exactly(
               'Alpha Omega Alpha Archives, 1894-1992'
             )
@@ -524,8 +536,8 @@ describe 'EAD 2 traject indexing' do
       end
 
       it 'indexes all names at any level in a type-specific name field' do
-        expect(result['persname_ssm']).to include_ignoring_whitespace 'Anfinsen, Christian B.'
-        expect(result['corpname_ssm']).to include_ignoring_whitespace 'Robertson\'s Crab House'
+        expect(result['persname_ssim']).to include_ignoring_whitespace 'Anfinsen, Christian B.'
+        expect(result['corpname_ssim']).to include_ignoring_whitespace 'Robertson\'s Crab House'
       end
     end
 
@@ -538,8 +550,8 @@ describe 'EAD 2 traject indexing' do
 
       it 'indexes names in fields for specific name types, regardless of <controlaccess>' do
         component = all_components.find { |c| c['id'] == ['aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'] }
-        expect(component['corpname_ssm']).to include_ignoring_whitespace 'Robertson\'s Crab House'
-        expect(component['persname_ssm']).to include_ignoring_whitespace 'Anfinsen, Christian B.'
+        expect(component['corpname_ssim']).to include_ignoring_whitespace 'Robertson\'s Crab House'
+        expect(component['persname_ssim']).to include_ignoring_whitespace 'Anfinsen, Christian B.'
       end
     end
   end
@@ -551,8 +563,8 @@ describe 'EAD 2 traject indexing' do
 
     it 'indexes geognames' do
       component = all_components.find { |d| d['id'] == ['aoa271aspace_843e8f9f22bac69872d0802d6fffbb04'] }
-      expect(component).to include 'geogname_sim'
-      expect(component['geogname_sim']).to include('Popes Creek (Md.)')
+      expect(component).to include 'geogname_ssim'
+      expect(component['geogname_ssim']).to include('Popes Creek (Md.)')
 
       expect(component).to include 'geogname_ssm'
       expect(component['geogname_ssm']).to include('Popes Creek (Md.)')
@@ -564,9 +576,9 @@ describe 'EAD 2 traject indexing' do
       Arclight::Engine.root.join('spec', 'fixtures', 'ead', 'nlm', 'alphaomegaalpha.xml')
     end
 
-    it 'creates date_range_sim' do
+    it 'creates date_range_ssim' do
       component = all_components.find { |d| d['id'] == ['aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671'] }
-      date_range = component['date_range_sim']
+      date_range = component['date_range_ssim']
       expect(date_range).to be_an Array
       expect(date_range.length).to eq 75
       expect(date_range.first).to eq 1902
@@ -699,7 +711,7 @@ describe 'EAD 2 traject indexing' do
     end
 
     it 'title' do
-      %w[title_ssm title_teim].each do |field|
+      %w[title_ssm title_tesim].each do |field|
         expect(result[field]).to include_ignoring_whitespace 'Stanford University student life photograph album'
       end
       expect(result['normalized_title_ssm']).to include_ignoring_whitespace 'Stanford University student life photograph album, circa 1900-1906'
@@ -716,11 +728,11 @@ describe 'EAD 2 traject indexing' do
     end
 
     it 'changes EAD level code to human-readable' do
-      expect(result['level_sim']).to include 'Record Group'
+      expect(result['level_ssim']).to include 'Record Group'
     end
 
     it 'retains both original level & Collection for faceting' do
-      expect(result['level_sim']).to eq ['Record Group', 'Collection']
+      expect(result['level_ssim']).to eq ['Record Group', 'Collection']
     end
   end
 end

--- a/spec/helpers/arclight_helper_spec.rb
+++ b/spec/helpers/arclight_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ArclightHelper do
   describe '#collection_active?' do
     context 'with active collection search' do
       let(:params) do
-        { 'f' => { 'level_sim' => ['Collection'] } }
+        { 'f' => { 'level_ssim' => ['Collection'] } }
       end
 
       it do
@@ -121,13 +121,13 @@ RSpec.describe ArclightHelper do
     end
 
     context 'when searching within a repository' do
-      let(:params) { { 'f' => { 'repository_sim' => ['My Repository'] } } }
+      let(:params) { { 'f' => { 'repository_ssim' => ['My Repository'] } } }
 
       it { expect(text).to eq 'Collections : [My Repository]' }
     end
 
     context 'when searching all collections' do
-      let(:params) { { 'f' => { 'level_sim' => ['Collection'] } } }
+      let(:params) { { 'f' => { 'level_ssim' => ['Collection'] } } }
 
       it { expect(text).to eq 'Collections' }
     end

--- a/spec/routing/collections_spec.rb
+++ b/spec/routing/collections_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Vanity collections route' do
   routes { Arclight::Engine.routes }
   it 'routes to collection search' do
     expect(get: '/collections').to route_to(
-      'f' => { 'level_sim' => ['Collection'] },
+      'f' => { 'level_ssim' => ['Collection'] },
       controller: 'catalog',
       action: 'index'
     )


### PR DESCRIPTION
This PR ensures that all document fields coming out of the indexer are stored (so can be appropriately regenerated by Solr), and that copyField destinations are not (so Solr doesn't double up on them)

I tried to collapse indexed fields where they are obviously the same, but there's still some redundancy (e.g. `creator_ssm`, `creator_ssim`, and `creators_ssm` sure seem to be the same 🤷‍♂️) that we might want to clean up in the future.

There's also quite a few indexed fields that seem entirely unused (`title_filing_ssi`, etc).