### PR TITLE
Improve and document use of mm (minimum should match) param in Solr c…

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -75,7 +75,15 @@
        <int name="rows">10</int>
 
        <str name="q.alt">*:*</str>
-       <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+
+       <!-- Minimum Should Match parameter (mm) -->
+       <str name="mm">4&lt;90%</str>
+       <!-- 1-4 term query, all must match
+            5+ term query, 90% must match; rounded down, so e.g.:
+            * 5-10 term query, all but one must match
+            * 11-20 term query, all but two must match
+            * 21-29 term query, all but three must match, etc.
+       -->
 
        <!-- this qf and pf are used by default, if not otherwise specified by
             client. The default blacklight_config will use these for the

--- a/spec/features/fielded_search_results_spec.rb
+++ b/spec/features/fielded_search_results_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Field-based search results' do
       end
 
       it 'matches titles with a boost for multiple hits' do
-        visit search_catalog_path q: 'alpha omega alpha archives', search_field: 'keyword'
+        visit search_catalog_path q: 'alpha omega alpha', search_field: 'keyword'
         expect(page).to have_css '.index_title', count: 6
         within('.document-position-1') do
           expect(page).to have_css '.index_title', text: /Alpha Omega Alpha Archives, 1894-1992/

--- a/spec/features/search_query_spec.rb
+++ b/spec/features/search_query_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Search queries' do
+  describe 'multi-term queries' do
+    context 'when a query has 4 terms, all present in a component' do
+      it 'returns the component' do
+        visit search_catalog_path q: 'articles incorporation revised constitution', search_field: 'all_fields'
+        expect(page).to have_css '.index_title', text: /Amendments to articles of incorporation and revised constitution/
+      end
+    end
+
+    context 'when a query has 4 terms, 1 is nonsense' do
+      it 'requires all terms to match; no results' do
+        visit search_catalog_path q: 'articles incorporation revised zzznonsensezzz', search_field: 'all_fields'
+        expect(page).to have_css 'h2', text: /No results found/
+      end
+    end
+
+    context 'when a query has 5 terms, 1 is nonsense' do
+      it 'can match on all but one; returns the component' do
+        visit search_catalog_path q: 'articles incorporation revised constitution zzznonsensezzz', search_field: 'all_fields'
+        expect(page).to have_css '.index_title', text: /Amendments to articles of incorporation and revised constitution/
+      end
+    end
+  end
+end


### PR DESCRIPTION
…onfig. Advances #532.

Fixes these problems with the previous config:
 - only 2 terms had to match in a 3-term query, or 3 terms out of 4 (too permissive)
 - any 3-10 term query had to match all but 1 term *except* for 6-term queries, which oddly had to match all but 2. Now all terms must match for a query of 4 or fewer. Above 4, 90% must match (rounded down).