### PR TITLE
Do not emit an empty ol tag when there are no breadcrumbs

### DIFF
--- a/app/components/arclight/breadcrumb_component.rb
+++ b/app/components/arclight/breadcrumb_component.rb
@@ -12,12 +12,8 @@ module Arclight
     end
 
     def call
-      breadcrumb_links = components.drop(@offset)
+      return unless breadcrumb_links.any?
 
-      if @count && breadcrumb_links.length > @count
-        breadcrumb_links = breadcrumb_links.first(@count)
-        breadcrumb_links << tag.li('&hellip;'.html_safe, class: 'breadcrumb-item')
-      end
       tag.ol class: 'breadcrumb' do
         safe_join(breadcrumb_links)
       end
@@ -35,6 +31,20 @@ module Arclight
 
     def build_repository_link
       render Arclight::RepositoryBreadcrumbComponent.new(document: @document)
+    end
+
+    private
+
+    def breadcrumb_links
+      @breadcrumb_links ||= limit_breadcrumb_links(components.drop(@offset))
+    end
+
+    def limit_breadcrumb_links(links)
+      return links unless @count && links.length > @count
+
+      limited_links = links.first(@count)
+      limited_links << tag.li('&hellip;'.html_safe, class: 'breadcrumb-item')
+      limited_links
     end
   end
 end

--- a/spec/components/arclight/breadcrumb_component_spec.rb
+++ b/spec/components/arclight/breadcrumb_component_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe Arclight::BreadcrumbComponent, type: :component do
     end
   end
 
+  context 'with an offset that removes all links' do
+    let(:attr) { { offset: 4 } }
+
+    it 'does not render an empty ordered list' do
+      expect(rendered).to have_no_selector 'ol'
+    end
+  end
+
   it 'renders breadcrumb links' do
     expect(rendered).to have_css 'li', text: 'my repository'
     expect(rendered).to have_link 'DEF', href: '/catalog/abc123_def'


### PR DESCRIPTION
Backports https://github.com/projectblacklight/arclight/commit/5bbacc079ac3054db6111d729e8a70d79cafe532 fix for #1616 to `release-1.x`