### PR TITLE
Add "collapsible-hierarchy" as a prefix instead of as a suffix.

### DIFF
--- a/app/components/arclight/document_collection_hierarchy_component.html.erb
+++ b/app/components/arclight/document_collection_hierarchy_component.html.erb
@@ -10,7 +10,7 @@
   <div class="documentHeader" data-document-id="<%= document.id %>">
     <% if document.children? %>
       <%= link_to('',
-          "##{document.id}-collapsible-hierarchy",
+          "#collapsible-hierarchy-#{document.id}",
           class: "al-toggle-view-children#{ ' collapsed' unless show_expanded?}",
           aria: {
             label: t('arclight.hierarchy.view_all'),
@@ -37,7 +37,7 @@
   
   <%= render Arclight::IndexMetadataFieldComponent.with_collection(@presenter&.field_presenters.select { |field| field.field_config.collection_context }, classes: ['col pl-0 my-0']) %>
   <% if document.number_of_children > 0 %>
-    <%= content_tag(:div, id: "#{document.id}-collapsible-hierarchy",
+    <%= content_tag(:div, id: "collapsible-hierarchy-#{document.id}",
       class: "collapse al-collection-context-collapsible al-hierarchy-level-#{document.component_level} #{'show' if show_expanded?}"
     ) do %>
       <%= render Arclight::DocumentComponentsHierarchyComponent.new(document: @document, target_index: target_index) %>

--- a/spec/features/collection_context_spec.rb
+++ b/spec/features/collection_context_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe 'Collection context', js: true do
     end
 
     it 'siblings are not expanded' do
-      expect(page).to have_css '.al-toggle-view-children.collapsed[href="#aoa271aspace_b70574c7229e6f237f780579cc04595d-collapsible-hierarchy"]'
+      expect(page).to have_css '.al-toggle-view-children.collapsed[href="#collapsible-hierarchy-aoa271aspace_b70574c7229e6f237f780579cc04595d"]'
     end
 
     it 'direct ancestors are expanded' do
-      expect(page).to have_css '#aoa271aspace_f934f1add34289f28bd0feb478e68275-collapsible-hierarchy.show', visible: :visible
-      expect(page).to have_css '#aoa271aspace_238a0567431f36f49acea49ef576d408-collapsible-hierarchy.show', visible: :visible
-      expect(page).to have_css '#aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671-collapsible-hierarchy.show', visible: :visible
+      expect(page).to have_css '#collapsible-hierarchy-aoa271aspace_f934f1add34289f28bd0feb478e68275.show', visible: :visible
+      expect(page).to have_css '#collapsible-hierarchy-aoa271aspace_238a0567431f36f49acea49ef576d408.show', visible: :visible
+      expect(page).to have_css '#collapsible-hierarchy-aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671.show', visible: :visible
     end
 
     it 'siblings above are hidden' do

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe 'Component Page' do
 
       it 'includes ancestor\'s preceding sibling when clicking ancestor\'s Expand button' do
         within '#collection-context' do
-          within('#aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671-collapsible-hierarchy') do
+          within('#collapsible-hierarchy-aoa271aspace_563a320bb37d24a9e1e6f7bf95b52671') do
             first('.btn-secondary', text: 'Expand').click
           end
           expect(page).to have_css '.document-title-heading', text: 'Officers and directors - lists, 1961, n.d.'

--- a/spec/features/many_component_ead_spec.rb
+++ b/spec/features/many_component_ead_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Many component EAD' do
       within '#collection-context' do
         click_link 'View'
         click_link 'Expand'
-        within '#lc0100aspace_327a75c226d44aa1a769edb4d2f13c6e-collapsible-hierarchy' do
+        within '#collapsible-hierarchy-lc0100aspace_327a75c226d44aa1a769edb4d2f13c6e' do
           expect(page).to have_css 'li.al-collection-context', count: 202
         end
       end


### PR DESCRIPTION
 This fixes issue with collections that start with numbers not being expandable.
Fix for: https://github.com/projectblacklight/arclight/issues/1029