### PR TITLE
Replace header padding style with bootstrap margin style

### DIFF
--- a/app/assets/stylesheets/arclight/modules/mastheads.scss
+++ b/app/assets/stylesheets/arclight/modules/mastheads.scss
@@ -31,10 +31,7 @@
   --bs-nav-link-font-weight: 700;
 
   .h1 {
-    display: block;
     font-size: var(--al-masthead-title-size);
-    margin: 0;
-    padding: ($spacer * 1.5) ($spacer * 0.5);
   }
 
   .navbar-nav {

--- a/app/components/arclight/masthead_component.html.erb
+++ b/app/components/arclight/masthead_component.html.erb
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="row align-items-center">
       <div class="col-md-8" >
-        <span class="h1 text-center text-md-start"><%= heading %></span>
+        <span class="h1 my-4 text-center text-md-start"><%= heading %></span>
       </div>
 
       <nav class="navbar navbar-expand col-md-4 d-flex justify-content-md-end justify-content-center" aria-label="browse">


### PR DESCRIPTION
This makes it easier to customize without having to override css classes