### PR TITLE
Ensures the display of containers only changes the case of first character.

### DIFF
--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -111,8 +111,13 @@ module Arclight
     end
 
     def containers
-      # NOTE: that .titlecase strips punctuation, like hyphens, we want to keep
-      fetch('containers_ssim', []).map(&:capitalize)
+      # NOTE: Keep uppercase characters if present, but upcase the first if not already
+      containers_field = fetch('containers_ssim', []).reject(&:empty?)
+      return [] if containers_field.blank?
+
+      containers_field.map do |container|
+        container.dup.sub!(/\A./, &:upcase)
+      end
     end
 
     # @return [Array<String>] with embedded highlights using <em>...</em>

--- a/spec/models/concerns/arclight/solr_document_spec.rb
+++ b/spec/models/concerns/arclight/solr_document_spec.rb
@@ -88,10 +88,15 @@ RSpec.describe Arclight::SolrDocument do
   end
 
   describe '#containers' do
-    let(:document) { SolrDocument.new(containers_ssim: ['box 1', 'folder 4-5']) }
+    let(:document) { SolrDocument.new(containers_ssim: ['box 1', 'folder 4-5', 'box ABC']) }
+
+    it 'handles capitalization properly' do
+      expect(document.containers.first).to eq 'Box 1'
+      expect(document.containers.last).to eq 'Box ABC'
+    end
 
     it 'uses our rules for joining' do
-      expect(document.containers.join(', ')).to eq 'Box 1, Folder 4-5'
+      expect(document.containers.join(', ')).to eq 'Box 1, Folder 4-5, Box ABC'
     end
   end
 


### PR DESCRIPTION
Closes #1433

Changes the display of containers, which currently uses `.capitalize`, to only change the first character but leave subsequent characters unchanged.