### PR TITLE
Index date range years as integers rather than strings. Closes #1017.

### DIFF
--- a/lib/arclight/traject/ead2_component_config.rb
+++ b/lib/arclight/traject/ead2_component_config.rb
@@ -214,7 +214,7 @@ to_field 'digital_objects_ssm', extract_xpath('./dao|./did/dao', to_text: false)
   end
 end
 
-to_field 'date_range_ssim', extract_xpath('./did/unitdate/@normal', to_text: false) do |_record, accumulator|
+to_field 'date_range_isim', extract_xpath('./did/unitdate/@normal', to_text: false) do |_record, accumulator|
   range = Arclight::YearRange.new
   next range.years if accumulator.blank?
 

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -189,7 +189,7 @@ to_field 'extent_ssm', extract_xpath('/ead/archdesc/did/physdesc/extent')
 to_field 'extent_tesim', extract_xpath('/ead/archdesc/did/physdesc/extent')
 to_field 'genreform_ssim', extract_xpath('/ead/archdesc/controlaccess/genreform')
 
-to_field 'date_range_ssim', extract_xpath('/ead/archdesc/did/unitdate/@normal', to_text: false) do |_record, accumulator|
+to_field 'date_range_isim', extract_xpath('/ead/archdesc/did/unitdate/@normal', to_text: false) do |_record, accumulator|
   range = Arclight::YearRange.new
   next range.years if accumulator.blank?
 

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -140,7 +140,7 @@ class CatalogController < ApplicationController
 
     config.add_facet_field 'collection', field: 'collection_ssim', limit: 10
     config.add_facet_field 'creator', field: 'creator_ssim', limit: 10
-    config.add_facet_field 'date_range', field: 'date_range_ssim', range: true
+    config.add_facet_field 'date_range', field: 'date_range_isim', range: true
     config.add_facet_field 'level', field: 'level_ssim', limit: 10
     config.add_facet_field 'names', field: 'names_ssim', limit: 10
     config.add_facet_field 'repository', field: 'repository_ssim', limit: 10

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -170,7 +170,7 @@
        <str name="facet.mincount">1</str>
        <str name="facet.field">level_ssim</str>
        <str name="facet.field">creator_ssim</str>
-       <str name="facet.field">date_range_ssim</str>
+       <str name="facet.field">date_range_isim</str>
        <str name="facet.field">names_ssim</str>
        <str name="facet.field">geogname_ssim</str>
        <str name="facet.field">access_subjects_ssim</str>

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe 'EAD 2 traject indexing' do
       expect(result['unitdate_other_ssim']).to be_nil
     end
 
-    it 'creates date_range_ssim' do
-      date_range = result['date_range_ssim']
+    it 'creates date_range_isim' do
+      date_range = result['date_range_isim']
       expect(date_range).to be_an Array
       expect(date_range.length).to eq 7
       expect(date_range.first).to eq 1900
@@ -541,9 +541,9 @@ RSpec.describe 'EAD 2 traject indexing' do
       Arclight::Engine.root.join('spec', 'fixtures', 'ead', 'nlm', 'alphaomegaalpha.xml')
     end
 
-    it 'creates date_range_ssim' do
+    it 'creates date_range_isim' do
       component = all_components.find { |d| d['id'] == ['aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671'] }
-      date_range = component['date_range_ssim']
+      date_range = component['date_range_isim']
       expect(date_range).to be_an Array
       expect(date_range.length).to eq 75
       expect(date_range.first).to eq 1902


### PR DESCRIPTION
- This helps ArcLight work better with blacklight_range_limit, esp. with dates < 1000.