### PR TITLE
Allow the masthead heading to contain html

### DIFF
--- a/app/components/arclight/masthead_component.rb
+++ b/app/components/arclight/masthead_component.rb
@@ -4,7 +4,7 @@ module Arclight
   # Render the masthead
   class MastheadComponent < Blacklight::Component
     def heading
-      t('arclight.masthead_heading')
+      t('arclight.masthead_heading_html')
     end
   end
 end

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -11,7 +11,7 @@ en:
       total_components: Total components
     hierarchy:
       view_all: View
-    masthead_heading: Archival Collections at Institution
+    masthead_heading_html: Archival Collections at Institution
     repositories: Repositories
     request:
       container: Request


### PR DESCRIPTION
In virtual-tribunals, we found that the text was wrapping at inopportune spots and we want to use a non-breaking space in it. This means we need the html to come through without being escaped.