### PR TITLE
Sort collections by title on repository page

### DIFF
--- a/app/controllers/arclight/repositories_controller.rb
+++ b/app/controllers/arclight/repositories_controller.rb
@@ -13,6 +13,7 @@ module Arclight
       search_service = Blacklight.repository_class.new(blacklight_config)
       @response = search_service.search(
         q: "level_ssim:Collection repository_ssim:\"#{@repository.name}\"",
+        sort: 'title_sort asc',
         rows: 100
       )
       @collections = @response.documents


### PR DESCRIPTION
While looking at https://github.com/sul-dlss/stanford-arclight/issues/429 we have been looking at how the repository page is sorted by default.

What do folks think about sorting that page using the default title sort field? I think it improves that page, but I'd also understand not wanting to tie it to specific configuration.