### PR TITLE
Deprecate SolrDocument#normalized_eadid in favor of collection_id

### DIFF
--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -51,6 +51,7 @@ module Arclight
     def normalized_eadid
       Arclight::NormalizedId.new(eadid).to_s
     end
+    Arclight.deprecation.deprecate_methods(self, normalized_eadid: 'Use `collection_id` instead')
 
     def repository
       first('repository_ssm') || collection&.first('repository_ssm')


### PR DESCRIPTION
As discussed on https://github.com/projectblacklight/arclight/pull/1531 this proposes we deprecate `SolrDocument#normalized_eadid` in favor of using `collection_id` to form links based on the collection (root) document.