### PR TITLE
Fix queries containing stand-alone punctuation

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -194,6 +194,23 @@
       </analyzer>
     </fieldType>
 
+    <!-- single token with punctuation terms removed so edismax doesn't look for punctuation terms in these fields -->
+    <!-- On client side, Lucene query parser breaks things up by whitespace *before* field analysis for edismax -->
+    <!-- so punctuation terms (& : ;) are stopwords to allow results from other fields when these chars -->
+    <!-- are surrounded by spaces in query. -->
+    <fieldType name="string_punct_stop" class="solr.TextField" omitNorms="true">
+      <analyzer type="index">
+        <tokenizer class="solr.KeywordTokenizerFactory" />
+        <filter class="solr.ICUNormalizer2FilterFactory" mode="compose" />
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.KeywordTokenizerFactory" />
+        <filter class="solr.ICUNormalizer2FilterFactory" mode="compose" />
+        <!-- removing punctuation for Lucene query parser issues -->
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_punctuation.txt"  />
+      </analyzer>
+    </fieldType>
+
     <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" >
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -283,6 +300,7 @@
    <!-- default, catch all search field, also used for search term highlighting (requires stored="true") -->
    <field name="text" type="text" indexed="true" stored="true" multiValued="true"/>
    <field name="unitid_identifier_match" type="identifier_match" indexed="true" stored="false" multiValued="true" />
+   <field name="identifier_search" type="string_punct_stop" indexed="true" stored="false" multiValued="true"/>
 
    <field name="_root_" type="string" indexed="true" stored="true" docValues="false" />
    <field name="_nest_parent_" type="string" indexed="true" stored="true"/>
@@ -347,6 +365,12 @@
    <copyField source="names_ssim" dest="text" />
    <copyField source="access_subjects_ssim" dest="text" />
    <copyField source="containers_ssim" dest="text" />
+
+  <!-- catch all identifier field suitable for search -->
+  <copyField source="id" dest="identifier_search" />
+  <copyField source="ead_ssi" dest="identifier_search" />
+  <copyField source="ref_ssm" dest="identifier_search" />
+  <copyField source="unitid_ssm" dest="identifier_search" />
 
    <!-- grab the searchable notes (SEARCHABLE_NOTES_FIELDS) -->
    <copyField source="accessrestrict_tesim" dest="text" />

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -106,10 +106,7 @@
          name_teim^10
          place_teim^10
          subject_teim^2
-         id
-         ead_ssi
-         ref_ssm
-         unitid_ssm
+         identifier_search
          container_teim
          parent_unittitles_tesim
          text
@@ -122,10 +119,7 @@
          name_teim^20
          place_teim^20
          subject_teim^5
-         id^2
-         ead_ssi^2
-         ref_ssm^2
-         unitid_ssm^2
+         identifier_search^2
          container_teim^2
          parent_unittitles_tesim^2
          text^2
@@ -138,17 +132,11 @@
          container_teim^2
        </str>
        <str name="qf_identifier">
-         id
-         ead_ssi
-         ref_ssm
-         unitid_ssm
+         identifier_search
          unitid_identifier_match
        </str>
        <str name="pf_identifier">
-         id^2
-         ead_ssi^2
-         ref_ssm^2
-         unitid_ssm^2
+         identifier_search^2
          unitid_identifier_match^2
        </str>
        <str name="qf_name">

--- a/solr/conf/stopwords_punctuation.txt
+++ b/solr/conf/stopwords_punctuation.txt
@@ -1,0 +1,23 @@
+# Punctuation characters we want to ignore as terms (i.e., when surrounded 
+# by whitespace in a query, like 'fred : the puppy') in queries
+# ONLY FOR SINGLE TOKEN ANALYZED FIELDS
+#   see https://issues.apache.org/jira/browse/SOLR-3085
+# Note that plusses and double hyphens are not treated as terms
+#   per debugQuery
+:
+;
+&
+/
+=
+>
+<
+,
+.
+(
+)
+…
+»
+§
+•
+·
+-

--- a/spec/features/search_query_spec.rb
+++ b/spec/features/search_query_spec.rb
@@ -68,6 +68,13 @@ RSpec.describe 'Search queries' do
         expect(page).to have_css '.index_title', text: /The constitution of the Alpha Omega/
       end
     end
+
+    context 'search containing stand-alone punctuation' do
+      it 'returns results' do
+        visit search_catalog_path q: 'constitution amendments - drafts', search_field: 'all_fields'
+        expect(page).to have_css '.index_title', text: /Constitution amendments - drafts/
+      end
+    end
   end
 
   context 'when two terms match two docs but proximity differs (pf test)' do


### PR DESCRIPTION
Fixes #1556 

This creates a new field type `string_punct_stop` specifically for identifier fields that we want to include in search configurations where other tokenized/text field types are included. This fixes a problem where punctuation is removed from tokenized/text fields but not from identifier fields and by combining these fields in a single search configuration the punctuation is removed from the query but still counts toward the minimum must match count...so you get 0 results. Adding this punctuation list as stopwords to the identifier fields makes solr not count the punctuation as part of the minimum must match count.