### PR TITLE
Add unitid_identifier_match to qf_identifier and pf_identifier

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -142,12 +142,14 @@
          ead_ssi
          ref_ssm
          unitid_ssm
+         unitid_identifier_match
        </str>
        <str name="pf_identifier">
          id^2
          ead_ssi^2
          ref_ssm^2
          unitid_ssm^2
+         unitid_identifier_match^2
        </str>
        <str name="qf_name">
          name_teim


### PR DESCRIPTION
The `unitid_identifier_match` field was added here https://github.com/projectblacklight/arclight/commit/91703d3b7567aaca187ac486eb772c2741315800 to improve identifier searching but was not added to the set of fields searched by the `qf_identifier` and `pf_identifier` field sets.

This PR adds `unitid_identifier_match` to those field sets.

`unitid_identifier_match` is already present in the all fields search field sets (the default set of `qf` and `pf` fields).