### PR TITLE
Use dt and dd elements inside result metadata container

### DIFF
--- a/app/assets/stylesheets/arclight/modules/search_results.scss
+++ b/app/assets/stylesheets/arclight/modules/search_results.scss
@@ -49,8 +49,8 @@ article.document {
     fill: $online-icon-color;
   }
   div.breadcrumb-links,
-  div.al-document-abstract-or-scope,
-  div.al-document-creator {
+  dd.al-document-abstract-or-scope,
+  dd.al-document-creator {
     margin-top: ($spacer * .5);
   }
 

--- a/app/components/arclight/index_metadata_field_component.html.erb
+++ b/app/components/arclight/index_metadata_field_component.html.erb
@@ -1,6 +1,7 @@
 <div class="row">
+  <%= tag.dt @field.label, class: 'visually-hidden' %>
   <% if truncate? %>
-    <%= tag.div(class: @classes + ['truncator'], data: { controller: 'arclight-truncate' }) do %>
+    <%= tag.dd(class: @classes + ['truncator'], data: { controller: 'arclight-truncate' }) do %>
       <%= tag.div @field.render, class: 'content', data: { arclight_truncate_target: 'content' } %>
       <%= button_tag(type: :button, class: 'btn btn-sm btn-link px-0',
                      data: { action: 'click->arclight-truncate#trigger' },
@@ -11,6 +12,6 @@
       <% end %>
     <% end %>
   <% else %>
-    <%= tag.div @field.render, class: @classes %>
+    <%= tag.dd @field.render, class: @classes %>
   <% end %>
 </div>


### PR DESCRIPTION
We use a dl for search result metadata display, but don't use the
corresponding child elements to mark up the actual metadata
fields and values. This changes the elements and inserts the
labels for metadata fields as visually-hidden dt so that screen
reader users can access them.

Ref https://github.com/sul-dlss/vt-arclight/pull/444
