### PR TITLE
Deprecate collection_id accessor

### DIFF
--- a/app/components/arclight/collection_sidebar_component.rb
+++ b/app/components/arclight/collection_sidebar_component.rb
@@ -29,7 +29,7 @@ module Arclight
     end
 
     def document_path
-      @document_path ||= solr_document_path(document.collection_id)
+      @document_path ||= solr_document_path(document.root)
     end
 
     def section_anchor(section)

--- a/app/models/arclight/parents.rb
+++ b/app/models/arclight/parents.rb
@@ -29,7 +29,7 @@ module Arclight
     # @param [SolrDocument] document
     def self.from_solr_document(document)
       ids = document.parent_ids
-      legacy_ids = document.legacy_parent_ids.map { |legacy_id| document.collection_id == legacy_id ? legacy_id : "#{document.collection_id}#{legacy_id}" }
+      legacy_ids = document.legacy_parent_ids.map { |legacy_id| document.root == legacy_id ? legacy_id : "#{document.root}#{legacy_id}" }
       labels = document.parent_labels
       eadid = document.eadid
       levels = document.parent_levels

--- a/app/models/concerns/arclight/solr_document.rb
+++ b/app/models/concerns/arclight/solr_document.rb
@@ -8,6 +8,7 @@ module Arclight
 
     included do
       attribute :collection_id, :string, '_root_'
+      Arclight.deprecation.deprecate_methods(self, collection_id: 'Use `root` instead')
       attribute :parent_ids, :array, 'parent_ids_ssim'
       attribute :legacy_parent_ids, :array, 'parent_ssim'
       Arclight.deprecation.deprecate_methods(self, legacy_parent_ids: 'Use `parent_ids` instead')
@@ -51,7 +52,7 @@ module Arclight
     def normalized_eadid
       Arclight::NormalizedId.new(eadid).to_s
     end
-    Arclight.deprecation.deprecate_methods(self, normalized_eadid: 'Use `collection_id` instead')
+    Arclight.deprecation.deprecate_methods(self, normalized_eadid: 'Use `root` instead')
 
     def repository
       first('repository_ssm') || collection&.first('repository_ssm')

--- a/spec/components/arclight/collection_sidebar_component_spec.rb
+++ b/spec/components/arclight/collection_sidebar_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Arclight::CollectionSidebarComponent, type: :component do
     render_inline(component)
   end
 
-  let(:document) { instance_double(SolrDocument, collection_id: 'foo') }
+  let(:document) { instance_double(SolrDocument, root: 'foo') }
   let(:collection_presenter) { instance_double(Arclight::ShowPresenter, with_field_group: group_presenter) }
   let(:group_presenter) { instance_double(Arclight::ShowPresenter, fields_to_render: [double]) }
 


### PR DESCRIPTION
Arclight 2.0.0 removes `collection_id` in favor of `root`: https://github.com/projectblacklight/arclight/pull/1586/commits/43e3f3fcd05f015801dd666dbee3efa05cfb80e3