### PR TITLE
Fix solr config path for solr 9.7

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,5 +1,5 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
 collection:
-  dir: solr/conf/
+  dir: solr/conf
   name: blacklight-core


### PR DESCRIPTION
Fixes:
```
Failed to execute solr create: Specified configuration directory /home/runner/work/arclight/solr/conf not found!
```