### PR TITLE
Preserve Unitdate Order

### DIFF
--- a/lib/arclight/traject/ead2_component_config.rb
+++ b/lib/arclight/traject/ead2_component_config.rb
@@ -107,15 +107,17 @@ to_field 'title_filing_ssi', extract_xpath('./did/unittitle'), first_only
 to_field 'title_ssm', extract_xpath('./did/unittitle')
 to_field 'title_tesim', extract_xpath('./did/unittitle')
 
-to_field 'unitdate_bulk_ssim', extract_xpath('./did/unitdate[@type="bulk"]')
-to_field 'unitdate_inclusive_ssm', extract_xpath('./did/unitdate[@type="inclusive"]')
-to_field 'unitdate_other_ssim', extract_xpath('./did/unitdate[not(@type)]')
+to_field 'unitdates_ssm', extract_xpath('/ead/archdesc/did/unitdate')
+to_field 'unitdates_labels_ssm' do |record, accumulator|
+  record.xpath('/ead/archdesc/did/unitdate').each do |unitdate|
+    accumulator << unitdate.attribute('type')&.value
+  end
+end
 
 to_field 'normalized_date_ssm' do |_record, accumulator, context|
   accumulator << settings['date_normalizer'].constantize.new(
-    context.output_hash['unitdate_inclusive_ssm'],
-    context.output_hash['unitdate_bulk_ssim'],
-    context.output_hash['unitdate_other_ssim']
+    context.output_hash['unitdates_ssm'],
+    context.output_hash['unitdates_labels_ssm']
   ).to_s
 end
 

--- a/lib/arclight/traject/ead2_component_config.rb
+++ b/lib/arclight/traject/ead2_component_config.rb
@@ -107,10 +107,14 @@ to_field 'title_filing_ssi', extract_xpath('./did/unittitle'), first_only
 to_field 'title_ssm', extract_xpath('./did/unittitle')
 to_field 'title_tesim', extract_xpath('./did/unittitle')
 
-to_field 'unitdates_ssm', extract_xpath('/ead/archdesc/did/unitdate')
+to_field 'unitdates_ssm', extract_xpath('./did/unitdate')
 to_field 'unitdates_labels_ssm' do |record, accumulator|
-  record.xpath('/ead/archdesc/did/unitdate').each do |unitdate|
-    accumulator << unitdate.attribute('type')&.value
+  record.xpath('.//did/unitdate').each do |unitdate|
+    if unitdate.attribute('type')
+      accumulator << unitdate.attribute('type')&.value
+    else
+      accumulator << ""
+    end
   end
 end
 

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -80,10 +80,12 @@ to_field 'title_ssm', extract_xpath('/ead/archdesc/did/unittitle')
 to_field 'title_tesim', extract_xpath('/ead/archdesc/did/unittitle')
 to_field 'ead_ssi', extract_xpath('/ead/eadheader/eadid')
 
-to_field 'unitdate_ssm', extract_xpath('/ead/archdesc/did/unitdate')
-to_field 'unitdate_bulk_ssim', extract_xpath('/ead/archdesc/did/unitdate[@type="bulk"]')
-to_field 'unitdate_inclusive_ssm', extract_xpath('/ead/archdesc/did/unitdate[@type="inclusive"]')
-to_field 'unitdate_other_ssim', extract_xpath('/ead/archdesc/did/unitdate[not(@type)]')
+to_field 'unitdates_ssm', extract_xpath('/ead/archdesc/did/unitdate')
+to_field 'unitdates_labels_ssm' do |record, accumulator|
+  record.xpath('/ead/archdesc/did/unitdate').each do |unitdate|
+    accumulator << unitdate.attribute('type')&.value
+  end
+end
 
 # All top-level docs treated as 'collection' for routing / display purposes
 to_field 'level_ssm' do |_record, accumulator|
@@ -104,9 +106,8 @@ to_field 'unitid_tesim', extract_xpath('/ead/archdesc/did/unitid')
 
 to_field 'normalized_date_ssm' do |_record, accumulator, context|
   accumulator << settings['date_normalizer'].constantize.new(
-    context.output_hash['unitdate_inclusive_ssm'],
-    context.output_hash['unitdate_bulk_ssim'],
-    context.output_hash['unitdate_other_ssim']
+    context.output_hash['unitdates_ssm'],
+    context.output_hash['unitdates_labels_ssm']
   ).to_s
 end
 

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -83,7 +83,11 @@ to_field 'ead_ssi', extract_xpath('/ead/eadheader/eadid')
 to_field 'unitdates_ssm', extract_xpath('/ead/archdesc/did/unitdate')
 to_field 'unitdates_labels_ssm' do |record, accumulator|
   record.xpath('/ead/archdesc/did/unitdate').each do |unitdate|
-    accumulator << unitdate.attribute('type')&.value
+    if unitdate.attribute('type')
+      accumulator << unitdate.attribute('type')&.value
+    else
+      accumulator << ""
+    end
   end
 end
 

--- a/spec/fixtures/ead/nlm/alphaomegaalpha.xml
+++ b/spec/fixtures/ead/nlm/alphaomegaalpha.xml
@@ -56,7 +56,9 @@
         <physfacet>Compact digital disc</physfacet>
         <extent altrender="materialtype spaceoccupied">3 CDs</extent>
       </physdesc>
+      <unitdate normal="1888">1888</unitdate>
       <unitdate normal="1894/1992" type="inclusive">1894-1992</unitdate>
+      <unitdate normal="1903/1962" type="bulk">1903-1962</unitdate>
       <langmaterial id="aspace_1cf405d4520ad390ab7b5532eab3ea00">Collection materials primarily in
           <language langcode="eng">English.</language></langmaterial>
       <abstract id="aspace_3dcd45a7a2d2d0a1568d71906a03a4c1">
@@ -392,6 +394,7 @@
           <unitid>MS C 271.I</unitid>
           <unitdate normal="1902/1976" type="inclusive">1902-1976</unitdate>
           <unitdate normal="1902/1976" type="bulk">1975-1976</unitdate>
+          <unitdate normal="1988">1988</unitdate>
         </did>
         <scopecontent id="aspace_00d4328c32ed5e54eac5c662aa45245a">
           <p>Administrative records include details materials directly related to the history and

--- a/spec/lib/arclight/normalized_date_spec.rb
+++ b/spec/lib/arclight/normalized_date_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Arclight::NormalizedDate do
   subject(:normalized_date) { described_class.new(unitdates, unitdate_labels).to_s }
 
   let(:unitdates) { ['1905', '1927-2000', '1982-1995'] }
-  let(:unitdate_labels) { '', 'inclusive', 'bulk' }
+  let(:unitdate_labels) { ['', 'inclusive', 'bulk'] }
 
   context 'under normal conditions' do
     it 'joins dates' do
@@ -27,8 +27,8 @@ RSpec.describe Arclight::NormalizedDate do
     # NOTE: This test is the only place where the code that exercises this is routable
     # This has to be a multidimensional array, and the resulting XML nodes sent in are always flat
     context 'multiples' do
-      let(:unitdates) { [%w[1990-2000 2001-2002 2004 1990-2004]] }
-      let(:unitdate_labels) { [%w[inclusive inclusive INCLUSIVE bulk] }
+      let(:unitdates) { ['1990-2000', '2001-2002', '2004', '1990-2004'] }
+      let(:unitdate_labels) { ['inclusive', 'inclusive', 'INCLUSIVE', 'bulk'] }
 
       it 'uses compressed joined years' do
         expect(normalized_date).to eq '1990-2000, 2001-2002, 2004, bulk 1990-2004'
@@ -43,12 +43,12 @@ RSpec.describe Arclight::NormalizedDate do
       end
     end
 
-    context 'circa' do
+    context 'circa and mixed case' do
       let(:unitdates) { ['1990-2000', 'c.1995'] }
-      let(:unitdate_labels) { ['', 'bulk'] }
+      let(:unitdate_labels) { ['', 'BuLk'] }
 
       it 'do not normalized term "circa"' do
-        expect(normalized_date).to eq '1990-2000, bulk c.1995'
+        expect(normalized_date).to eq '1990-2000, BuLk c.1995'
       end
     end
 
@@ -83,7 +83,7 @@ RSpec.describe Arclight::NormalizedDate do
       let(:unitdate_labels) { nil }
 
       it 'does not know what to do' do
-        expect(normalized_date).to be_nil
+        expect(normalized_date).to eq ''
       end
     end
   end


### PR DESCRIPTION
This simplifies how Arclight handles `<unitdate>`s for both collections and components per the approach in #1028 comments.

Arclight now stores a list of unitdates in `unitdates_ssm` and a corresponding list of type labels in `unitdates_labels_ssm`. Labels only display for `@type="bulk"`. The order of `<unitdate>` elements in the EAD is preserved.

This does simply how Arclight handles unitdates and more just displays what's in the EAD where before it had some more logic. I think this is generally a good approach, and covers the all the use cases I can think of, but I'm not totally sure it replicates existing functionality 100%. There is some [logic here in particular](https://github.com/projectblacklight/arclight/blob/91420125acc80381502a8b0996b39b931f3bf4aa/lib/arclight/normalized_date.rb#L13-L17) that I wasn't sure what it was doing.