### PR TITLE
Permits ERB syntax in `downloads.yml` file

### DIFF
--- a/app/models/arclight/document_downloads.rb
+++ b/app/models/arclight/document_downloads.rb
@@ -33,7 +33,8 @@ module Arclight
     class << self
       def config
         @config ||= begin
-          YAML.safe_load(::File.read(config_filename))
+          content = ERB.new(::File.read(config_filename)).result
+          YAML.safe_load(content)
         rescue Errno::ENOENT
           {}
         end


### PR DESCRIPTION
This commit fixes the `malformed format string - %=` error that occurs when ERB syntax is used in the `downloads.yml` file.

<img width="1028" alt="Screenshot 2024-11-07 at 4 40 09 PM" src="https://github.com/user-attachments/assets/576c8c0b-8fb5-46fa-aee2-7c6499c91fda">
