### PR TITLE
Display Related section at component level

### DIFF
--- a/app/components/arclight/document_component.html.erb
+++ b/app/components/arclight/document_component.html.erb
@@ -36,4 +36,6 @@
 </div>
 <% end %>
 
+<%= related %>
+
 <%= access %>

--- a/app/components/arclight/document_component.rb
+++ b/app/components/arclight/document_component.rb
@@ -38,6 +38,10 @@ module Arclight
       render (blacklight_config.show.access_component || Arclight::AccessComponent).new(presenter: presenter)
     end
 
+    def related
+      render (blacklight_config.show.related || Arclight::RelatedComponent).new(presenter: presenter)
+    end
+
     def toggle_sidebar
       button_tag(t('arclight.views.show.toggle_sidebar'),
                  type: :button,

--- a/app/components/arclight/related_component.html.erb
+++ b/app/components/arclight/related_component.html.erb
@@ -1,0 +1,14 @@
+
+<% related_content = capture do %>
+    <%= render Arclight::MetadataSectionComponent.with_collection(section_names,
+                metadata_attr: { layout: Arclight::UpperMetadataLayoutComponent },
+                presenter: presenter) %>
+  <% end %>
+  
+  <% if related_content.present? %>
+    <div id="<%= t('arclight.views.show.sections.related_field').parameterize %>">
+      <h2 class="al-show-sub-heading"><%= t 'arclight.views.show.sections.related_field' %></h2>
+  
+      <%= related_content %>
+    </div>
+  <% end %>

--- a/app/components/arclight/related_component.rb
+++ b/app/components/arclight/related_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Arclight
+  # Render "related" information for a document
+  class RelatedComponent < ViewComponent::Base
+    def initialize(presenter:)
+      super
+      @show_config = presenter.configuration.show
+      @presenter = presenter
+    end
+
+    attr_reader :presenter, :show_config
+
+    delegate :collection?, to: :presenter
+
+    # @return Array<Symbol> a list of metadata section names
+    def section_names
+      return Array(collection_related_items) if collection?
+
+      Array(component_related_items)
+    end
+
+    delegate :collection_related_items, :component_related_items, to: :show_config
+  end
+end

--- a/app/models/concerns/arclight/catalog.rb
+++ b/app/models/concerns/arclight/catalog.rb
@@ -26,6 +26,7 @@ module Arclight
       Blacklight::Configuration.define_field_access :cite_field, Blacklight::Configuration::ShowField
       Blacklight::Configuration.define_field_access :contact_field, Blacklight::Configuration::ShowField
       Blacklight::Configuration.define_field_access :component_field, Blacklight::Configuration::ShowField
+      Blacklight::Configuration.define_field_access :component_related_field, Blacklight::Configuration::ShowField
       Blacklight::Configuration.define_field_access :component_indexed_terms_field, Blacklight::Configuration::ShowField
       Blacklight::Configuration.define_field_access :terms_field, Blacklight::Configuration::ShowField
       Blacklight::Configuration.define_field_access :component_terms_field, Blacklight::Configuration::ShowField

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -77,6 +77,7 @@ class CatalogController < ApplicationController
     config.show.breadcrumb_component = Arclight::BreadcrumbsHierarchyComponent
     config.show.embed_component = Arclight::EmbedComponent
     config.show.access_component = Arclight::AccessComponent
+    config.show.related_component = Arclight::AccessComponent
     config.show.online_status_component = Arclight::OnlineStatusIndicatorComponent
     config.show.display_type_field = 'level_ssm'
     # config.show.thumbnail_field = 'thumbnail_path_ss'
@@ -106,6 +107,10 @@ class CatalogController < ApplicationController
       cite_field
       in_person_field
       contact_field
+    ]
+
+    config.show.component_related_items = %i[
+      component_related_field
     ]
 
     ##
@@ -300,9 +305,9 @@ class CatalogController < ApplicationController
     # Collection Show Page - Related Section
     config.add_related_field 'relatedmaterial', field: 'relatedmaterial_html_tesm', helper_method: :render_html_tags
     config.add_related_field 'separatedmaterial', field: 'separatedmaterial_html_tesm', helper_method: :render_html_tags
+    config.add_related_field 'originalsloc', field: 'originalsloc_html_tesm', helper_method: :render_html_tags
     config.add_related_field 'otherfindaid', field: 'otherfindaid_html_tesm', helper_method: :render_html_tags
     config.add_related_field 'altformavail', field: 'altformavail_html_tesm', helper_method: :render_html_tags
-    config.add_related_field 'originalsloc', field: 'originalsloc_html_tesm', helper_method: :render_html_tags
     config.add_related_field 'odd', field: 'odd_html_tesim', helper_method: :render_html_tags
 
     # Collection Show Page - Indexed Terms Section
@@ -372,6 +377,11 @@ class CatalogController < ApplicationController
       two_words_connector: '<br/>',
       last_word_connector: '<br/>'
     }
+
+    # Component Show Page - Related Section
+    config.add_component_related_field 'relatedmaterial', field: 'relatedmaterial_html_tesm', helper_method: :render_html_tags
+    config.add_component_related_field 'separatedmaterial', field: 'separatedmaterial_html_tesm', helper_method: :render_html_tags
+    config.add_component_related_field 'originalsloc', field: 'originalsloc_html_tesm', helper_method: :render_html_tags
 
     # =================
     # ACCESS TAB FIELDS

--- a/spec/features/collection_filtering_spec.rb
+++ b/spec/features/collection_filtering_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Collection filtering' do
       click_button 'Search'
 
       expect(page).to have_css('.constraint-value .filter-value', text: 'Alpha Omega Alpha Archives, 1894-1992')
-      expect(page).to have_css('.al-document-listings .document', count: 1) # has results
+      expect(page).to have_css('.al-document-listings .document', count: 2) # has results
     end
 
     it 'allows the user to choose to search all collections' do

--- a/spec/fixtures/ead/nlm/alphaomegaalpha.xml
+++ b/spec/fixtures/ead/nlm/alphaomegaalpha.xml
@@ -515,6 +515,24 @@
           </did>
         </c>
         <c id="aspace_e440da3c98ed7d64ef8179d56244f931" level="otherlevel">
+          <originalsloc>
+                <p>File contains photocopies of original still held by the donor.</p>
+          </originalsloc>
+          <separatedmaterial>
+            <p>Photographs and sound recordings have been transferred to the appropriate
+            custodial divisions of the Library where they are identified as part of these papers.
+            Among the sound recordings are the following broadcasts:</p>
+            <list>Example broadcast</list>
+          </separatedmaterial>
+          <separatedmaterial>
+            <p>Other papers of Alpha Omega, which relate chiefly to his early years
+            and public service in California, are held by the California State Archives in
+            Sacramento.</p>
+          </separatedmaterial>
+          <relatedmaterial>
+            <p>Records relating to the Alpha Omega Commission are held in the National
+            Archives and Records Administration.</p>
+          </relatedmaterial>
           <did>
             <unittitle>Constitution amendments - drafts,</unittitle>
             <unitdate>n.d.</unitdate>


### PR DESCRIPTION
Closes #1464

To be honest, I don't understand why it was necessary to add a whole new ViewComponent to achieve this. I had to follow the exact pattern that already existed for `AccessComponent` to get this to display as its own section at the (EAD) component level. Initially I was able display it as part of the upper metadata with much less code, but I wanted it to look similar to the top collection level display, which puts "Related" as its own section. 

Open to feedback on doing this in a simpler way! If this seems like the right approach, I can add some tests as well. 

Here is the result of this in the UI 
<img width="962" alt="Screenshot 2023-12-14 at 3 44 56 PM" src="https://github.com/projectblacklight/arclight/assets/1328900/6a24f106-6ca1-47b2-9cb3-9993853ba952">
