### PR TITLE
Color contrast improvements for accessibility

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -141,6 +141,7 @@ $hierarchy-view-collapse-icon: url("data:image/svg+xml,<svg xmlns='http://www.w3
 
   .online-contents {
     grid-area: online-contents;
+    margin-bottom: 1rem;
   
     h2 {
       font-size: 1rem;

--- a/app/assets/stylesheets/arclight/modules/repository_card.scss
+++ b/app/assets/stylesheets/arclight/modules/repository_card.scss
@@ -1,6 +1,5 @@
 .al-repository {
   border: $default-border-styling;
-  background-color: $gray-200;
 }
 
 @include media-breakpoint-up(sm) {

--- a/app/components/arclight/online_content_filter_component.html.erb
+++ b/app/components/arclight/online_content_filter_component.html.erb
@@ -1,8 +1,11 @@
-<div class="online-contents">
-  <div class="alert alert-success d-flex align-items-center">
+<div class="card online-contents">
+  <div class="card-body d-flex align-items-center">
     <div class="d-flex">
       <span class="al-online-content-icon mr-2 me-2" aria-hidden="true"><%= helpers.blacklight_icon :online %></span>
-      <h2 class="d-none d-lg-inline"><%= t('arclight.views.show.online_content.title') %></h2>
+      <h2 class="d-none d-lg-inline">
+        <span class="visually-hidden">Filter</span>
+        <%= t('arclight.views.show.online_content.title') %>
+      </h2>
     </div>
     <div class="ml-3 ms-3 ml-xl-5 ms-xl-5">
       <div><%= t('arclight.views.show.online_content.description') %></div>

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Collection Page' do
   describe 'online content indicator' do
     context 'when there is online content available' do
       it 'is rendered' do
-        expect(page).to have_css('.alert', text: 'Online content')
+        expect(page).to have_css('.card', text: 'Online content')
       end
     end
 
@@ -43,7 +43,7 @@ RSpec.describe 'Collection Page' do
       let(:doc_id) { 'm0198-xml' }
 
       it 'is not rendered' do
-        expect(page).not_to have_css('.alert', text: 'Online content')
+        expect(page).not_to have_css('.card', text: 'Online content')
       end
     end
   end


### PR DESCRIPTION
A couple of minor color contrast updates for things that didn't have sufficient contrast for accessibility purposes:

Links don't have sufficient contrast against the repository box background color. No lighter gray, in fact, provides sufficient contrast. So I went with removing the background color. We can assume implementers will style these differently to match their local style, anyway.

### Before
<img width="1165" alt="Screen Shot 2023-01-17 at 5 26 11 PM" src="https://user-images.githubusercontent.com/101482/213047927-c27d21c8-cd47-45ce-bc5e-acfce649e065.png">

### After
<img width="1175" alt="Screen Shot 2023-01-17 at 4 19 06 PM" src="https://user-images.githubusercontent.com/101482/213048003-109fc2f9-1954-45ff-a487-b353f4733275.png">

---

Same thing with the online content box. No lighter version of green provides sufficient contrast with the default Bootstrap blue link. Basically same solution as above.

### Before
<img width="770" alt="Screen Shot 2023-01-17 at 5 25 16 PM" src="https://user-images.githubusercontent.com/101482/213048585-aedb2a90-ca38-4b10-a0fa-749a22ab0a59.png">


### After
<img width="770" alt="Screen Shot 2023-01-17 at 5 24 59 PM" src="https://user-images.githubusercontent.com/101482/213048648-765de00c-9033-4195-8f4e-d68e7b5774dd.png">
