### PR TITLE
Return nil instead of an empty string from normalized_date

### DIFF
--- a/lib/arclight/normalized_date.rb
+++ b/lib/arclight/normalized_date.rb
@@ -43,7 +43,7 @@ module Arclight
       result << inclusive if inclusive.present?
       result << other if other.present?
       result << "bulk #{bulk}" if bulk.present?
-      result.compact.map(&:strip).join(', ')
+      result.compact.map(&:strip).join(', ').presence
     end
   end
 end

--- a/spec/lib/arclight/normalized_date_spec.rb
+++ b/spec/lib/arclight/normalized_date_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Arclight::NormalizedDate do
       let(:date_other) { nil }
 
       it 'does not know what to do' do
-        expect(normalized_date).to eq ''
+        expect(normalized_date).to be_nil
       end
     end
   end


### PR DESCRIPTION
ArcLight 1.1 is indexing empty strings in `normalized_date_ssm` if the normalization process results in no normalized values for any of the various date types. The downstream effect is the UI displays labels without values where the `normalized_date_ssm` field is configured to display. 

Changes to date normalization changed this behavior (and the test) here: https://github.com/projectblacklight/arclight/pull/1486/commits/3eb358b20466c52a69df3d585f20fc42bf6369de

Before this change:
<img width="868" alt="Screenshot 2024-03-12 at 2 59 54 PM" src="https://github.com/projectblacklight/arclight/assets/458247/c014d86b-f40b-42be-b060-69b73e6ad87e">


After this change:
<img width="865" alt="Screenshot 2024-03-12 at 3 00 25 PM" src="https://github.com/projectblacklight/arclight/assets/458247/c0ac17f5-839b-4748-99da-0eb4c81cd123">
