### PR TITLE
Support passing extra params to the oEmbed viewer

### DIFF
--- a/app/assets/javascripts/arclight/oembed_viewer.js
+++ b/app/assets/javascripts/arclight/oembed_viewer.js
@@ -5,27 +5,52 @@ class OembedLoader {
 
   load() {
     const loadedAttr = this.el.getAttribute('loaded')
-    var data = this.el.dataset
-    var resourceUrl = data.arclightOembedUrl
+    const { arclightOembed, arclightOembedUrl, ...extraOembedParams } = this.el.dataset
+    const extraParams = OembedLoader.normalizeParams(extraOembedParams)
+
     if (loadedAttr && loadedAttr === 'loaded') {
       return
     }
 
-    fetch(resourceUrl)
+    fetch(arclightOembedUrl)
       .then((response) => response.text())
       .then((body) => {
-        const oEmbedEndPoint = OembedLoader.findOEmbedEndPoint(body)
+        const oEmbedEndPoint = OembedLoader.findOEmbedEndPoint(body, extraParams)
         if (!oEmbedEndPoint || oEmbedEndPoint.length === 0) {
+          console.warn(`No oEmbed endpoint found in <head> at ${arclightOembedUrl}`)
           return
         }
         this.loadEndPoint(oEmbedEndPoint)
       })
   }
 
-  static findOEmbedEndPoint(body) {
+  // Convert data-arclight-oembed-* attributes to URL parameters for the viewer
+  static normalizeParams(attributes) {
+    return Object.keys(attributes).reduce((acc, attribute) => {
+      // Reverse data attribute name conversion. See:
+      // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset#name_conversion
+      const parameterName = attribute.replace('arclightOembed', '')
+        .replace(/([a-z])([A-Z])/g, '$1-$2')
+        .toLowerCase()
+
+      acc[parameterName] = attributes[attribute]
+      return acc
+    }, {})
+  }
+
+  static findOEmbedEndPoint(body, extraParams = {}) {
+    // Parse out link elements so image assets are not loaded
     const template = document.createElement('template')
-    template.innerHTML = body.match(/<link .*>/g).join('') // Parse out link elements so image assets are not loaded
-    return template.content.querySelector('link[rel="alternate"][type="application/json+oembed"]')?.getAttribute('href')
+    template.innerHTML = body.match(/<link .*>/g).join('')
+
+    // Look for a link element containing the oEmbed endpoint; bail out if none
+    const endpoint = template.content.querySelector('link[rel="alternate"][type="application/json+oembed"]')
+      ?.getAttribute('href')
+    if (!endpoint) return ''
+
+    // Serialize any extra params and append them to the endpoint
+    const qs = new URLSearchParams(extraParams).toString()
+    return `${endpoint}&${qs}`
   }
 
   loadEndPoint(oEmbedEndPoint) {


### PR DESCRIPTION
Closes #1378

Supports https://github.com/sul-dlss/vt-arclight/issues/155

If you add, for example, `data-arclight-oembed-search="hess"` and `data-arclight-oembed-hide_title="true"` to the viewer's template (two parameters supported by sul-embed), you now get:

<img width="860" alt="Screen Shot 2022-12-20 at 11 50 10" src="https://user-images.githubusercontent.com/4924494/208754435-b5706049-f3ee-45ba-b121-e568a9d283ea.png">
