### PR TITLE
Bugfix: increase navbar z-index so autosuggest options appear over ac…

### DIFF
--- a/app/assets/stylesheets/arclight/modules/mastheads.scss
+++ b/app/assets/stylesheets/arclight/modules/mastheads.scss
@@ -1,4 +1,5 @@
 .navbar-search {
+  z-index: 10;
   .search-query-form {
     max-width: 100% !important;   // work around blacklight styles
     display: flex;


### PR DESCRIPTION
…tive group toggle. Fixes #1518.

### Rationale
The `.navbar-search` is currently getting a `z-index: 1` from upstream blacklight here:
https://github.com/projectblacklight/blacklight/blob/main/app/assets/stylesheets/blacklight/_header.scss#L25

That ties the `z-index: 1` set on the active elements in the `search-widgets` section, and because those appear later they take precedence.
<img width="532" alt="Screenshot 2024-03-13 at 4 15 24 PM" src="https://github.com/projectblacklight/arclight/assets/3933756/f06046d7-3621-4e90-8cfb-c2bf6c7879d3">
<img width="533" alt="Screenshot 2024-03-13 at 4 15 16 PM" src="https://github.com/projectblacklight/arclight/assets/3933756/7e2160dd-52a9-44f0-be12-233fe6dcda82">

