### PR TITLE
Fix typo in solr schema

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -347,7 +347,7 @@
    <copyField source="access_subjects_ssim" dest="text" />
    <!-- grab the searchable notes -->
    <copyField source="abstract_tesim" dest="text" />
-   <copyField source="accessrestricct_tesim" dest="text" />
+   <copyField source="accessrestrict_tesim" dest="text" />
    <copyField source="accruals_tesim" dest="text" />
    <copyField source="acqinfo_tesim" dest="text" />
    <copyField source="altformavail_tesim" dest="text" />


### PR DESCRIPTION
Closes https://github.com/projectblacklight/arclight/issues/1439

How I tested this:

1. changed the `<accessrestrict>` entry for one of the fixture xmls to have a distinctive word in it (I used my name...) and indexed that into local solr
2. running the arclight main branch, use the search bar to search for the name -- no results
3. change the schema to fix the typo and restart solr
4. search my name, with successful result
