### PR TITLE
Pin docker solr to 9.7.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   solr:
-    image: solr:latest
+    image: solr:9.7.0
     volumes:
       - $PWD/solr/conf:/opt/solr/conf
     ports:


### PR DESCRIPTION
This fixes an issue with not finding ICUTokenizerFactory. We have implemented this across other applications.

I was not able to start the docker instance of solr using `:latest`