### PR TITLE
Align field names for subjects, places

### DIFF
--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -209,3 +209,13 @@ dl.deflist dt {
   margin: $spacer 0;
   padding: $spacer 0;
 }
+
+// Original style comes from https://github.com/twbs/bootstrap/blob/v5.3.2/scss/_dropdown.scss#L184
+// via https://github.com/projectblacklight/blacklight/blob/v8.1.0/app/assets/stylesheets/blacklight/_search_form.scss#L25
+.input-group > .search-autocomplete-wrapper {
+  ul {
+    li {
+      white-space: normal;
+    }
+  }
+}

--- a/app/assets/stylesheets/arclight/modules/layout.scss
+++ b/app/assets/stylesheets/arclight/modules/layout.scss
@@ -209,13 +209,3 @@ dl.deflist dt {
   margin: $spacer 0;
   padding: $spacer 0;
 }
-
-// Original style comes from https://github.com/twbs/bootstrap/blob/v5.3.2/scss/_dropdown.scss#L184
-// via https://github.com/projectblacklight/blacklight/blob/v8.1.0/app/assets/stylesheets/blacklight/_search_form.scss#L25
-.input-group > .search-autocomplete-wrapper {
-  ul {
-    li {
-      white-space: normal;
-    }
-  }
-}

--- a/app/components/arclight/group_component.html.erb
+++ b/app/components/arclight/group_component.html.erb
@@ -9,10 +9,8 @@
       <h3><%= helpers.link_to_document document %></h3>
       <% document.extent.each do |extent| %>
         <%= tag.span extent, class: 'al-document-extent badge' unless compact? %>
-      <% end %>
-      <dl>
-        <%= render Arclight::IndexMetadataFieldComponent.with_collection(presenter.field_presenters.select { |field| !compact? || field.field_config.compact }) %>
-      </dl>
+      <% end %>        
+      <%= render Arclight::IndexMetadataFieldComponent.with_collection(presenter.field_presenters.select { |field| !compact? || field.field_config.compact }) %>
     </div>
   </div>
 </div>

--- a/app/components/arclight/group_component.html.erb
+++ b/app/components/arclight/group_component.html.erb
@@ -9,8 +9,10 @@
       <h3><%= helpers.link_to_document document %></h3>
       <% document.extent.each do |extent| %>
         <%= tag.span extent, class: 'al-document-extent badge' unless compact? %>
-      <% end %>        
-      <%= render Arclight::IndexMetadataFieldComponent.with_collection(presenter.field_presenters.select { |field| !compact? || field.field_config.compact }) %>
+      <% end %>
+      <dl>
+        <%= render Arclight::IndexMetadataFieldComponent.with_collection(presenter.field_presenters.select { |field| !compact? || field.field_config.compact }) %>
+      </dl>
     </div>
   </div>
 </div>

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -140,7 +140,7 @@ class CatalogController < ApplicationController
 
     config.add_facet_field 'collection', field: 'collection_ssim', limit: 10
     config.add_facet_field 'creator', field: 'creator_ssim', limit: 10
-    config.add_facet_field 'date_range', field: 'date_range_ssim', range: true
+    config.add_facet_field 'date_range', field: 'date_range_isim', range: true
     config.add_facet_field 'level', field: 'level_ssim', limit: 10
     config.add_facet_field 'names', field: 'names_ssim', limit: 10
     config.add_facet_field 'repository', field: 'repository_ssim', limit: 10

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -140,7 +140,7 @@ class CatalogController < ApplicationController
 
     config.add_facet_field 'collection', field: 'collection_ssim', limit: 10
     config.add_facet_field 'creator', field: 'creator_ssim', limit: 10
-    config.add_facet_field 'date_range', field: 'date_range_isim', range: true
+    config.add_facet_field 'date_range', field: 'date_range_ssim', range: true
     config.add_facet_field 'level', field: 'level_ssim', limit: 10
     config.add_facet_field 'names', field: 'names_ssim', limit: 10
     config.add_facet_field 'repository', field: 'repository_ssim', limit: 10

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -144,8 +144,8 @@ class CatalogController < ApplicationController
     config.add_facet_field 'level', field: 'level_ssim', limit: 10
     config.add_facet_field 'names', field: 'names_ssim', limit: 10
     config.add_facet_field 'repository', field: 'repository_ssim', limit: 10
-    config.add_facet_field 'place', field: 'geogname_ssim', limit: 10
-    config.add_facet_field 'subject', field: 'access_subjects_ssim', limit: 10
+    config.add_facet_field 'places', field: 'geogname_ssim', limit: 10
+    config.add_facet_field 'access_subjects', field: 'access_subjects_ssim', limit: 10
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -104,14 +104,14 @@ RSpec.describe 'Search results' do
           expect(page).to have_css('li .facet-label', text: 'National Library of Medicine. History of Medicine Division', visible: :hidden)
         end
 
-        within('.blacklight-place') do
-          expect(page).to have_css('h3 button', text: 'Place')
+        within('.blacklight-places') do
+          expect(page).to have_css('h3 button', text: 'Places')
           expect(page).to have_css('li .facet-label', text: 'Mindanao Island (Philippines)', visible: :hidden)
           expect(page).to have_css('li .facet-label', text: 'Yosemite National Park (Calif.)', visible: :hidden)
         end
 
-        within('.blacklight-subject') do
-          expect(page).to have_css('h3 button', text: 'Subject')
+        within('.blacklight-access_subjects') do
+          expect(page).to have_css('h3 button', text: 'Subjects')
           expect(page).to have_css('li .facet-label', text: 'Slides.', visible: :hidden)
           expect(page).to have_css('li .facet-label', text: 'Fraternizing', visible: :hidden)
         end


### PR DESCRIPTION
Fixes #1422

"Places" was having the same issue as "access_subjects," so I addressed that as well.