### PR TITLE
Scoped repository searching

### DIFF
--- a/app/components/arclight/search_bar_component.html.erb
+++ b/app/components/arclight/search_bar_component.html.erb
@@ -9,7 +9,13 @@
       <label class="input-group-text" for="within_collection">
         <%= t('arclight.within_collection_dropdown.label_html') %>
       </label>
-      <%= select_tag ('f[collection][]' if collection_name.present?), within_collection_options, id: 'within_collection', class: 'form-select search-field rounded-end' %>
+      <% if collection_name.present? %>
+        <%= select_tag 'f[collection][]', within_collection_options, id: 'within_collection', class: 'form-select search-field rounded-end' %>
+      <% elsif repository_name.present? %>
+        <%= select_tag 'f[repository][]', within_collection_options, id: 'within_collection', class: 'form-select search-field rounded-end' %>
+      <% else %>
+        <%= select_tag ('f[collection][]' if collection_name.present?), within_collection_options, id: 'within_collection', class: 'form-select search-field rounded-end' %>
+      <% end %>
     </div>
   <% end %>
 

--- a/app/components/arclight/search_bar_component.rb
+++ b/app/components/arclight/search_bar_component.rb
@@ -13,13 +13,17 @@ module Arclight
     end
 
     def within_collection_options
-      value = collection_name || 'none-selected'
+      all_collections_option = [t('arclight.within_collection_dropdown.all_collections'), '']
+      this_collection_option = [t('arclight.within_collection_dropdown.this_collection'), collection_name || 'none-selected']
+      this_repository_option = [t('arclight.within_collection_dropdown.this_repository'), repository_name].compact
+
+      options = [all_collections_option]
+      options << this_collection_option if collection_name.present?
+      options << this_repository_option if repository_name.present?
+
       options_for_select(
-        [
-          [t('arclight.within_collection_dropdown.all_collections'), ''],
-          [t('arclight.within_collection_dropdown.this_collection'), value]
-        ],
-        selected: collection_name,
+        options,
+        selected: selected_option(options),
         disabled: 'none-selected'
       )
     end
@@ -27,6 +31,18 @@ module Arclight
     def collection_name
       @collection_name ||= Array(@params.dig(:f, :collection)).reject(&:empty?).first ||
                            helpers.current_context_document&.collection_name
+    end
+
+    def repository_name
+      if controller.controller_name == "repositories" && controller.action_name == "show"
+          @repository_name ||= Repository.find_by!(slug: params[:id]).name
+      else
+        @repository_name ||= Array(@params.dig(:f, :repository)).reject(&:empty?).first      
+      end
+    end
+
+    def selected_option(options)
+      options.detect { |option| option.last.present? }&.last || ''
     end
   end
 end

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -89,6 +89,7 @@ en:
       all_collections: all collections
       label_html: Search<span class="sr-only visually-hidden"> within</span>
       this_collection: this collection
+      this_repository: this repository
   blacklight:
     entry_name:
       grouped:


### PR DESCRIPTION
"As a small repository contributing to a regional aggregator that uses Arclight, I don't have a local discovery system. Thus I would like to use the arclight landing page for my repository as my main discovery system and I would like users to be able to easily search our collections from that page."

I'm not 100% if this is the best implementation, but seems to work. Arguably, it might be better to have the dropdown literally day the repository name instead of "this repository" but this continues the default pattern and its easy to customize.

Needs some better tests which I tried and failed at this afternoon.