### PR TITLE
Fix a11y issue by making second nav landmark unique

### DIFF
--- a/app/components/arclight/collection_sidebar_component.html.erb
+++ b/app/components/arclight/collection_sidebar_component.html.erb
@@ -1,5 +1,5 @@
-<nav id="about-collection-nav" class="al-sidebar-navigation-context sidebar-section">
-  <h2><%= t('arclight.views.show.context_nav.title') %></h2>
+<nav class="al-sidebar-navigation-context sidebar-section" aria-labelledby="collection-nav">
+  <h2 id="collection-nav"><%= t('arclight.views.show.context_nav.title') %></h2>
   <ul class='nav flex-column'>
     <% partials.each do |section| %>
       <% next unless has_section?(section) %>


### PR DESCRIPTION
We currently get an accessibility error because -- on pages with the collection sidebar -- we have two `nav` elements and they aren't considered unique. There's no visible change to the UI to fix this. I added an `aria-labelledby` element to the second, collection overview nav to make it unique.

As part of this I removed the id element on the collection overview `nav`, because it didn't seem to be referenced anywhere. So I don't think that broke anything.