### PR TITLE
Add drop shadow to Collection info dropdown

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -123,6 +123,7 @@
     .dropdown-toggle:after {
       margin-left: 0;
     }
+
     table {
       td {
         text-align: right;

--- a/app/components/arclight/collection_info_component.html.erb
+++ b/app/components/arclight/collection_info_component.html.erb
@@ -4,7 +4,7 @@
     <button class="dropdown-toggle btn btn-secondary btn-sm" type="button" data-bs-toggle="dropdown" aria-expanded="false">
       <%= info_icon %> <%= t('.more_info') %>
     </button>
-    <div class="dropdown-menu p-2" style="min-width: 300px;" >
+    <div class="dropdown-menu shadow-lg p-2" style="min-width: 300px;" >
       <table style="width: 100%">
         <tr>
           <th scope="row"><%= t('.collection_id') %></th>


### PR DESCRIPTION
This is a small thing but the Collection info dropdown box can kind of blend in with the underlying page if the user isn't paying attention when opening it. This PR adds a drop shadow to the box to make it stand out from the underlying page a bit.

### Before
<img width="540" alt="Screen Shot 2023-01-13 at 1 59 30 PM" src="https://user-images.githubusercontent.com/101482/212418736-c7894d70-bb5e-4363-9dbc-88360e4d8db5.png">


### After
<img width="540" alt="Screen Shot 2023-01-13 at 2 04 38 PM" src="https://user-images.githubusercontent.com/101482/212418820-3962328d-50f2-4e2c-ab06-fff527b629cf.png">
