### PR TITLE
Delegate the blacklight_icon to the helpers

### DIFF
--- a/app/components/arclight/breadcrumbs_hierarchy_component.rb
+++ b/app/components/arclight/breadcrumbs_hierarchy_component.rb
@@ -4,6 +4,8 @@ module Arclight
   # Render the hierarchy for a document
   class BreadcrumbsHierarchyComponent < ViewComponent::Base
     delegate :document, to: :@presenter
+    delegate :blacklight_icon, to: :helpers
+
     def initialize(presenter:)
       super
 

--- a/app/components/arclight/collection_info_component.rb
+++ b/app/components/arclight/collection_info_component.rb
@@ -12,6 +12,7 @@ module Arclight
     attr_reader :collection
 
     delegate :total_component_count, :online_item_count, :last_indexed, :collection_unitid, to: :collection
+    delegate :blacklight_icon, to: :helpers
 
     def info_icon
       icon = <<~SVG

--- a/app/components/arclight/online_status_indicator_component.rb
+++ b/app/components/arclight/online_status_indicator_component.rb
@@ -13,7 +13,7 @@ module Arclight
     end
 
     def call
-      tag.span blacklight_icon(:online), class: 'al-online-content-icon'
+      tag.span helpers.blacklight_icon(:online), class: 'al-online-content-icon'
     end
   end
 end

--- a/app/components/arclight/repository_breadcrumb_component.rb
+++ b/app/components/arclight/repository_breadcrumb_component.rb
@@ -8,6 +8,8 @@ module Arclight
       @document = document
     end
 
+    delegate :blacklight_icon, to: :helpers
+
     def repository_path
       @document.repository_config&.slug
     end

--- a/app/components/arclight/search_result_component.rb
+++ b/app/components/arclight/search_result_component.rb
@@ -12,7 +12,7 @@ module Arclight
     end
 
     def icon
-      blacklight_icon helpers.document_or_parent_icon(@document)
+      helpers.blacklight_icon helpers.document_or_parent_icon(@document)
     end
   end
 end


### PR DESCRIPTION
It's no longer on the view: https://github.com/projectblacklight/blacklight/commit/b839ef7861d662b25e3b5d99e10750d011d1107d