### PR TITLE
Add placeholder loading animation to expand button

### DIFF
--- a/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
+++ b/app/assets/stylesheets/arclight/modules/hierarchy_and_online_contents.scss
@@ -46,8 +46,8 @@ $hierarchy-view-collapse-icon: url("data:image/svg+xml,<svg xmlns='http://www.w3
     display: none;
   }
 
-  turbo-frame[loading]:not([complete]) {
-    &::after {
+  turbo-frame[busy] {
+    &::before {
       @extend .placeholder !optional;
       animation: placeholder-glow 2s ease-in-out infinite;
       content: 'Loading...';


### PR DESCRIPTION
Increases the scope of the selector to target all turbo frames, not only the lazy loading turbo frames, in the collection context sidebar. This adds the loading animation above the "Expand" button once clicked:
![Screenshot 2024-05-08 at 12 49 45 PM](https://github.com/projectblacklight/arclight/assets/4421877/094ec483-501d-44c9-aa7f-0ad8b41d18d0)

The change from `after` to `before` does not change the existing behavior because all the `loading="lazy"` turbo frame containers in `app/components/arclight/document_components_hierarchy_component.html.erb` are empty.

I believe the [docs](https://turbo.hotwired.dev/reference/frames) suggest we can use `busy` in this way:
> busy is a [boolean attribute](https://www.w3.org/TR/html52/infrastructure.html#sec-boolean-attributes) toggled to be present when a <turbo-frame\>-initiated request starts, and toggled false when the request ends

This is something we are thinking of adding to our app. I thought I'd check if there was interest here first.