### PR TITLE
Prefer root field; remove collection_id field

### DIFF
--- a/app/components/arclight/collection_sidebar_component.rb
+++ b/app/components/arclight/collection_sidebar_component.rb
@@ -29,7 +29,7 @@ module Arclight
     end
 
     def document_path
-      @document_path ||= solr_document_path(document.collection_id)
+      @document_path ||= solr_document_path(document.root)
     end
 
     def section_anchor(section)

--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -7,7 +7,7 @@ module Arclight
     extend ActiveSupport::Concern
 
     included do
-      attribute :collection_id, :string, '_root_'
+      attribute :root, :string, '_root_'
       attribute :parent_ids, :array, 'parent_ids_ssim'
       attribute :parent_labels, :array, 'parent_unittitles_ssm'
       attribute :parent_levels, :array, 'parent_levels_ssm'
@@ -139,10 +139,6 @@ module Arclight
 
     def nest_path
       self['_nest_path_']
-    end
-
-    def root
-      self['_root_'] || self['id']
     end
 
     def requestable?

--- a/spec/components/arclight/collection_sidebar_component_spec.rb
+++ b/spec/components/arclight/collection_sidebar_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Arclight::CollectionSidebarComponent, type: :component do
     render_inline(component)
   end
 
-  let(:document) { instance_double(SolrDocument, collection_id: 'foo') }
+  let(:document) { instance_double(SolrDocument, root: 'foo') }
   let(:collection_presenter) { instance_double(Arclight::ShowPresenter, with_field_group: group_presenter) }
   let(:group_presenter) { instance_double(Arclight::ShowPresenter, fields_to_render: [double]) }
 

--- a/spec/models/concerns/arclight/solr_document_spec.rb
+++ b/spec/models/concerns/arclight/solr_document_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Arclight::SolrDocument do
     it { expect(document).to respond_to(:parent_ids) }
     it { expect(document).to respond_to(:parent_labels) }
     it { expect(document).to respond_to(:eadid) }
-    it { expect(document).to respond_to(:collection_id) }
+    it { expect(document).to respond_to(:root) }
   end
 
   describe '#repository_config' do


### PR DESCRIPTION
Fixes https://github.com/projectblacklight/arclight/issues/1581

Both `root` and `collection_id` were defined in `SolrDocument` and were nearly identical, with `root` falling back to `id` if missing. I've opted to consolidate these fields to `root` so it's clear this is an accessor for Solr's nested document `_root_` field. We use `collection_id` elsewhere (as a translation key and in the UI) to refer to the collection's `unitid`, so preferring `root` for this nested document field seems less likely to cause confusion. The fallback to `id` is also removed because all nested documents (even the parent/root) have a `_root_` field.

For reference, `root` was added here: https://github.com/projectblacklight/arclight/commit/e7d40cc4c9c996ffa24da80358012c8d959741b5
And `collection_id` was added here: https://github.com/projectblacklight/arclight/commit/8151234fbe227a58281e0e5e1eb8c4491e98b349

