### PR TITLE
Easier override for `Arclight::BookmarkComponent`

### DIFF
--- a/app/components/arclight/document_component.html.erb
+++ b/app/components/arclight/document_component.html.erb
@@ -11,7 +11,7 @@
     <%= document.normalized_title %>
   <% end %>
   <%= render 'arclight/requests', document: document %>
-  <%= render Arclight::BookmarkComponent.new document: document, action: bookmark_config %>
+  <%= render (blacklight_config.index.document_actions.arclight_bookmark_control.component || Arclight::BookmarkComponent).new document: document, action: bookmark_config %>
   <%= toggle_sidebar %>
   <%= online_filter %>
 </div>


### PR DESCRIPTION
This commit will make it easier to override the `Arclight::BookmarkComponent` where all you would have to do is add it to the `CatalogController`.  Other components should reference that and have a fallback to the original `Arclight::BookmarkComponent`