### PR TITLE
All <unitdates> now display

### DIFF
--- a/lib/arclight/normalized_date.rb
+++ b/lib/arclight/normalized_date.rb
@@ -45,6 +45,5 @@ module Arclight
       result << "bulk #{bulk}" if bulk.present?
       result.compact.map(&:strip).join(', ')
     end
-
   end
 end

--- a/lib/arclight/normalized_date.rb
+++ b/lib/arclight/normalized_date.rb
@@ -39,16 +39,12 @@ module Arclight
 
     # @see http://www2.archivists.org/standards/DACS/part_I/chapter_2/4_date for rules
     def normalize
-      if inclusive.present?
-        result = inclusive.to_s
-        result << ", bulk #{bulk}" if bulk.present?
-      elsif other.present?
-        result = other.to_s
-      else
-        result = nil
-      end
-
-      result&.strip
+      result = []
+      result << inclusive if inclusive.present?
+      result << other if other.present?
+      result << "bulk #{bulk}" if bulk.present?
+      result.compact.map(&:strip).join(', ')
     end
+
   end
 end

--- a/spec/fixtures/ead/nlm/alphaomegaalpha.xml
+++ b/spec/fixtures/ead/nlm/alphaomegaalpha.xml
@@ -409,7 +409,8 @@
             </origination>
             <unittitle>"A brief account of the origin of the Alpha Omega Alpha Honorary Fraternity"
               - William W. Root,</unittitle>
-            <unitdate>n.d.</unitdate>
+            <unitdate>ca. 1967</unitdate>
+            <unitdate type="inclusive">n.d.</unitdate>
             <container id="aspace_d258aae2bcdc020db8152ebcd05b648f" label="Mixed Materials"
               type="box">1</container>
             <container id="aspace_8a0450988fafd6cee4c334fe4811c392"

--- a/spec/lib/arclight/normalized_date_spec.rb
+++ b/spec/lib/arclight/normalized_date_spec.rb
@@ -7,18 +7,18 @@ RSpec.describe Arclight::NormalizedDate do
 
   let(:date_inclusive) { ['1990-2000'] }
   let(:date_bulk) { '1999-2005' }
-  let(:date_other) { nil }
+  let(:date_other) { 'Undated' }
 
   context 'under normal conditions' do
     it 'joins dates' do
-      expect(normalized_date).to eq '1990-2000, bulk 1999-2005'
+      expect(normalized_date).to eq '1990-2000, Undated, bulk 1999-2005'
     end
 
     context 'multiple normalized dates' do
       let(:date_inclusive) { %w[1990 1992] }
 
       it 'are joined w/ a comma' do
-        expect(normalized_date).to eq '1990, 1992, bulk 1999-2005'
+        expect(normalized_date).to eq '1990, 1992, Undated, bulk 1999-2005'
       end
     end
   end
@@ -31,7 +31,7 @@ RSpec.describe Arclight::NormalizedDate do
       let(:date_bulk) { '1990-2004' }
 
       it 'uses compressed joined years' do
-        expect(normalized_date).to eq '1990-2002, 2004, bulk 1990-2004'
+        expect(normalized_date).to eq '1990-2002, 2004, Undated, bulk 1990-2004'
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe Arclight::NormalizedDate do
       let(:date_bulk) { 'n.d.' }
 
       it 'do not normalized term "undated"' do
-        expect(normalized_date).to eq '1990-2000, bulk n.d.'
+        expect(normalized_date).to eq '1990-2000, Undated, bulk n.d.'
       end
     end
 
@@ -47,12 +47,13 @@ RSpec.describe Arclight::NormalizedDate do
       let(:date_bulk) { 'c.1995' }
 
       it 'do not normalized term "circa"' do
-        expect(normalized_date).to eq '1990-2000, bulk c.1995'
+        expect(normalized_date).to eq '1990-2000, Undated, bulk c.1995'
       end
     end
 
     context 'no bulk' do
       let(:date_bulk) { nil }
+      let(:date_other) { nil }
 
       it 'uses inclusive date only' do
         expect(normalized_date).to eq '1990-2000'
@@ -72,17 +73,18 @@ RSpec.describe Arclight::NormalizedDate do
     context 'no inclusive but bulk' do
       let(:date_inclusive) { nil }
 
-      it 'does not know what to do' do
-        expect(normalized_date).to be_nil
+      it 'uses other and bulk' do
+        expect(normalized_date).to eq 'Undated, bulk 1999-2005'
       end
     end
 
     context 'no information' do
       let(:date_inclusive) { nil }
       let(:date_bulk) { nil }
+      let(:date_other) { nil }
 
       it 'does not know what to do' do
-        expect(normalized_date).to be_nil
+        expect(normalized_date).to eq ''
       end
     end
   end


### PR DESCRIPTION
Implemented Duke's fix so that all `<unitdates>` are displayed, even when only some have `@type`. Also added example fixture.

This does not necessarily preserve `<unitdate>` order unless they all have the same `@type`, so #1028 should remain open.