### PR TITLE
Only apply card styling to bookmark toggle in title container

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -154,7 +154,7 @@
 .show-document {
   @extend .ps-lg-4;
 
-  .bookmark-toggle {
+  .title-container .bookmark-toggle {
     @extend .card;
     @extend .bg-light;
     @extend .p-2;


### PR DESCRIPTION
This ensures that lists of child components are more concise
and readable by removing the card padding/styling. The card style
is used only for the main bookmark toggle in the title/header.

Fixes https://github.com/sul-dlss/vt-arclight/issues/448
