### PR TITLE
Allow breadcrumbs to fallback and function with :parent_ssim

### DIFF
--- a/app/models/arclight/parent.rb
+++ b/app/models/arclight/parent.rb
@@ -7,6 +7,9 @@ module Arclight
   class Parent
     attr_reader :id, :label, :eadid, :level
 
+    alias global_id id
+    Arclight.deprecation.deprecate_methods(self, global_id: 'Call `id` instead')
+
     def initialize(id:, label:, eadid:, level:)
       @id = id
       @label = label

--- a/app/models/arclight/parents.rb
+++ b/app/models/arclight/parents.rb
@@ -5,10 +5,11 @@ module Arclight
   # Object for parsing and formalizing Solr_Ead "Parents"
   # https://github.com/awead/solr_ead/blob/8cf7ffaa66e0e4c9c0b12f5646d6c2e20984cd99/lib/solr_ead/behaviors.rb#L54-L57
   class Parents
-    attr_reader :ids, :labels, :levels
+    attr_reader :ids, :legacy_ids, :labels, :levels
 
-    def initialize(ids:, labels:, eadid:, levels:)
+    def initialize(ids:, legacy_ids:, labels:, eadid:, levels:)
       @ids = ids
+      @legacy_ids = legacy_ids
       @labels = labels
       @eadid = eadid
       @levels = levels
@@ -21,17 +22,18 @@ module Arclight
     ##
     # @return [Array[Arclight::Parent]]
     def as_parents
-      ids.map.with_index { |id, idx| Arclight::Parent.new(id: id, label: labels[idx], eadid: eadid, level: levels[idx]) }
+      (ids.presence || legacy_ids).map.with_index { |id, idx| Arclight::Parent.new(id: id, label: labels[idx], eadid: eadid, level: levels[idx]) }
     end
 
     ##
     # @param [SolrDocument] document
     def self.from_solr_document(document)
       ids = document.parent_ids
+      legacy_ids = document.legacy_parent_ids.map { |legacy_id| document.eadid == legacy_id ? legacy_id : "#{document.eadid}#{legacy_id}" }
       labels = document.parent_labels
       eadid = document.eadid
       levels = document.parent_levels
-      new(ids: ids, labels: labels, eadid: eadid, levels: levels)
+      new(ids: ids, legacy_ids: legacy_ids, labels: labels, eadid: eadid, levels: levels)
     end
   end
 end

--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -8,6 +8,8 @@ module Arclight
 
     included do
       attribute :parent_ids, :array, 'parent_ids_ssim'
+      attribute :legacy_parent_ids, :array, 'parent_ssim'
+      Arclight.deprecation.deprecate_methods(self, legacy_parent_ids: 'Use `parent_ids` instead')
       attribute :parent_labels, :array, 'parent_unittitles_ssm'
       attribute :parent_levels, :array, 'parent_levels_ssm'
       attribute :unitid, :string, 'unitid_ssm'

--- a/spec/components/arclight/breadcrumb_component_spec.rb
+++ b/spec/components/arclight/breadcrumb_component_spec.rb
@@ -55,4 +55,22 @@ RSpec.describe Arclight::BreadcrumbComponent, type: :component do
     expect(rendered).to have_link 'DEF', href: '/catalog/abc123_def'
     expect(rendered).to have_link 'GHI', href: '/catalog/abc123_ghi'
   end
+
+  context 'with legacy parent_ssm data' do
+    let(:legacy_document) do
+      SolrDocument.new(
+        parent_ssim: %w[abc123 def ghi],
+        parent_unittitles_ssm: %w[ABC123 DEF GHI],
+        ead_ssi: 'abc123',
+        repository_ssm: 'my repository'
+      )
+    end
+
+    let(:component) { described_class.new(document: legacy_document, **attr) }
+
+    it 'renders breadcrumb links' do
+      expect(rendered).to have_link 'DEF', href: '/catalog/abc123def'
+      expect(rendered).to have_link 'GHI', href: '/catalog/abc123ghi'
+    end
+  end
 end

--- a/spec/models/arclight/parents_spec.rb
+++ b/spec/models/arclight/parents_spec.rb
@@ -12,6 +12,15 @@ RSpec.describe Arclight::Parents do
     )
   end
 
+  let(:legacy_parent_ids_doc) do
+    SolrDocument.new(
+      parent_ssim: %w[abc123 def ghi],
+      parent_unittitles_ssm: %w[ABC123 DEF GHI],
+      ead_ssi: 'abc123',
+      parent_levels_ssm: %w[collection]
+    )
+  end
+
   let(:dot_eadid_doc) do
     SolrDocument.new(
       parent_ids_ssim: %w[abc123-xml abc123-xml_def abc123-xml_ghi],
@@ -24,6 +33,7 @@ RSpec.describe Arclight::Parents do
   let(:empty_document) { SolrDocument.new }
   let(:good_instance) { described_class.from_solr_document(document) }
   let(:dot_eadid_instance) { described_class.from_solr_document(dot_eadid_doc) }
+  let(:legacy_parent_ids_instance) { described_class.from_solr_document(legacy_parent_ids_doc) }
 
   describe '.from_solr_document' do
     context 'with good data' do
@@ -33,6 +43,7 @@ RSpec.describe Arclight::Parents do
 
       it 'values are appropriately set' do
         expect(good_instance.ids).to eq %w[abc123 abc123_def abc123_ghi]
+        expect(good_instance.legacy_ids).to be_empty
         expect(good_instance.labels).to eq %w[ABC123 DEF GHI]
         expect(good_instance.eadid).to eq 'abc123'
         expect(good_instance.levels).to eq %w[collection]
@@ -40,6 +51,13 @@ RSpec.describe Arclight::Parents do
 
       it 'cleans up the eadid properly by replacing dots with dashes' do
         expect(dot_eadid_instance.eadid).to eq 'abc123-xml'
+      end
+    end
+
+    context 'with legacy parent_ssim data' do
+      it 'id values are appropriately set' do
+        expect(legacy_parent_ids_instance.ids).to be_empty
+        expect(legacy_parent_ids_instance.legacy_ids).to eq %w[abc123 abc123def abc123ghi]
       end
     end
 
@@ -72,9 +90,16 @@ RSpec.describe Arclight::Parents do
       end
     end
 
+    context 'with legacy parent_ssim data' do
+      it 'the containing parents have the correct data' do
+        expect(legacy_parent_ids_instance.as_parents.first.id).to eq 'abc123'
+        expect(legacy_parent_ids_instance.as_parents.last.id).to eq 'abc123ghi'
+      end
+    end
+
     context 'with no data' do
       it 'returns an empty array' do
-        expect(described_class.new(ids: [], labels: [], eadid: '', levels: '').as_parents).to eq []
+        expect(described_class.new(ids: [], legacy_ids: [], labels: [], eadid: '', levels: '').as_parents).to eq []
       end
     end
   end

--- a/spec/models/concerns/arclight/solr_document_spec.rb
+++ b/spec/models/concerns/arclight/solr_document_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Arclight::SolrDocument do
   let(:document) { SolrDocument.new(id: '123') }
 
   describe 'custom accessors' do
+    it { expect(document).to respond_to(:legacy_parent_ids) }
     it { expect(document).to respond_to(:parent_ids) }
     it { expect(document).to respond_to(:parent_labels) }
     it { expect(document).to respond_to(:eadid) }


### PR DESCRIPTION
In Arclight 1.1 the `parent_ids` attribute was modified and mapped to a new field `:parent_ids_ssim` from `:parent_ssim`. This breaks breadcrumbs unless an index created with 1.0 or earlier is recreated with 1.1. I propose we allow breadcrumbs to work with either `:parents_ssim` or `parent_ids_ssim` and remove the backwards compatibility with `:parents_ssim` in version 2.