### PR TITLE
Extract col-md-4 from the navbar

### DIFF
--- a/app/components/arclight/masthead_component.html.erb
+++ b/app/components/arclight/masthead_component.html.erb
@@ -5,11 +5,13 @@
         <span class="h1 my-4 text-center text-md-start"><%= heading %></span>
       </div>
 
-      <nav class="navbar navbar-expand col-md-4 d-flex justify-content-md-end justify-content-center" aria-label="browse">
-        <ul class="navbar-nav">
-          <%= render 'shared/main_menu_links' %>
-        </ul>
-      </nav>
+      <div class="col-md-4">
+        <nav class="navbar navbar-expand d-flex justify-content-md-end justify-content-center" aria-label="browse">
+          <ul class="navbar-nav">
+            <%= render 'shared/main_menu_links' %>
+          </ul>
+        </nav>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The navbar ovewrites the padding of the col-md-4, which means these links don't line up with those in the topbar