### PR TITLE
Adding missing elements from physdesc

### DIFF
--- a/lib/arclight/traject/ead2_component_config.rb
+++ b/lib/arclight/traject/ead2_component_config.rb
@@ -168,7 +168,7 @@ to_field 'collection_ssim' do |_record, accumulator, _context|
 end
 
 # This accumulates direct text from a physdesc, ignoring child elements handled elsewhere
-to_field 'physdesc_ssm', extract_xpath('./did/physdesc', to_text: false) do |_record, accumulator|
+to_field 'physdesc_tesim', extract_xpath('./did/physdesc', to_text: false) do |_record, accumulator|
   accumulator.map! do |element|
     physdesc = []
     element.children.map do |child|
@@ -178,10 +178,6 @@ to_field 'physdesc_ssm', extract_xpath('./did/physdesc', to_text: false) do |_re
     end.flatten
     physdesc.join(' ') unless physdesc.empty?
   end
-end
-
-to_field 'physdesc_tesim' do |_record, accumulator, context|
-  accumulator.concat context.output_hash['physdesc_ssm'] || []
 end
 
 to_field 'extent_ssm' do |record, accumulator|
@@ -200,10 +196,7 @@ to_field 'extent_tesim' do |_record, accumulator, context|
   accumulator.concat context.output_hash['extent_ssm'] || []
 end
 
-to_field 'physfacet_ssm', extract_xpath('./did/physdesc/physfacet')
 to_field 'physfacet_tesim', extract_xpath('./did/physdesc/physfacet')
-
-to_field 'dimensions_ssm', extract_xpath('./did/physdesc/dimensions')
 to_field 'dimensions_tesim', extract_xpath('./did/physdesc/dimensions')
 
 to_field 'creator_ssm', extract_xpath('./did/origination')

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -183,12 +183,29 @@ to_field 'digital_objects_ssm', extract_xpath('/ead/archdesc/did/dao|/ead/archde
   end
 end
 
+# This accumulates direct text from a physdesc, ignoring child elements handled elsewhere
+to_field 'physdesc_ssm', extract_xpath('/ead/archdesc/did/physdesc', to_text: false) do |_record, accumulator|
+  accumulator.map! do |element|
+    physdesc = []
+    element.children.map do |child|
+      next if child.instance_of?(Nokogiri::XML::Element)
+
+      physdesc << child.text&.strip unless child.text&.strip&.empty?
+    end.flatten
+    physdesc.join(' ') unless physdesc.empty?
+  end
+end
+
+to_field 'physdesc_tesim' do |_record, accumulator, context|
+  accumulator.concat context.output_hash['physdesc_ssm'] || []
+end
+
 to_field 'extent_ssm' do |record, accumulator|
   physdescs = record.xpath('/ead/archdesc/did/physdesc')
   extents_per_physdesc = physdescs.map do |physdesc|
     extents = physdesc.xpath('./extent').map { |e| e.text.strip }
     # Join extents within the same physdesc with an empty string
-    extents.join(' ')
+    extents.join(' ') unless extents.empty?
   end
 
   # Add each physdesc separately to the accumulator
@@ -198,6 +215,12 @@ end
 to_field 'extent_tesim' do |_record, accumulator, context|
   accumulator.concat context.output_hash['extent_ssm'] || []
 end
+
+to_field 'physfacet_ssm', extract_xpath('/ead/archdesc/did/physdesc/physfacet')
+to_field 'physfacet_tesim', extract_xpath('/ead/archdesc/did/physdesc/physfacet')
+
+to_field 'dimensions_ssm', extract_xpath('/ead/archdesc/did/physdesc/dimensions')
+to_field 'dimensions_tesim', extract_xpath('/ead/archdesc/did/physdesc/dimensions')
 
 to_field 'genreform_ssim', extract_xpath('/ead/archdesc/controlaccess/genreform')
 

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -184,7 +184,7 @@ to_field 'digital_objects_ssm', extract_xpath('/ead/archdesc/did/dao|/ead/archde
 end
 
 # This accumulates direct text from a physdesc, ignoring child elements handled elsewhere
-to_field 'physdesc_ssm', extract_xpath('/ead/archdesc/did/physdesc', to_text: false) do |_record, accumulator|
+to_field 'physdesc_tesim', extract_xpath('/ead/archdesc/did/physdesc', to_text: false) do |_record, accumulator|
   accumulator.map! do |element|
     physdesc = []
     element.children.map do |child|
@@ -194,10 +194,6 @@ to_field 'physdesc_ssm', extract_xpath('/ead/archdesc/did/physdesc', to_text: fa
     end.flatten
     physdesc.join(' ') unless physdesc.empty?
   end
-end
-
-to_field 'physdesc_tesim' do |_record, accumulator, context|
-  accumulator.concat context.output_hash['physdesc_ssm'] || []
 end
 
 to_field 'extent_ssm' do |record, accumulator|
@@ -216,10 +212,7 @@ to_field 'extent_tesim' do |_record, accumulator, context|
   accumulator.concat context.output_hash['extent_ssm'] || []
 end
 
-to_field 'physfacet_ssm', extract_xpath('/ead/archdesc/did/physdesc/physfacet')
 to_field 'physfacet_tesim', extract_xpath('/ead/archdesc/did/physdesc/physfacet')
-
-to_field 'dimensions_ssm', extract_xpath('/ead/archdesc/did/physdesc/dimensions')
 to_field 'dimensions_tesim', extract_xpath('/ead/archdesc/did/physdesc/dimensions')
 
 to_field 'genreform_ssim', extract_xpath('/ead/archdesc/controlaccess/genreform')

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -279,6 +279,8 @@ class CatalogController < ApplicationController
     config.add_background_field 'accruals', field: 'accruals_html_tesm', helper_method: :render_html_tags
     config.add_background_field 'phystech', field: 'phystech_html_tesm', helper_method: :render_html_tags
     config.add_background_field 'physloc', field: 'physloc_html_tesm', helper_method: :render_html_tags
+    config.add_background_field 'physfacet', field: 'physfacet_ssm', helper_method: :render_html_tags
+    config.add_background_field 'dimensions', field: 'dimensions_ssm', helper_method: :render_html_tags
     config.add_background_field 'materialspec', field: 'materialspec_tesim', helper_method: :render_html_tags
     config.add_background_field 'fileplan', field: 'fileplan_html_tesim', helper_method: :render_html_tags
     config.add_background_field 'descrules', field: 'descrules_ssm', helper_method: :render_html_tags
@@ -335,6 +337,8 @@ class CatalogController < ApplicationController
     config.add_component_field 'phystech', field: 'phystech_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'materialspec', field: 'materialspec_tesim', helper_method: :render_html_tags
     config.add_component_field 'physloc', field: 'physloc_html_tesm', helper_method: :render_html_tags
+    config.add_component_field 'physfacet', field: 'physfacet_tesim', helper_method: :render_html_tags
+    config.add_component_field 'dimensions', field: 'dimensions_tesim', helper_method: :render_html_tags
     config.add_component_field 'fileplan', field: 'fileplan_html_tesim', helper_method: :render_html_tags
     config.add_component_field 'altformavail', field: 'altformavail_html_tesim', helper_method: :render_html_tags
     config.add_component_field 'otherfindaid', field: 'otherfindaid_html_tesm', helper_method: :render_html_tags

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -279,8 +279,8 @@ class CatalogController < ApplicationController
     config.add_background_field 'accruals', field: 'accruals_html_tesm', helper_method: :render_html_tags
     config.add_background_field 'phystech', field: 'phystech_html_tesm', helper_method: :render_html_tags
     config.add_background_field 'physloc', field: 'physloc_html_tesm', helper_method: :render_html_tags
-    config.add_background_field 'physfacet', field: 'physfacet_ssm', helper_method: :render_html_tags
-    config.add_background_field 'dimensions', field: 'dimensions_ssm', helper_method: :render_html_tags
+    config.add_background_field 'physfacet', field: 'physfacet_tesim', helper_method: :render_html_tags
+    config.add_background_field 'dimensions', field: 'dimensions_tesim', helper_method: :render_html_tags
     config.add_background_field 'materialspec', field: 'materialspec_tesim', helper_method: :render_html_tags
     config.add_background_field 'fileplan', field: 'fileplan_html_tesim', helper_method: :render_html_tags
     config.add_background_field 'descrules', field: 'descrules_ssm', helper_method: :render_html_tags

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -279,6 +279,7 @@ class CatalogController < ApplicationController
     config.add_background_field 'accruals', field: 'accruals_html_tesm', helper_method: :render_html_tags
     config.add_background_field 'phystech', field: 'phystech_html_tesm', helper_method: :render_html_tags
     config.add_background_field 'physloc', field: 'physloc_html_tesm', helper_method: :render_html_tags
+    config.add_background_field 'physdesc', field: 'physdesc_tesim', helper_method: :render_html_tags
     config.add_background_field 'physfacet', field: 'physfacet_tesim', helper_method: :render_html_tags
     config.add_background_field 'dimensions', field: 'dimensions_tesim', helper_method: :render_html_tags
     config.add_background_field 'materialspec', field: 'materialspec_tesim', helper_method: :render_html_tags
@@ -337,6 +338,7 @@ class CatalogController < ApplicationController
     config.add_component_field 'phystech', field: 'phystech_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'materialspec', field: 'materialspec_tesim', helper_method: :render_html_tags
     config.add_component_field 'physloc', field: 'physloc_html_tesm', helper_method: :render_html_tags
+    config.add_component_field 'physdesc', field: 'physdesc_tesim', helper_method: :render_html_tags
     config.add_component_field 'physfacet', field: 'physfacet_tesim', helper_method: :render_html_tags
     config.add_component_field 'dimensions', field: 'dimensions_tesim', helper_method: :render_html_tags
     config.add_component_field 'fileplan', field: 'fileplan_html_tesim', helper_method: :render_html_tags

--- a/lib/generators/arclight/templates/config/locales/arclight.en.yml
+++ b/lib/generators/arclight/templates/config/locales/arclight.en.yml
@@ -18,6 +18,8 @@ en:
         accruals: Accruals
         phystech: Physical / technical requirements
         physloc: Physical location
+        physfacet: Physical facet
+        dimensions: Dimensions
         descrules: Rules or conventions
 
         relatedmaterial: Related material

--- a/lib/generators/arclight/templates/config/locales/arclight.en.yml
+++ b/lib/generators/arclight/templates/config/locales/arclight.en.yml
@@ -18,6 +18,7 @@ en:
         accruals: Accruals
         phystech: Physical / technical requirements
         physloc: Physical location
+        physdesc: Physical description
         physfacet: Physical facet
         dimensions: Dimensions
         descrules: Rules or conventions

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Collection Page' do
       end
     end
 
-    it 'background has configured metadata' do
+    it 'background has configured metadata' do # rubocop:disable RSpec/MultipleExpectations
       within '#background' do
         expect(page).to have_css('dt', text: 'Scope and content')
         expect(page).to have_css('dd', text: /^Correspondence, documents, records, photos/)
@@ -98,6 +98,15 @@ RSpec.describe 'Collection Page' do
 
         expect(page).to have_css('dt', text: 'Arrangement')
         expect(page).to have_css('dd', text: /^Arranged into seven series\./)
+
+        expect(page).to have_css('dt', text: 'Physical description')
+        expect(page).to have_css('dd', text: /^Boxes and folders/)
+
+        expect(page).to have_css('dt', text: 'Physical facet')
+        expect(page).to have_css('dd', text: /^Compact digital disc/)
+
+        expect(page).to have_css('dt', text: 'Dimensions')
+        expect(page).to have_css('dd', text: /^7\.5 x 5\.5 in\./)
 
         expect(page).to have_css('dt', text: 'Rules or conventions')
         expect(page).to have_css('dd', text: /^Finding aid prepared using Rules for Archival Description/)

--- a/spec/features/component_page_spec.rb
+++ b/spec/features/component_page_spec.rb
@@ -83,6 +83,17 @@ RSpec.describe 'Component Page' do
       expect(page).to have_css('dd', text: /^These papers were maintained by the staff/)
     end
 
+    it 'shows configured component fields' do
+      expect(page).to have_css('dt', text: 'Extent')
+      expect(page).to have_css('dd', text: /^2 Linear Feet/)
+      expect(page).to have_css('dt', text: 'Physical description')
+      expect(page).to have_css('dd', text: /^Mixed Materials/)
+      expect(page).to have_css('dt', text: 'Dimensions')
+      expect(page).to have_css('dd', text: /^various/)
+      expect(page).to have_css('dt', text: 'Physical facet')
+      expect(page).to have_css('dd', text: /^Boxes and folders/)
+    end
+
     it 'multivalued notes are rendered as paragaphs' do
       within 'dd.blacklight-appraisal' do
         expect(page).to have_css('p', count: 2)

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -120,8 +120,22 @@ RSpec.describe 'EAD 2 traject indexing' do
       expect(result['places_ssim']).to equal_array_ignoring_whitespace ['Yosemite National Park (Calif.)']
     end
 
-    it 'physdesc' do
-      expect(result['extent_ssm']).to equal_array_ignoring_whitespace ['1.25 Linear Feet (1 volume)', '1 document case', '16 DVDRs']
+    describe 'physdesc' do
+      it 'direct text' do
+        expect(result['physdesc_ssm']).to equal_array_ignoring_whitespace ['Photographic album', 'Single bound volume']
+      end
+
+      it 'extent' do
+        expect(result['extent_ssm']).to equal_array_ignoring_whitespace ['1.25 Linear Feet (1 volume)', '1 document case', '16 DVDRs']
+      end
+
+      it 'physfacet' do
+        expect(result['physfacet_ssm']).to equal_array_ignoring_whitespace ['Printed material', 'Digital Video Disc']
+      end
+
+      it 'dimensions' do
+        expect(result['dimensions_ssm']).to equal_array_ignoring_whitespace ['20 x 20 in.', '7.5 x 5.5 in.']
+      end
     end
 
     it 'has_online_content' do
@@ -295,18 +309,49 @@ RSpec.describe 'EAD 2 traject indexing' do
       ).to_a.first
     end
 
-    it 'extent at the collection level' do
-      %w[extent_ssm extent_tesim].each do |field|
-        expect(result[field]).to equal_array_ignoring_whitespace(['15.0 linear feet (36 boxes + oversize folder)', '3 CDs'])
+    describe 'physdesc at the collection level' do
+      it 'direct text' do
+        expect(result['physdesc_ssm']).to equal_array_ignoring_whitespace ['Boxes and folders', 'Compact discs']
+      end
+
+      it 'extent' do
+        %w[extent_ssm extent_tesim].each do |field|
+          expect(result[field]).to equal_array_ignoring_whitespace(['15.0 linear feet (36 boxes + oversize folder)', '3 CDs'])
+        end
+      end
+
+      it 'physfacet' do
+        expect(result['physfacet_ssm']).to equal_array_ignoring_whitespace ['Compact digital disc']
+      end
+
+      it 'dimensions' do
+        expect(result['dimensions_ssm']).to equal_array_ignoring_whitespace ['7.5 x 5.5 in.']
       end
     end
 
-    it 'extent at the component level' do
-      component = all_components.find { |c| c['ref_ssi'] == ['aspace_a951375d104030369a993ff943f61a77'] }
-      %w[extent_ssm extent_tesim].each do |field|
-        expect(component[field]).to equal_array_ignoring_whitespace(
-          ['1.5 Linear Feet']
-        )
+    describe 'physdesc at the component level' do
+      let(:component) do
+        all_components.find { |c| c['ref_ssi'] == ['aspace_a951375d104030369a993ff943f61a77'] }
+      end
+
+      it 'direct text' do
+        expect(component['physdesc_ssm']).to equal_array_ignoring_whitespace ['Cards and sheets of various sizes']
+      end
+
+      it 'extent' do
+        %w[extent_ssm extent_tesim].each do |field|
+          expect(component[field]).to equal_array_ignoring_whitespace(
+            ['1.5 Linear Feet']
+          )
+        end
+      end
+
+      it 'physfacet' do
+        expect(component['physfacet_ssm']).to equal_array_ignoring_whitespace ['Informational cards']
+      end
+
+      it 'dimensions' do
+        expect(component['dimensions_ssm']).to equal_array_ignoring_whitespace ['various']
       end
     end
 

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -122,19 +122,19 @@ RSpec.describe 'EAD 2 traject indexing' do
 
     describe 'physdesc' do
       it 'direct text' do
-        expect(result['physdesc_ssm']).to equal_array_ignoring_whitespace ['Photographic album', 'Single bound volume']
+        expect(result['physdesc_tesim']).to equal_array_ignoring_whitespace ['Photographic album', 'Single bound volume']
       end
 
       it 'extent' do
-        expect(result['extent_ssm']).to equal_array_ignoring_whitespace ['1.25 Linear Feet (1 volume)', '1 document case', '16 DVDRs']
+        expect(result['extent_tesim']).to equal_array_ignoring_whitespace ['1.25 Linear Feet (1 volume)', '1 document case', '16 DVDRs']
       end
 
       it 'physfacet' do
-        expect(result['physfacet_ssm']).to equal_array_ignoring_whitespace ['Printed material', 'Digital Video Disc']
+        expect(result['physfacet_tesim']).to equal_array_ignoring_whitespace ['Printed material', 'Digital Video Disc']
       end
 
       it 'dimensions' do
-        expect(result['dimensions_ssm']).to equal_array_ignoring_whitespace ['20 x 20 in.', '7.5 x 5.5 in.']
+        expect(result['dimensions_tesim']).to equal_array_ignoring_whitespace ['20 x 20 in.', '7.5 x 5.5 in.']
       end
     end
 
@@ -311,7 +311,7 @@ RSpec.describe 'EAD 2 traject indexing' do
 
     describe 'physdesc at the collection level' do
       it 'direct text' do
-        expect(result['physdesc_ssm']).to equal_array_ignoring_whitespace ['Boxes and folders', 'Compact discs']
+        expect(result['physdesc_tesim']).to equal_array_ignoring_whitespace ['Boxes and folders', 'Compact discs']
       end
 
       it 'extent' do
@@ -321,11 +321,11 @@ RSpec.describe 'EAD 2 traject indexing' do
       end
 
       it 'physfacet' do
-        expect(result['physfacet_ssm']).to equal_array_ignoring_whitespace ['Compact digital disc']
+        expect(result['physfacet_tesim']).to equal_array_ignoring_whitespace ['Compact digital disc']
       end
 
       it 'dimensions' do
-        expect(result['dimensions_ssm']).to equal_array_ignoring_whitespace ['7.5 x 5.5 in.']
+        expect(result['dimensions_tesim']).to equal_array_ignoring_whitespace ['7.5 x 5.5 in.']
       end
     end
 
@@ -335,7 +335,7 @@ RSpec.describe 'EAD 2 traject indexing' do
       end
 
       it 'direct text' do
-        expect(component['physdesc_ssm']).to equal_array_ignoring_whitespace ['Cards and sheets of various sizes']
+        expect(component['physdesc_tesim']).to equal_array_ignoring_whitespace ['Cards and sheets of various sizes']
       end
 
       it 'extent' do
@@ -347,11 +347,11 @@ RSpec.describe 'EAD 2 traject indexing' do
       end
 
       it 'physfacet' do
-        expect(component['physfacet_ssm']).to equal_array_ignoring_whitespace ['Informational cards']
+        expect(component['physfacet_tesim']).to equal_array_ignoring_whitespace ['Informational cards']
       end
 
       it 'dimensions' do
-        expect(component['dimensions_ssm']).to equal_array_ignoring_whitespace ['various']
+        expect(component['dimensions_tesim']).to equal_array_ignoring_whitespace ['various']
       end
     end
 

--- a/spec/fixtures/ead/nlm/alphaomegaalpha.xml
+++ b/spec/fixtures/ead/nlm/alphaomegaalpha.xml
@@ -474,6 +474,16 @@
           <did>
             <unittitle>Constitution and by-laws - drafts,</unittitle>
             <unitdate normal="1902/1904" type="inclusive">1902-1904</unitdate>
+            <physdesc>
+              Mixed Materials
+            </physdesc>
+            <physdesc>
+              <physfacet>Boxes and folders</physfacet>
+            </physdesc>
+            <physdesc altrender="whole">
+              <dimensions>various</dimensions>
+              <extent altrender="materialtype spaceoccupied">2 Linear Feet</extent>
+            </physdesc>
             <container id="aspace_19171bacef2f302c352195eaafca6b75" label="Mixed Materials"
               type="box">1</container>
             <container id="aspace_4cceb568b39913f2342e43dd3d54b772"

--- a/spec/fixtures/ead/nlm/alphaomegaalpha.xml
+++ b/spec/fixtures/ead/nlm/alphaomegaalpha.xml
@@ -41,11 +41,19 @@
         <corpname source="ingest">Alpha Omega Alpha</corpname>
       </origination>
       <unitid>MS C 271</unitid>
+      <physdesc>
+        Boxes and folders
+      </physdesc>
+      <physdesc>
+        Compact discs
+      </physdesc>
       <physdesc altrender="part">
         <extent altrender="materialtype spaceoccupied">15.0 linear feet (36 boxes + oversize
           folder)</extent>
       </physdesc>
       <physdesc altrender="part">
+        <dimensions>7.5 x 5.5 in.</dimensions>
+        <physfacet>Compact digital disc</physfacet>
         <extent altrender="materialtype spaceoccupied">3 CDs</extent>
       </physdesc>
       <unitdate normal="1894/1992" type="inclusive">1894-1992</unitdate>
@@ -393,7 +401,7 @@
         <bioghist id="aspace_ff0f536406ce214f5u38e1f7c798d76e">
           <head>Historical Note</head>
           <p>
-            The Society started keeping consistent adminstrative records in 1975, the same year that E. L. Doctorow published <emph render="italic">Ragtime</emph>. 
+            The Society started keeping consistent adminstrative records in 1975, the same year that E. L. Doctorow published <emph render="italic">Ragtime</emph>.
           </p>
         </bioghist>
         <accessrestrict id="aspace_7bbec2cdc1e6e0cb7b2ff1acb7c9e364">
@@ -724,8 +732,16 @@
         <did>
           <unittitle>Series II: Membership,</unittitle>
           <unitid>MS C 271.II</unitid>
-          <physdesc altrender="whole"><extent altrender="materialtype spaceoccupied">1.5 Linear
-              Feet</extent></physdesc>
+          <physdesc>
+            Cards and sheets of various sizes
+          </physdesc>
+          <physdesc>
+            <physfacet>Informational cards</physfacet>
+          </physdesc>
+          <physdesc altrender="whole">
+            <dimensions>various</dimensions>
+            <extent altrender="materialtype spaceoccupied">1.5 Linear Feet</extent>
+          </physdesc>
           <unitdate normal="1902/1973" type="inclusive">1902-1973</unitdate>
           <abstract id="aspace_e806089c6553f2132b727ead99b47a70">Contains a mixture of membership
             cards and membership rosters.</abstract>

--- a/spec/fixtures/ead/sul-spec/a0011.xml
+++ b/spec/fixtures/ead/sul-spec/a0011.xml
@@ -78,13 +78,23 @@
             </origination>
             <unitid>A0011</unitid>
             <physdesc altrender="part">
+                Photographic album
+            </physdesc>
+            <physdesc altrender="part">
+                Single bound volume
+            </physdesc>
+            <physdesc altrender="part">
+                <physfacet>Printed material</physfacet>
                 <extent altrender="materialtype spaceoccupied">1.25 Linear Feet</extent>
                 <extent altrender="carrier">(1 volume)</extent>
             </physdesc>
             <physdesc altrender="part">
+                <dimensions>20 x 20 in.</dimensions>
                 <extent altrender="materialtype spaceoccupied">1 document case</extent>
             </physdesc>
             <physdesc altrender="part">
+                <dimensions>7.5 x 5.5 in.</dimensions>
+                <physfacet>Digital Video Disc</physfacet>
                 <extent altrender="materialtype spaceoccupied">16 DVDRs</extent>
             </physdesc>
             <unitdate normal="1900/1906" type="inclusive">circa 1900-1906


### PR DESCRIPTION
This PR adds individual indexing and display of the missing child elements of `physdesc` at both a collection and component level .  In doing so, it carefully preserves the preexisting behaviors of the `extents` child element.

Assuming the test app is already running this commit level locally, this can be tested with:
```
cd .internal_test_app
export FILE=../spec/fixtures/ead/nlm/alphaomegaalpha.xml
export REPOSITORY_ID=nlm

bundle exec rake arclight:index
```
For the [new document In the locally running test app](http://localhost:3000/catalog/aoa271) ...

Summary should contain:
- Extent:  15.0 linear feet (36 boxes + oversize folder) and 3 CDs

Background should contain:
- Physical facet:  Compact digital disc
- Dimensions:  7.5 x 5.5 in.

[This component in the document](http://localhost:3000/catalog/aoa271aspace_a951375d104030369a993ff943f61a77) should contain:

- Extent:  1.5 Linear Feet
- Physical facet:  Informational cards
- Dimensions:  various
