### PR TITLE
Fixes missing _html_tesm fields and <notes>

### DIFF
--- a/lib/arclight/traject/ead2_component_config.rb
+++ b/lib/arclight/traject/ead2_component_config.rb
@@ -61,6 +61,7 @@ DID_SEARCHABLE_NOTES_FIELDS = %w[
   abstract
   materialspec
   physloc
+  note
 ].freeze
 
 # ==================
@@ -306,7 +307,6 @@ end
 DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_html_tesm", extract_xpath("./did/#{selector}", to_text: false)
 end
-to_field 'did_note_ssm', extract_xpath('./did/note')
 
 # =============================
 # Each component child document

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -48,6 +48,7 @@ DID_SEARCHABLE_NOTES_FIELDS = %w[
   abstract
   materialspec
   physloc
+  note
 ].freeze
 
 settings do
@@ -240,7 +241,6 @@ end
 DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_html_tesm", extract_xpath("/ead/archdesc/did/#{selector}", to_text: false)
 end
-to_field 'did_note_ssm', extract_xpath('ead/archdesc/did/note')
 
 NAME_ELEMENTS.map do |selector|
   to_field 'names_coll_ssim', extract_xpath("/ead/archdesc/controlaccess/#{selector}")

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -240,6 +240,7 @@ end
 DID_SEARCHABLE_NOTES_FIELDS.map do |selector|
   to_field "#{selector}_html_tesm", extract_xpath("/ead/archdesc/did/#{selector}", to_text: false)
 end
+to_field 'did_note_ssm', extract_xpath('ead/archdesc/did/note')
 
 NAME_ELEMENTS.map do |selector|
   to_field 'names_coll_ssim', extract_xpath("/ead/archdesc/controlaccess/#{selector}")

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -300,7 +300,6 @@ class CatalogController < ApplicationController
     config.add_background_field 'fileplan', field: 'fileplan_html_tesm', helper_method: :render_html_tags
     config.add_background_field 'descrules', field: 'descrules_ssm', helper_method: :render_html_tags
     config.add_background_field 'note', field: 'note_html_tesm', helper_method: :render_html_tags
-    config.add_background_field 'did_note', field: 'did_note_ssm', helper_method: :render_html_tags
 
     # Collection Show Page - Related Section
     config.add_related_field 'relatedmaterial', field: 'relatedmaterial_html_tesm', helper_method: :render_html_tags
@@ -368,7 +367,6 @@ class CatalogController < ApplicationController
     config.add_component_field 'separatedmaterial', field: 'separatedmaterial_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'originalsloc', field: 'originalsloc_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'note', field: 'note_html_tesm', helper_method: :render_html_tags
-    config.add_component_field 'did_note', field: 'did_note_ssm', helper_method: :render_html_tags
   
     # Component Show Page - Indexed Terms Section
     config.add_component_indexed_terms_field 'access_subjects', field: 'access_subjects_ssim', link_to_facet: true, separator_options: {

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -296,9 +296,11 @@ class CatalogController < ApplicationController
     config.add_background_field 'physdesc', field: 'physdesc_tesim', helper_method: :render_html_tags
     config.add_background_field 'physfacet', field: 'physfacet_tesim', helper_method: :render_html_tags
     config.add_background_field 'dimensions', field: 'dimensions_tesim', helper_method: :render_html_tags
-    config.add_background_field 'materialspec', field: 'materialspec_tesim', helper_method: :render_html_tags
-    config.add_background_field 'fileplan', field: 'fileplan_html_tesim', helper_method: :render_html_tags
+    config.add_background_field 'materialspec', field: 'materialspec_html_tesm', helper_method: :render_html_tags
+    config.add_background_field 'fileplan', field: 'fileplan_html_tesm', helper_method: :render_html_tags
     config.add_background_field 'descrules', field: 'descrules_ssm', helper_method: :render_html_tags
+    config.add_background_field 'note', field: 'note_html_tesm', helper_method: :render_html_tags
+    config.add_background_field 'did_note', field: 'did_note_ssm', helper_method: :render_html_tags
 
     # Collection Show Page - Related Section
     config.add_related_field 'relatedmaterial', field: 'relatedmaterial_html_tesm', helper_method: :render_html_tags
@@ -353,18 +355,20 @@ class CatalogController < ApplicationController
     config.add_component_field 'arrangement', field: 'arrangement_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'accruals', field: 'accruals_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'phystech', field: 'phystech_html_tesm', helper_method: :render_html_tags
-    config.add_component_field 'materialspec', field: 'materialspec_tesim', helper_method: :render_html_tags
+    config.add_component_field 'materialspec', field: 'materialspec_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'physloc', field: 'physloc_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'physdesc', field: 'physdesc_tesim', helper_method: :render_html_tags
     config.add_component_field 'physfacet', field: 'physfacet_tesim', helper_method: :render_html_tags
     config.add_component_field 'dimensions', field: 'dimensions_tesim', helper_method: :render_html_tags
-    config.add_component_field 'fileplan', field: 'fileplan_html_tesim', helper_method: :render_html_tags
-    config.add_component_field 'altformavail', field: 'altformavail_html_tesim', helper_method: :render_html_tags
+    config.add_component_field 'fileplan', field: 'fileplan_html_tesm', helper_method: :render_html_tags
+    config.add_component_field 'altformavail', field: 'altformavail_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'otherfindaid', field: 'otherfindaid_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'odd', field: 'odd_html_tesim', helper_method: :render_html_tags
     config.add_component_field 'relatedmaterial', field: 'relatedmaterial_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'separatedmaterial', field: 'separatedmaterial_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'originalsloc', field: 'originalsloc_html_tesm', helper_method: :render_html_tags
+    config.add_component_field 'note', field: 'note_html_tesm', helper_method: :render_html_tags
+    config.add_component_field 'did_note', field: 'did_note_ssm', helper_method: :render_html_tags
   
     # Component Show Page - Indexed Terms Section
     config.add_component_indexed_terms_field 'access_subjects', field: 'access_subjects_ssim', link_to_facet: true, separator_options: {

--- a/lib/generators/arclight/templates/config/locales/arclight.en.yml
+++ b/lib/generators/arclight/templates/config/locales/arclight.en.yml
@@ -32,6 +32,8 @@ en:
         materialspec: Material specific details
         fileplan: File plan
         odd: Other descriptive data
+        note: Note
+        did_note: Note
 
         access_subjects: Subjects
         names_coll: Names

--- a/spec/fixtures/ead/nlm/alphaomegaalpha.xml
+++ b/spec/fixtures/ead/nlm/alphaomegaalpha.xml
@@ -818,6 +818,9 @@
           <unitdate normal="1902/1973" type="inclusive">1902-1973</unitdate>
           <abstract id="aspace_e806089c6553f2132b727ead99b47a70">Contains a mixture of membership
             cards and membership rosters.</abstract>
+          <note>
+              <p>For more information, please contact us.</p>
+          </note>
         </did>
       </c>
       <c id="aspace_d5765d98e333f83b6278c00e9a81f31f" level="series">

--- a/spec/fixtures/ead/sul-spec/a0011.xml
+++ b/spec/fixtures/ead/sul-spec/a0011.xml
@@ -147,6 +147,9 @@
                 here: http://purl.stanford.edu/kc844kt2526
             </p>
         </altformavail>
+        <note>
+          <p>For more information, please contact us.</p>
+        </note>
         <controlaccess>
             <genreform source="aat">Photoprints.</genreform>
             <geogname source="lcsh">Yosemite National Park (Calif.)


### PR DESCRIPTION
Now displays component fields correctly, which Closes #1451, Closes #1450, and Closes #1459. They all now display at
 - [http://localhost:3000/catalog/pc0170-xml_aspace_ref5_edi](http://localhost:3000/catalog/pc0170-xml_aspace_ref5_edi)
 - [http://localhost:3000/catalog/umich-bhl-851981_aspace_7a47b946a5107eb56d93ef0cd069d568](http://localhost:3000/catalog/umich-bhl-851981_aspace_7a47b946a5107eb56d93ef0cd069d568).
 - [http://localhost:3000/catalog/pc0170-xml_aspace_6a6648be46e57d220d1f4f6d07316570](http://localhost:3000/catalog/pc0170-xml_aspace_6a6648be46e57d220d1f4f6d07316570)

This also handles many `<note>` elements both inside and and outside of collection and component `<did>` elements, which Closes #1467