### PR TITLE
Extract an expand hierarchy button component

### DIFF
--- a/app/components/arclight/document_components_hierarchy_component.html.erb
+++ b/app/components/arclight/document_components_hierarchy_component.html.erb
@@ -2,29 +2,17 @@
   <%# render the hierarchy as: outer (left) window ... window ... because our current document hierarchy is so far down the list it'd be buried %>
   <%= helpers.turbo_frame_tag "al-hierarchy-#{@document.id}-left", loading: 'lazy', src: hierarchy_path(limit: @left_outer_window, key: '-left') %>
   <%= tag.turbo_frame id: "al-hierarchy-#{@document.id}-gap" do %>
-    <ul>
-      <li>
-        <%= link_to t('arclight.views.show.expand'), hierarchy_path(offset: @left_outer_window, limit: @target_index - @left_outer_window - (@window / 2), key: '-gap'), class: 'btn btn-secondary btn-sm' %>
-      </li>
-    </ul>
+    <%= render expand_hierarchy_component.new(path: hierarchy_path(offset: @left_outer_window, limit: @target_index - @left_outer_window - (@window / 2), key: '-gap')) %>
   <% end %>
   <%= helpers.turbo_frame_tag "al-hierarchy-#{@document.id}-window", src: hierarchy_path(offset: @target_index - (@window / 2), limit: @window, key: '-window') %>
   <%= tag.turbo_frame id: "al-hierarchy-#{@document.id}-right" do %>
-    <ul>
-      <li>
-        <%= link_to t('arclight.views.show.expand'), hierarchy_path(offset: @target_index + (@window / 2), key: '-right'), class: 'btn btn-secondary btn-sm' %>
-      </li>
-    </ul>
+    <%= render expand_hierarchy_component.new(path: hierarchy_path(offset: @target_index + (@window / 2), key: '-right')) %>
   <% end %>
 <% elsif paginate? %>
   <%# render the first N documents, and let the user expand the remaining if desired %>
   <%= helpers.turbo_frame_tag "al-hierarchy-#{@document.id}-sidebar", loading: ('lazy' unless @target_index >= 0), src: hierarchy_path(limit: @maximum_left_gap, key: '-sidebar') %>
   <%= tag.turbo_frame id: "al-hierarchy-#{@document.id}-right" do %>
-    <ul>
-      <li>
-        <%= link_to t('arclight.views.show.expand'), hierarchy_path(offset: @maximum_left_gap, key: '-right'), class: 'btn btn-secondary btn-sm' %>
-      </li>
-    </ul>
+    <%= render expand_hierarchy_component.new(path: hierarchy_path(offset: @maximum_left_gap, key: '-right')) %>
   <% end %>
 <% else %>
   <%# there aren't enough to bother paginating, so load them all at once %>

--- a/app/components/arclight/document_components_hierarchy_component.rb
+++ b/app/components/arclight/document_components_hierarchy_component.rb
@@ -24,5 +24,11 @@ module Arclight
     def hierarchy_path(**kwargs)
       helpers.hierarchy_solr_document_path(id: @document.id, hierarchy: true, nest_path: params[:nest_path], **kwargs)
     end
+
+    def expand_hierarchy_component
+      blacklight_config.show.expand_hierarchy_component || Arclight::ExpandHierarchyButtonComponent
+    end
+
+    delegate :blacklight_config, to: :helpers
   end
 end

--- a/app/components/arclight/expand_hierarchy_button_component.html.erb
+++ b/app/components/arclight/expand_hierarchy_button_component.html.erb
@@ -1,0 +1,5 @@
+<ul>
+  <li>
+    <%= expand_link %>
+  </li>
+</ul>

--- a/app/components/arclight/expand_hierarchy_button_component.rb
+++ b/app/components/arclight/expand_hierarchy_button_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Arclight
+  # Component for rendering an expand button in the hierarchy view
+  class ExpandHierarchyButtonComponent < Blacklight::Component
+    def initialize(path:, classes: 'btn btn-secondary btn-sm')
+      super
+      @path = path
+      @classes = classes
+    end
+
+    def expand_link
+      link_to t('arclight.views.show.expand'), @path, class: @classes
+    end
+  end
+end

--- a/lib/generators/arclight/templates/catalog_controller.rb
+++ b/lib/generators/arclight/templates/catalog_controller.rb
@@ -78,6 +78,7 @@ class CatalogController < ApplicationController
     config.show.embed_component = Arclight::EmbedComponent
     config.show.access_component = Arclight::AccessComponent
     config.show.online_status_component = Arclight::OnlineStatusIndicatorComponent
+    config.show.expand_hierarchy_component = Arclight::ExpandHierarchyButtonComponent
     config.show.display_type_field = 'level_ssm'
     # config.show.thumbnail_field = 'thumbnail_path_ss'
     config.show.document_presenter_class = Arclight::ShowPresenter

--- a/spec/components/arclight/expand_hierarchy_button_component_spec.rb
+++ b/spec/components/arclight/expand_hierarchy_button_component_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Arclight::ExpandHierarchyButtonComponent, type: :component do
+  subject(:component) { described_class.new(path: '/some/path') }
+
+  before do
+    render_inline(component)
+  end
+
+  it 'renders the button' do
+    expect(page).to have_text('Expand')
+    expect(page).to have_css('.btn.btn-secondary.btn-sm')
+  end
+
+  context 'with a custom class' do
+    subject(:component) { described_class.new(path: '/path/to_file', classes: 'btn btn-primary') }
+
+    it 'renders the button with the custom classes' do
+      expect(page).to have_text('Expand')
+      expect(page).to have_css('.btn.btn-primary')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1600 

This will let us customize the expand hierarchy button without extraneous overrides.