### PR TITLE
Supply title and repository as kwargs for local id forming requirements

### DIFF
--- a/lib/arclight/normalized_id.rb
+++ b/lib/arclight/normalized_id.rb
@@ -5,9 +5,11 @@ require 'arclight/exceptions'
 module Arclight
   ##
   # A simple utility class to normalize identifiers
-  # to be used around the application for linking
   class NormalizedId
-    def initialize(id)
+    # Accepts unused kwargs from the ead2_config.rb id to_field directive
+    # (:title and :repository) so that applications can provide a custom
+    # id_normalizer class to traject to form the collection id from these attributes.
+    def initialize(id, **_kwargs)
       @id = id
     end
 

--- a/lib/arclight/traject/ead2_config.rb
+++ b/lib/arclight/traject/ead2_config.rb
@@ -6,6 +6,7 @@ require 'traject/nokogiri_reader'
 require 'traject_plus'
 require 'traject_plus/macros'
 require 'arclight/level_label'
+require 'arclight/normalized_id'
 require 'arclight/normalized_date'
 require 'arclight/normalized_title'
 require 'active_model/conversion' ## Needed for Arclight::Repository
@@ -53,6 +54,7 @@ DID_SEARCHABLE_NOTES_FIELDS = %w[
 
 settings do
   provide 'component_traject_config', File.join(__dir__, 'ead2_component_config.rb')
+  provide 'id_normalizer', 'Arclight::NormalizedId'
   provide 'date_normalizer', 'Arclight::NormalizedDate'
   provide 'title_normalizer', 'Arclight::NormalizedTitle'
   provide 'reader_class_name', 'Arclight::Traject::NokogiriNamespacelessReader'
@@ -75,7 +77,13 @@ end
 # NOTE: All fields should be stored in Solr
 # ==================
 
-to_field 'id', extract_xpath('/ead/eadheader/eadid'), strip, gsub('.', '-')
+to_field 'id' do |record, accumulator|
+  id = record.at_xpath('/ead/eadheader/eadid')&.text
+  title = record.at_xpath('/ead/archdesc/did/unittitle')&.text
+  repository = settings['repository']
+  accumulator << settings['id_normalizer'].constantize.new(id, title: title, repository: repository).to_s
+end
+
 to_field 'title_filing_ssi', extract_xpath('/ead/eadheader/filedesc/titlestmt/titleproper[@type="filing"]')
 to_field 'title_ssm', extract_xpath('/ead/archdesc/did/unittitle')
 to_field 'title_tesim', extract_xpath('/ead/archdesc/did/unittitle')

--- a/spec/lib/arclight/normalized_id_spec.rb
+++ b/spec/lib/arclight/normalized_id_spec.rb
@@ -31,4 +31,12 @@ RSpec.describe Arclight::NormalizedId do
       )
     end
   end
+
+  context 'when additional keyword arguments are supplied' do
+    subject(:normalized_id) { described_class.new('abc123.xml', title: 'a title', repository: 'repo').to_s }
+
+    it 'accepts the additional arguments without changing the output' do
+      expect(normalized_id).to eq 'abc123-xml'
+    end
+  end
 end


### PR DESCRIPTION
This builds on #1531 to provide a way for applications to customize how the collection id is formed, making it possible to add either the title or repository to the id to fulfill local requirements. This does not change how the default id is formed from the eadid.

Here's an example of how a local application could use this to add a slug form of the title to the collection id: https://github.com/sul-dlss/stanford-arclight/compare/add-title-to-id?expand=1