### PR TITLE
Eliminate media query in favor of a bootstrap class

### DIFF
--- a/app/assets/stylesheets/arclight/modules/mastheads.scss
+++ b/app/assets/stylesheets/arclight/modules/mastheads.scss
@@ -44,10 +44,4 @@
       color: var(--al-mastead-active-link-color);
     }
   }
-
-  @media (max-width: 767px) {
-    h1 {
-      text-align: center;
-    }
-  }
 }

--- a/app/components/arclight/masthead_component.html.erb
+++ b/app/components/arclight/masthead_component.html.erb
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="row align-items-center">
       <div class="col-md-8" >
-        <span class="h1"><%= heading %></span>
+        <span class="h1 text-center text-md-start"><%= heading %></span>
       </div>
 
       <nav class="navbar navbar-expand col-md-4 d-flex justify-content-md-end justify-content-center" aria-label="browse">


### PR DESCRIPTION
This makes it easier for the downstream consumers to customize (by overriding the template)