### PR TITLE
Allow autocomplete items to wrap. Otherwise, very long suggestions can bleed off the screen.

### DIFF
--- a/app/assets/stylesheets/arclight/application.scss
+++ b/app/assets/stylesheets/arclight/application.scss
@@ -11,3 +11,4 @@
 @import 'modules/search_results';
 @import 'modules/show_collection';
 @import 'modules/truncator';
+@import 'modules/search_form';

--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -209,13 +209,3 @@ dl.deflist dt {
   margin: $spacer 0;
   padding: $spacer 0;
 }
-
-// Original style comes from https://github.com/twbs/bootstrap/blob/v5.3.2/scss/_dropdown.scss#L184
-// via https://github.com/projectblacklight/blacklight/blob/v8.1.0/app/assets/stylesheets/blacklight/_search_form.scss#L25
-.input-group > .search-autocomplete-wrapper {
-  ul {
-    li {
-      white-space: normal;
-    }
-  }
-}

--- a/app/assets/stylesheets/arclight/modules/search_form.scss
+++ b/app/assets/stylesheets/arclight/modules/search_form.scss
@@ -1,0 +1,9 @@
+// Original style comes from https://github.com/twbs/bootstrap/blob/v5.3.2/scss/_dropdown.scss#L184
+// via https://github.com/projectblacklight/blacklight/blob/v8.1.0/app/assets/stylesheets/blacklight/_search_form.scss#L25
+.input-group > .search-autocomplete-wrapper {
+  ul {
+    li {
+      white-space: normal;
+    }
+  }
+}


### PR DESCRIPTION
PR for https://github.com/projectblacklight/arclight/issues/1383

Fixes issue with autocomplete options bleeding off the side of the screen. It restricts the autocomplete options to the width of the search input it is providing options for. See issue above for screenshots of the original issue.