### PR TITLE
Fix rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rspec
   - rubocop-rails
   - rubocop-rake
@@ -36,7 +36,7 @@ Metrics/BlockLength:
     - "spec/**/*"
     - "tasks/**/*"
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   ForbiddenPrefixes:
     - is_
 
@@ -205,7 +205,7 @@ RSpec/VerifiedDoubleReference: # new in 2.10.0
   Enabled: true
 Capybara/SpecificFinders: # new in 2.13
   Enabled: true
-Capybara/SpecificMatcher: # new in 2.12
+Capybara/RSpec/SpecificMatcher: # new in 2.12
   Enabled: true
 FactoryBot/SyntaxMethods: # new in 2.7
   Enabled: true
@@ -317,7 +317,7 @@ Style/RedundantStringEscape: # new in 1.37
   Enabled: true
 RSpec/SortMetadata: # new in 2.14
   Enabled: true
-Capybara/NegationMatcher: # new in 2.14
+Capybara/RSpec/NegationMatcher: # new in 2.14
   Enabled: true
 Capybara/SpecificActions: # new in 2.14
   Enabled: true
@@ -351,7 +351,7 @@ Style/RedundantDoubleSplatHashBraces: # new in 1.41
   Enabled: true
 Style/RedundantHeredocDelimiterQuotes: # new in 1.45
   Enabled: true
-Capybara/MatchStyle: # new in 2.17
+Capybara/RSpec/MatchStyle: # new in 2.17
   Enabled: true
 RSpec/DuplicatedMetadata: # new in 2.16
   Enabled: true
@@ -440,8 +440,6 @@ Style/SuperArguments: # new in 1.64
 Style/SuperWithArgsParentheses: # new in 1.58
   Enabled: true
 Style/YAMLFileRead: # new in 1.53
-  Enabled: true
-Capybara/ClickLinkOrButtonStyle: # new in 2.19
   Enabled: true
 Capybara/RedundantWithinFind: # new in 2.20
   Enabled: true

--- a/spec/features/autocomplete_spec.rb
+++ b/spec/features/autocomplete_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Autocomplete', :js do
     it 'is configured properly to allow non-prefix autocomplete' do
       visit '/catalog'
       find_by_id('q').send_keys 'by-laws'
-      expect(page).to have_content 'amendments to articles'
+      expect(page).to have_text 'amendments to articles'
       send_keys(:arrow_down)
       send_keys(:tab)
       expect(page).to have_field('search for', with: 'amendments to articles of incorporation and revised constitution and              by-laws, 1960')

--- a/spec/features/collection_page_spec.rb
+++ b/spec/features/collection_page_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Collection Page' do
   describe 'arclight document header' do
     it 'includes a div with the repository and collection ID' do
       within('.al-show-breadcrumb') do
-        expect(page).to have_content 'National Library of Medicine. History of Medicine Division'
+        expect(page).to have_text 'National Library of Medicine. History of Medicine Division'
       end
     end
   end

--- a/spec/features/google_form_request_spec.rb
+++ b/spec/features/google_form_request_spec.rb
@@ -26,6 +26,7 @@ xdescribe 'Google Form Request', :js do
       context 'repository is not requestable' do
         it 'form is absent' do
           visit solr_document_path 'm0198-xml_aspace_ref14_di4'
+          expect(page).to have_css 'h1'
           expect(page).to have_no_css 'form'
         end
       end
@@ -35,6 +36,7 @@ xdescribe 'Google Form Request', :js do
   context 'when container is absent' do
     it 'form is absent' do
       visit solr_document_path 'aoa271_aspace_238a0567431f36f49acea49ef576d408'
+      expect(page).to have_css 'h1'
       expect(page).to have_no_css 'form'
     end
   end

--- a/spec/features/search_breadcrumb_spec.rb
+++ b/spec/features/search_breadcrumb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Search Breadcrumb' do
       visit search_catalog_path q: 'a brief', search_field: 'all_fields'
       within '.al-search-breadcrumb' do
         expect(page).to have_link 'Home'
-        expect(page).to have_content 'Search results'
+        expect(page).to have_text 'Search results'
       end
     end
 
@@ -16,7 +16,7 @@ RSpec.describe 'Search Breadcrumb' do
       visit search_catalog_path f: { level: ['Collection'] }, search_field: 'all_fields'
       within '.al-search-breadcrumb' do
         expect(page).to have_link 'Home'
-        expect(page).to have_content 'Collections'
+        expect(page).to have_text 'Collections'
       end
     end
   end

--- a/spec/features/search_query_spec.rb
+++ b/spec/features/search_query_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe 'Search queries' do
   describe 'stemming is appropriate and not overly aggressive' do
     it 'does not stem "eugenics" to "eugen" in a search' do
       visit search_catalog_path q: 'eugenics', search_field: 'all_fields'
+      expect(page).to have_css 'input#q[value="eugenics"]'
       expect(page).to have_no_css '.index_title', text: /Interlochen Center for The Arts records/
     end
 

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe 'Search results' do
     it 'does not include result numbers in the document header' do
       visit search_catalog_path q: '', search_field: 'all_fields'
 
+      expect(page).to have_css('.index_title')
       expect(page).to have_no_css('.document-counter')
     end
 
@@ -141,6 +142,7 @@ RSpec.describe 'Search results' do
     it 'does not include repository card if not faceted on repository' do
       visit search_catalog_path q: '', search_field: 'all_fields'
 
+      expect(page).to have_css('.index_title')
       expect(page).to have_no_css('.al-repository-card')
     end
 
@@ -149,6 +151,7 @@ RSpec.describe 'Search results' do
         names: ['Owner of the reel of yellow nylon rope']
       }, search_field: 'all_fields'
 
+      expect(page).to have_css('.index_title')
       expect(page).to have_no_css('.al-repository-card')
     end
   end


### PR DESCRIPTION
Fixes:

```
rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in /home/runner/work/arclight/arclight/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in /home/runner/work/arclight/arclight/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
rubocop-rake extension supports plugin, specify `plugins: rubocop-rake` instead of `require: rubocop-rake` in /home/runner/work/arclight/arclight/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
rubocop-rspec_rails extension supports plugin, specify `plugins: rubocop-rspec_rails` instead of `require: rubocop-rspec_rails` in /home/runner/work/arclight/arclight/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
rubocop-capybara extension supports plugin, specify `plugins: rubocop-capybara` instead of `require: rubocop-capybara` in /home/runner/work/arclight/arclight/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
rubocop-factory_bot extension supports plugin, specify `plugins: rubocop-factory_bot` instead of `require: rubocop-factory_bot` in /home/runner/work/arclight/arclight/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
.rubocop.yml: Warning: Capybara/SpecificMatcher has the wrong namespace - replace it with Capybara/RSpec/SpecificMatcher
.rubocop.yml: Warning: Capybara/NegationMatcher has the wrong namespace - replace it with Capybara/RSpec/NegationMatcher
.rubocop.yml: Warning: Capybara/MatchStyle has the wrong namespace - replace it with Capybara/RSpec/MatchStyle
Warning: The `Naming/PredicateName` cop has been renamed to `Naming/PredicatePrefix`.
(obsolete configuration found in .rubocop.yml, please update it)
Error: unrecognized cop or department Capybara/ClickLinkOrButtonStyle found in .rubocop.yml
Did you mean `Capybara/FindAllFirst`?
RuboCop failed!
Running RuboCop...
```