### PR TITLE
Adds creator field for components

### DIFF
--- a/lib/arclight/traject/ead2_component_config.rb
+++ b/lib/arclight/traject/ead2_component_config.rb
@@ -202,9 +202,7 @@ to_field 'dimensions_tesim', extract_xpath('./did/physdesc/dimensions')
 to_field 'indexes_html_tesm', extract_xpath('./index', to_text: false)
 to_field 'indexes_tesim', extract_xpath('./index')
 
-to_field 'creator_ssm', extract_xpath('./did/origination')
 to_field 'creator_ssim', extract_xpath('./did/origination')
-to_field 'creators_ssim', extract_xpath('./did/origination')
 to_field 'creator_sort' do |record, accumulator|
   accumulator << record.xpath('./did/origination').map(&:text).join(', ')
 end

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -276,7 +276,7 @@ class CatalogController < ApplicationController
     # ===========================
 
     # Collection Show Page - Summary Section
-    config.add_summary_field 'creators', field: 'creators_ssim', link_to_facet: true
+    config.add_summary_field 'creators', field: 'creator_ssim', link_to_facet: true
     config.add_summary_field 'abstract', field: 'abstract_html_tesm', helper_method: :render_html_tags
     config.add_summary_field 'extent', field: 'extent_ssm'
     config.add_summary_field 'language', field: 'language_ssim'
@@ -342,6 +342,7 @@ class CatalogController < ApplicationController
     }, if: lambda { |_context, _field_config, document|
       document.containers.present?
     }
+    config.add_component_field 'creators', field: 'creator_ssim', link_to_facet: true
     config.add_component_field 'abstract', field: 'abstract_html_tesm', helper_method: :render_html_tags
     config.add_component_field 'extent', field: 'extent_ssm'
     config.add_component_field 'scopecontent', field: 'scopecontent_html_tesm', helper_method: :render_html_tags


### PR DESCRIPTION
Creator field now displays for components such as [http://localhost:3000/catalog/aoa271_aspace_843e8f9f22bac69872d0802d6fffbb04](http://localhost:3000/catalog/aoa271_aspace_843e8f9f22bac69872d0802d6fffbb04).

Closes #1432

Also removes redundant `creator_ssim` and `creators_ssim` for components.