### PR TITLE
Draft: Don't load all hierarchical items at once when expanding the tree

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -26,6 +26,15 @@ $hierarchy-view-collapse-icon: url("data:image/svg+xml,<svg xmlns='http://www.w3
   background: $mark-bg;
 }
 
+li.collapse .al-hierarchy-more {
+  display: none;
+}
+
+li.collapse.show .al-hierarchy-more {
+  display: block;
+  margin-bottom: 5px;
+}
+
 #collection-context {
   ul {
     list-style: none;

--- a/app/components/arclight/document_components_hierarchy_component.html.erb
+++ b/app/components/arclight/document_components_hierarchy_component.html.erb
@@ -19,12 +19,14 @@
 <% elsif paginate? %>
   <%# render the first N documents, and let the user expand the remaining if desired %>
   <%= helpers.turbo_frame_tag "al-hierarchy-#{@document.id}-sidebar", loading: ('lazy' unless @target_index >= 0), src: hierarchy_path(limit: @maximum_left_gap, key: '-sidebar') %>
-  <%= tag.turbo_frame id: "al-hierarchy-#{@document.id}-right" do %>
-    <ul>
-      <li>
-        <%= link_to t('arclight.views.show.expand'), hierarchy_path(offset: @maximum_left_gap, key: '-right'), class: 'btn btn-secondary btn-sm' %>
-      </li>
-    </ul>
+  <% num_pages.each do |page| %>
+    <%= tag.turbo_frame id: "al-hierarchy-#{@document.id}-right", class: "al-hierarchy-more" do %>
+      <ul>
+        <li>
+          <%= link_to "\"#{@document.normalized_title.truncate(25, seperator: ' ')}\" Items #{more_text(page)}", hierarchy_path(offset: get_offset(page), limit: @maximum_left_gap, key: '-right'), class: 'btn btn-secondary btn-sm' %>
+        </li>
+      </ul>
+    <% end %>
   <% end %>
 <% else %>
   <%# there aren't enough to bother paginating, so load them all at once %>

--- a/app/components/arclight/document_components_hierarchy_component.rb
+++ b/app/components/arclight/document_components_hierarchy_component.rb
@@ -4,8 +4,8 @@ module Arclight
   # Display a document's constituent components with appropriate lazy-loading
   # to keep the page load time reasonable.
   class DocumentComponentsHierarchyComponent < ViewComponent::Base
-    # rubocop:disable Metrics/ParameterLists
-    def initialize(document: nil, target_index: -1, minimum_pagination_size: 20, left_outer_window: 3, maximum_left_gap: 10, window: 10)
+   # rubocop:disable Metrics/ParameterLists
+    def initialize(document: nil, target_index: -1, minimum_pagination_size: 200, left_outer_window: 30, maximum_left_gap: 100, window: 100)
       super
 
       @document = document
@@ -19,6 +19,26 @@ module Arclight
 
     def paginate?
       @document.number_of_children > @minimum_pagination_size
+    end
+
+    def num_pages
+      number_of_pages = (@document.number_of_children / @maximum_left_gap.to_f).round
+      (1..number_of_pages).to_a
+    end
+
+    def get_offset(page)
+      page * @maximum_left_gap
+    end
+
+    def more_text(page)
+      offset = get_offset(page)
+      last_item = offset + (@maximum_left_gap - 1)
+
+      if page == num_pages.last
+        last_item = @document.number_of_children
+      end
+
+      "#{offset + 1} to #{last_item}"
     end
 
     def hierarchy_path(**kwargs)


### PR DESCRIPTION
This should work to speed up loading of large sibling lists. It essentially paginates the results. It bumps up the results size from 10 to 100 and adds a button for every subsequent 100 items with a truncated document title as part of the button display for navigation context. This can result in a LOT of buttons for REALLY long lists

<img width="330" alt="Screen Shot 2023-12-14 at 3 41 37 PM" src="https://github.com/projectblacklight/arclight/assets/436691/c91d8cee-9211-4ff8-b356-8bc6a4114f8c">


I'm not sure it's a great idea to do it this way, but if folks think it's worth pursuing. I can continue down this path.