### PR TITLE
Improve results when searching for unitids

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -191,7 +191,6 @@
           catenateAll="1"
           />
         <filter class="solr.ICUFoldingFilterFactory" />
-        <filter class="solr.WordDelimiterGraphFilterFactory"/>
       </analyzer>
     </fieldType>
 

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -89,9 +89,9 @@
          collection_title_tesim^150
          title_tesim^100
          normalized_title_teim^100
+         unitid_identifier_match^40
          name_teim^10
          place_teim^10
-         unitid_identifier_match^5
          subject_teim^2
          text
        </str>
@@ -99,9 +99,9 @@
          collection_title_tesim^150
          title_tesim^100
          normalized_title_teim^100
+         unitid_identifier_match^40
          name_teim^10
          place_teim^10
-         unitid_identifier_match^5
          subject_teim^2
          text
        </str>


### PR DESCRIPTION
- Remove duplicate WordDelimiterGraphFilterFactory on unitid field
- Boost relevance of unitid_identifier_match in search results

This work comes out of observations made in https://github.com/sul-dlss/vt-arclight/issues/186 -- when searching by unit identifier, the corresponding item came multiple pages deep in the search results. 