### PR TITLE
Improve search relevance by enabling queries for ids, containers, lan…

### DIFF
--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -231,6 +231,20 @@ class CatalogController < ApplicationController
         pf:  '${pf_title}'
       }
     end
+    config.add_search_field 'container', label: 'Container' do |field|
+      field.qt = 'search'
+      field.solr_parameters = {
+        qf:  '${qf_container}',
+        pf:  '${pf_container}'
+      }
+    end
+    config.add_search_field 'identifier', label: 'Identifier' do |field|
+      field.qt = 'search'
+      field.solr_parameters = {
+        qf:  '${qf_identifier}',
+        pf:  '${pf_identifier}'
+      }
+    end
 
     # These are the parameters passed through in search_state.params_for_search
     config.search_state_fields += %i[id group hierarchy_context original_document]

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -338,6 +338,7 @@
    <copyField source="places_ssim" dest="place_teim"/>
    <copyField source="names_ssim" dest="name_teim"/>
    <copyField source="access_subjects_ssim" dest="subject_teim"/>
+   <copyField source="containers_ssim" dest="container_teim" />
 
    <!-- The catch all `text` field -->
    <!-- grab the fielded searches -->
@@ -345,6 +346,8 @@
    <copyField source="places_ssim" dest="text" />
    <copyField source="names_ssim" dest="text" />
    <copyField source="access_subjects_ssim" dest="text" />
+   <copyField source="containers_ssim" dest="text" />
+
    <!-- grab the searchable notes -->
    <copyField source="abstract_tesim" dest="text" />
    <copyField source="accessrestrict_tesim" dest="text" />
@@ -358,10 +361,12 @@
    <copyField source="custodhist_tesim" dest="text" />
    <copyField source="did_note_tesim" dest="text" />
    <copyField source="fileplan_tesim" dest="text" />
+   <copyField source="language_ssim" dest="text" />
    <copyField source="materialspec_tesim" dest="text" />
    <copyField source="note_tesim" dest="text" />
    <copyField source="odd_tesim" dest="text" />
    <copyField source="originalsloc_tesim" dest="text" />
+   <copyField source="parent_unittitles_tesim" dest="text" />
    <copyField source="physdesc_tesim" dest="text" />
    <copyField source="physloc_tesim" dest="text" />
    <copyField source="phystech_tesim" dest="text" />

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -101,6 +101,12 @@
          name_teim^10
          place_teim^10
          subject_teim^2
+         id
+         ead_ssi
+         ref_ssm
+         unitid_ssm
+         container_teim
+         parent_unittitles_tesim
          text
        </str>
        <str name="pf">
@@ -111,9 +117,33 @@
          name_teim^10
          place_teim^10
          subject_teim^2
+         id
+         ead_ssi
+         ref_ssm
+         unitid_ssm
+         container_teim
+         parent_unittitles_tesim
          text
        </str>
 
+       <str name="qf_container">
+         container_teim
+       </str>
+       <str name="pf_container">
+         container_teim
+       </str>
+       <str name="qf_identifier">
+         id
+         ead_ssi
+         ref_ssm
+         unitid_ssm
+       </str>
+       <str name="pf_identifier">
+         id
+         ead_ssi
+         ref_ssm
+         unitid_ssm
+       </str>
        <str name="qf_name">
          name_teim
        </str>

--- a/spec/features/fielded_search_results_spec.rb
+++ b/spec/features/fielded_search_results_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Field-based search results' do
 
       it 'matches titles with a boost for multiple hits' do
         visit search_catalog_path q: 'alpha omega alpha', search_field: 'keyword'
-        expect(page).to have_css '.index_title', count: 6
+        expect(page).to have_css '.index_title', count: 10
         within('.document-position-1') do
           expect(page).to have_css '.index_title', text: /Alpha Omega Alpha Archives, 1894-1992/
         end
@@ -112,6 +112,20 @@ RSpec.describe 'Field-based search results' do
       end
       within('.document-position-2') do
         expect(page).to have_css '.index_title', text: /Dr. Root and L. Raymond Higgins/
+      end
+    end
+
+    it '#container' do
+      visit search_catalog_path q: '"folder 12"', search_field: 'container'
+      within('.document-position-1') do
+        expect(page).to have_css '.index_title', text: /Amendments to articles of incorporation/
+      end
+    end
+
+    it '#identifer' do
+      visit search_catalog_path q: 'aoa271', search_field: 'identifier'
+      within('.document-position-1') do
+        expect(page).to have_css '.index_title', text: /Alpha Omega Alpha Archives/
       end
     end
   end

--- a/spec/features/grouped_results_spec.rb
+++ b/spec/features/grouped_results_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Grouped search results' do
       expect(page).to have_css('.al-document-extent.badge', count: 3)
     end
     within '.grouped-documents' do
-      expect(page).to have_css 'article', count: 1
+      expect(page).to have_css 'article', count: 2
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.describe 'Grouped search results' do
     expect(page).to have_css '.al-grouped-more', text: /Top 3 results/
     expect(page).to have_css(
       '.al-grouped-more a[href*="/catalog?f%5Bcollection%5D%5B%5D=Alpha+Omega+Alpha+Archives%2C+1894-1992"]',
-      text: 'view all 6'
+      text: 'view all 39'
     )
   end
 

--- a/spec/features/search_query_spec.rb
+++ b/spec/features/search_query_spec.rb
@@ -25,4 +25,48 @@ RSpec.describe 'Search queries' do
       end
     end
   end
+
+  describe 'default all fields search for' do
+    context 'EAD ID' do
+      it 'returns a collection with a matching EAD ID' do
+        visit search_catalog_path q: 'umich-bhl-851981', search_field: 'all_fields'
+        expect(page).to have_css '.index_title', text: /Interlochen Center for The Arts records/
+      end
+    end
+
+    context 'component ref ID' do
+      it 'returns a component with a matching ref' do
+        visit search_catalog_path q: 'aspace_563a320bb37d24a9e1e6f7bf95b52671', search_field: 'all_fields'
+        expect(page).to have_css '.index_title', text: /Series I: Administrative Records/
+      end
+    end
+
+    context 'component full ID (with eadid & ref)' do
+      it 'returns a component with a matching full ID' do
+        visit search_catalog_path q: 'aoa271_aspace_2d7e583e94eb2b46d5dd1a0ec4cdca1f', search_field: 'all_fields'
+        expect(page).to have_css '.index_title', text: /Dr. Root and L. Raymond Higgins/
+      end
+    end
+
+    context 'container' do
+      it 'returns a component with a matching container' do
+        visit search_catalog_path q: '"box 92"', search_field: 'all_fields'
+        expect(page).to have_css '.index_title', text: /Card index/
+      end
+    end
+
+    context 'language' do
+      it 'returns a component with a matching language' do
+        visit search_catalog_path q: 'english', search_field: 'all_fields'
+        expect(page).to have_css '.index_title', text: /Stanford University student life photograph album/
+      end
+    end
+
+    context 'terms appearing in different ancestor component titles' do
+      it 'returns a component where one term hit is only in its parent title' do
+        visit search_catalog_path q: 'administrative hippocrates', search_field: 'all_fields'
+        expect(page).to have_css '.index_title', text: /The constitution of the Alpha Omega/
+      end
+    end
+  end
 end


### PR DESCRIPTION
…guage, & ancestor component titles. Closes #894 & Advances #532.

- Adds Container & Identifier to search scope dropdown
- Adds parent component titles, language, containers, & identifiers into the default all-fields search
- TODO: more scoring boost refinement; this PR only gets these elements to be considered at all in queries