### PR TITLE
Use collection_id for linking rather than inferring from eadid

### DIFF
--- a/app/components/arclight/collection_sidebar_component.rb
+++ b/app/components/arclight/collection_sidebar_component.rb
@@ -29,13 +29,11 @@ module Arclight
     end
 
     def document_path
-      @document_path ||= solr_document_path(normalized_eadid)
+      @document_path ||= solr_document_path(document.collection_id)
     end
 
     def section_anchor(section)
       "##{t("arclight.views.show.sections.#{section}").parameterize}"
     end
-
-    delegate :normalized_eadid, to: :document
   end
 end

--- a/app/models/arclight/parents.rb
+++ b/app/models/arclight/parents.rb
@@ -29,7 +29,7 @@ module Arclight
     # @param [SolrDocument] document
     def self.from_solr_document(document)
       ids = document.parent_ids
-      legacy_ids = document.legacy_parent_ids.map { |legacy_id| document.eadid == legacy_id ? legacy_id : "#{document.eadid}#{legacy_id}" }
+      legacy_ids = document.legacy_parent_ids.map { |legacy_id| document.collection_id == legacy_id ? legacy_id : "#{document.collection_id}#{legacy_id}" }
       labels = document.parent_labels
       eadid = document.eadid
       levels = document.parent_levels

--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -29,6 +29,7 @@ module Arclight
       attribute :total_component_count, :string, 'total_component_count_is'
       attribute :online_item_count, :string, 'online_item_count_is'
       attribute :last_indexed, :date, 'timestamp'
+      attribute :collection_id, :string, '_root_'
     end
 
     def repository_config

--- a/spec/components/arclight/breadcrumb_component_spec.rb
+++ b/spec/components/arclight/breadcrumb_component_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Arclight::BreadcrumbComponent, type: :component do
       parent_ids_ssim: %w[abc123 abc123_def abc123_ghi],
       parent_unittitles_ssm: %w[ABC123 DEF GHI],
       ead_ssi: 'abc123',
-      repository_ssm: 'my repository'
+      repository_ssm: 'my repository',
+      _root_: 'abc123'
     )
   end
 
@@ -62,7 +63,8 @@ RSpec.describe Arclight::BreadcrumbComponent, type: :component do
         parent_ssim: %w[abc123 def ghi],
         parent_unittitles_ssm: %w[ABC123 DEF GHI],
         ead_ssi: 'abc123',
-        repository_ssm: 'my repository'
+        repository_ssm: 'my repository',
+        _root_: 'abc123'
       )
     end
 

--- a/spec/components/arclight/collection_sidebar_component_spec.rb
+++ b/spec/components/arclight/collection_sidebar_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Arclight::CollectionSidebarComponent, type: :component do
     render_inline(component)
   end
 
-  let(:document) { instance_double(SolrDocument, normalized_eadid: 'foo') }
+  let(:document) { instance_double(SolrDocument, collection_id: 'foo') }
   let(:collection_presenter) { instance_double(Arclight::ShowPresenter, with_field_group: group_presenter) }
   let(:group_presenter) { instance_double(Arclight::ShowPresenter, fields_to_render: [double]) }
 

--- a/spec/models/arclight/parents_spec.rb
+++ b/spec/models/arclight/parents_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Arclight::Parents do
       parent_ids_ssim: %w[abc123 abc123_def abc123_ghi],
       parent_unittitles_ssm: %w[ABC123 DEF GHI],
       ead_ssi: 'abc123',
+      _root_: 'abc123',
       parent_levels_ssm: %w[collection]
     )
   end
@@ -17,6 +18,7 @@ RSpec.describe Arclight::Parents do
       parent_ssim: %w[abc123 def ghi],
       parent_unittitles_ssm: %w[ABC123 DEF GHI],
       ead_ssi: 'abc123',
+      _root_: 'abc123',
       parent_levels_ssm: %w[collection]
     )
   end

--- a/spec/models/concerns/arclight/solr_document_spec.rb
+++ b/spec/models/concerns/arclight/solr_document_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Arclight::SolrDocument do
     it { expect(document).to respond_to(:parent_ids) }
     it { expect(document).to respond_to(:parent_labels) }
     it { expect(document).to respond_to(:eadid) }
+    it { expect(document).to respond_to(:collection_id) }
   end
 
   describe '#repository_config' do


### PR DESCRIPTION
At the last community call (2024-04-22) we discussion a desired feature to make it easier to customize the formation of the collection document id. The use cases cited were needing to add the repository name/code to prevent identifier collisions across repositories and adding a slug version of the title to the id for friendlier URLs.

As I was looking at how we could better support this I found that there were a couple places in the application where we were inferring the parent collection id from the normalized form of the eadid. I found this confusing and was concerned that allowing customization of the document id would break these assumptions about the relationship between the parent collection document id and the eadid.

This PR attempts to remove this assumption from the app so we can (in a future PR) add a seam for customizing the collection document id formation.

Instead of inferring the parent collection document id from the `eadid` this creates a `SolrDocument` accessor method `collection_id` using the `_root_` Solr field from Solr's nested document structure. This change works with either older style `legacy_id` parent field relationships or the newer `parent_ids` field. It should be completely backwards compatible with existing arclight v1 apps.

Grateful for feedback, questions, concerns.