### PR TITLE
Index names on components so search works as expected

### DIFF
--- a/lib/arclight/traject/ead2_component_config.rb
+++ b/lib/arclight/traject/ead2_component_config.rb
@@ -259,6 +259,7 @@ end
 
 NAME_ELEMENTS.map do |selector|
   to_field 'names_ssim', extract_xpath("./controlaccess/#{selector}"), unique
+  to_field 'names_ssim', extract_xpath(".//#{selector}"), unique
   to_field "#{selector}_ssim", extract_xpath(".//#{selector}")
 end
 

--- a/spec/features/fielded_search_results_spec.rb
+++ b/spec/features/fielded_search_results_spec.rb
@@ -87,6 +87,10 @@ RSpec.describe 'Field-based search results' do
     it '#name' do
       visit search_catalog_path q: 'root', search_field: 'name'
       within('.document-position-1') do
+        expect(page).to have_css '.index_title', text: /Dr. Root and L. Raymond Higgins/
+      end
+
+      within('.document-position-2') do
         expect(page).to have_css '.index_title', text: /Alpha Omega Alpha Archives/
       end
     end

--- a/spec/features/highlighted_search_results_spec.rb
+++ b/spec/features/highlighted_search_results_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe 'Highlighted search results' do
         visit search_catalog_path q: 'william root', search_field: 'name'
         within '.document-position-1' do
           within '.al-document-highlight' do
-            expect(page).to have_css 'em', text: 'William', count: 3
-            expect(page).to have_css 'em', text: 'Root', count: 3
+            expect(page).to have_css 'em', text: 'William', count: 1
+            expect(page).to have_css 'em', text: 'Root', count: 2
           end
         end
       end

--- a/spec/features/traject/ead2_indexing_spec.rb
+++ b/spec/features/traject/ead2_indexing_spec.rb
@@ -176,6 +176,10 @@ RSpec.describe 'EAD 2 traject indexing' do
         )
       end
 
+      it 'names' do
+        expect(first_component['names_ssim']).to include 'Stanford, Leland'
+      end
+
       it 'geogname' do
         %w[geogname_ssim geogname_ssm].each do |field|
           expect(all_components.first[field]).to be_nil

--- a/spec/fixtures/ead/sul-spec/a0011.xml
+++ b/spec/fixtures/ead/sul-spec/a0011.xml
@@ -177,6 +177,9 @@
                     <container id="aspace_76137544d2e63550e7a7ef7cf2168c48"
                                label="Mixed Materials" type="box">1
                     </container>
+                    <origination label="Creator">
+                        <persname rules="aacr" source="naf">Stanford, Leland</persname>
+                    </origination>
                 </did>
             </c01>
         </dsc>


### PR DESCRIPTION
Fixes #1608 

If this gets merged I'll backport it to `release-1.x`

There's some related history, including that we seem to have deliberately left this out, but I'm not seeing a convincing reason why and a follow up issue was created to revisit. I can't see the harm in indexing names on components in `names_ssim` so they are searchable. And we have gotten at least one report of this as a problem.

- https://github.com/projectblacklight/arclight/pull/634
- https://github.com/projectblacklight/arclight/issues/654

> Some things about how the existing SolrEAD setup indexes names data strike me as likely unintentional. E.g., at the component level only names wrapped in <controlaccess> get added to names_ssim but at the document/collection level names_ssim includes component names that aren't wrapped in <controlaccess>. But I thought better to try to stick to achieving parity for now, and revise this sort of thing later.